### PR TITLE
feat: Mark memory growth functions as noinline to optimize hot paths

### DIFF
--- a/src/evm/memory/context.zig
+++ b/src/evm/memory/context.zig
@@ -5,7 +5,7 @@ const MemoryError = @import("errors.zig").MemoryError;
 const constants = @import("constants.zig");
 
 /// Returns the size of the memory region visible to the current context.
-pub fn context_size(self: *const Memory) usize {
+pub inline fn context_size(self: *const Memory) usize {
     const total_len = self.shared_buffer_ref.items.len;
     if (total_len < self.my_checkpoint) {
         // This indicates a bug or inconsistent state
@@ -17,7 +17,7 @@ pub fn context_size(self: *const Memory) usize {
 /// Ensures the current context's memory region is at least `min_context_size` bytes.
 /// Returns the number of *new 32-byte words added to the shared_buffer* if it expanded.
 /// This is crucial for EVM gas calculation.
-pub fn ensure_context_capacity(self: *Memory, min_context_size: usize) MemoryError!u64 {
+pub noinline fn ensure_context_capacity(self: *Memory, min_context_size: usize) MemoryError!u64 {
     const required_total_len = self.my_checkpoint + min_context_size;
     Log.debug("Memory.ensure_context_capacity: Ensuring capacity, min_context_size={}, required_total_len={}, memory_limit={}", .{ min_context_size, required_total_len, self.memory_limit });
 
@@ -70,16 +70,16 @@ pub fn ensure_context_capacity(self: *Memory, min_context_size: usize) MemoryErr
 }
 
 /// Resize the context to the specified size (for test compatibility)
-pub fn resize_context(self: *Memory, new_size: usize) MemoryError!void {
+pub noinline fn resize_context(self: *Memory, new_size: usize) MemoryError!void {
     _ = try self.ensure_context_capacity(new_size);
 }
 
 /// Get the memory size (alias for context_size for test compatibility)
-pub fn size(self: *const Memory) usize {
+pub inline fn size(self: *const Memory) usize {
     return self.context_size();
 }
 
 /// Get total size of memory (context size)
-pub fn total_size(self: *const Memory) usize {
+pub inline fn total_size(self: *const Memory) usize {
     return self.context_size();
 }

--- a/src/evm/memory/read.zig
+++ b/src/evm/memory/read.zig
@@ -5,7 +5,7 @@ const MemoryError = @import("errors.zig").MemoryError;
 const context = @import("context.zig");
 
 /// Read 32 bytes as u256 at context-relative offset.
-pub fn get_u256(self: *const Memory, relative_offset: usize) MemoryError!u256 {
+pub inline fn get_u256(self: *const Memory, relative_offset: usize) MemoryError!u256 {
     if (relative_offset + 32 > self.context_size()) {
         return MemoryError.InvalidOffset;
     }
@@ -15,7 +15,7 @@ pub fn get_u256(self: *const Memory, relative_offset: usize) MemoryError!u256 {
 }
 
 /// Read arbitrary slice of memory at context-relative offset.
-pub fn get_slice(self: *const Memory, relative_offset: usize, len: usize) MemoryError![]const u8 {
+pub inline fn get_slice(self: *const Memory, relative_offset: usize, len: usize) MemoryError![]const u8 {
     // Debug logging removed for fuzz testing compatibility
     if (len == 0) return &[_]u8{};
     const end = std.math.add(usize, relative_offset, len) catch {
@@ -33,7 +33,7 @@ pub fn get_slice(self: *const Memory, relative_offset: usize, len: usize) Memory
 }
 
 /// Read a single byte at context-relative offset (for test compatibility)
-pub fn get_byte(self: *const Memory, relative_offset: usize) MemoryError!u8 {
+pub inline fn get_byte(self: *const Memory, relative_offset: usize) MemoryError!u8 {
     if (relative_offset >= self.context_size()) return MemoryError.InvalidOffset;
     const abs_offset = self.my_checkpoint + relative_offset;
     return self.shared_buffer_ref.items[abs_offset];

--- a/src/evm/memory/write.zig
+++ b/src/evm/memory/write.zig
@@ -5,7 +5,7 @@ const MemoryError = @import("errors.zig").MemoryError;
 const context = @import("context.zig");
 
 /// Write arbitrary data at context-relative offset.
-pub fn set_data(self: *Memory, relative_offset: usize, data: []const u8) MemoryError!void {
+pub inline fn set_data(self: *Memory, relative_offset: usize, data: []const u8) MemoryError!void {
     // Debug logging removed for fuzz testing compatibility
     if (data.len == 0) return;
 
@@ -62,7 +62,7 @@ pub fn set_data_bounded(
 }
 
 /// Write u256 value at context-relative offset (for test compatibility)
-pub fn set_u256(self: *Memory, relative_offset: usize, value: u256) MemoryError!void {
+pub inline fn set_u256(self: *Memory, relative_offset: usize, value: u256) MemoryError!void {
     _ = try self.ensure_context_capacity(relative_offset + 32);
     const abs_offset = self.my_checkpoint + relative_offset;
     const bytes_ptr: *[32]u8 = @ptrCast(self.shared_buffer_ref.items[abs_offset..abs_offset + 32].ptr);


### PR DESCRIPTION
## Summary
- Marks memory growth functions (`ensure_context_capacity`, `resize_context`) as `noinline` to keep them out of hot paths
- Marks frequently-called functions (getters/setters) as `inline` for better performance
- Improves instruction cache usage and branch prediction

## Implementation Details

This PR implements the performance optimization described in #15 by adding `inline` and `noinline` attributes to memory functions:

**Marked as `noinline` (cold paths):**
- `ensure_context_capacity` - Memory expansion function
- `resize_context` - Memory resizing function

**Marked as `inline` (hot paths):**
- `context_size`, `size`, `total_size` - Simple getters
- `get_u256`, `get_slice`, `get_byte` - Read operations
- `set_data`, `set_u256` - Write operations

## Benefits

1. **Smaller hot path code** - Memory growth logic is kept separate from frequently executed paths
2. **Better instruction cache usage** - Hot functions fit better in CPU cache
3. **Improved branch prediction** - Predictable paths aren't polluted by infrequent memory growth
4. **Clearer performance profile** - Easier to identify bottlenecks when profiling

## Test Plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] No functional changes, only performance optimization

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)