### PR TITLE
refactor: Use std.math.order for comparisons in comparison.zig

### DIFF
--- a/src/evm/execution/comparison.zig
+++ b/src/evm/execution/comparison.zig
@@ -26,7 +26,10 @@ pub fn op_lt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
     const a = frame.stack.peek_unsafe().*;
 
     // EVM LT computes: a < b (where a was second from top, b was top)
-    const result: u256 = if (a < b) 1 else 0;
+    const result: u256 = switch (std.math.order(a, b)) {
+        .lt => 1,
+        .eq, .gt => 0,
+    };
 
     // Modify the current top of the stack in-place with the result
     frame.stack.set_top_unsafe(result);
@@ -51,7 +54,10 @@ pub fn op_gt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
     const a = frame.stack.peek_unsafe().*;
 
     // EVM GT computes: a > b (where a was second from top, b was top)
-    const result: u256 = if (a > b) 1 else 0;
+    const result: u256 = switch (std.math.order(a, b)) {
+        .gt => 1,
+        .eq, .lt => 0,
+    };
 
     // Modify the current top of the stack in-place with the result
     frame.stack.set_top_unsafe(result);
@@ -79,7 +85,10 @@ pub fn op_slt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     const a_i256 = @as(i256, @bitCast(a));
     const b_i256 = @as(i256, @bitCast(b));
 
-    const result: u256 = if (a_i256 < b_i256) 1 else 0;
+    const result: u256 = switch (std.math.order(a_i256, b_i256)) {
+        .lt => 1,
+        .eq, .gt => 0,
+    };
 
     // Modify the current top of the stack in-place with the result
     frame.stack.set_top_unsafe(result);


### PR DESCRIPTION
## Summary
- Replace manual comparison logic with `std.math.order` for `op_lt`, `op_gt`, and `op_slt` functions
- Makes the code more idiomatic, clearer in intent, and improves type safety
- Maintains existing function signatures and behavior

## Test plan
- [x] All existing tests pass without modification
- [x] Build completes successfully
- [x] No functional changes - only refactoring

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)