### PR TITLE
Size Optimization: Remove unused code and dead functions

### DIFF
--- a/src/evm/constants/gas_constants.zig
+++ b/src/evm/constants/gas_constants.zig
@@ -98,15 +98,3 @@ pub const CALL_GAS_RETENTION_DIVISOR = GasConstants.CALL_GAS_RETENTION_DIVISOR;
 // Re-export functions
 pub const memory_gas_cost = GasConstants.memory_gas_cost;
 
-// Re-export the lookup table if needed
-pub const MEMORY_EXPANSION_LUT = blk: {
-    @setEvalBranchQuota(10000);
-    const max_words = 1024; // Pre-compute for up to 32KB of memory
-    var costs: [max_words]u64 = undefined;
-
-    for (0..max_words) |words| {
-        costs[words] = MemoryGas * words + (words * words) / QuadCoeffDiv;
-    }
-
-    break :blk costs;
-};

--- a/src/evm/execution/memory.zig
+++ b/src/evm/execution/memory.zig
@@ -7,13 +7,6 @@ const Frame = @import("../frame/frame.zig");
 const Memory = @import("../memory/memory.zig");
 const gas_constants = @import("../constants/gas_constants.zig");
 
-// Helper to check if u256 fits in usize
-fn check_offset_bounds(value: u256) ExecutionError.Error!void {
-    if (value > std.math.maxInt(usize)) {
-        @branchHint(.unlikely);
-        return ExecutionError.Error.InvalidOffset;
-    }
-}
 
 pub fn op_mload(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.State) ExecutionError.Error!Operation.ExecutionResult {
     _ = pc;

--- a/src/evm/state/database_factory.zig
+++ b/src/evm/state/database_factory.zig
@@ -130,51 +130,6 @@ pub fn create_database(allocator: std.mem.Allocator, config: DatabaseConfig) !Da
             return memory_db.to_database_interface();
         },
 
-        // Future database types can be implemented here:
-        //
-        // .Fork => |fork_config| {
-        //     const fork_db = try allocator.create(ForkDatabase);
-        //     fork_db.* = try ForkDatabase.init(allocator, fork_config.remote_url, fork_config.block_number);
-        //
-        //     const metadata = DatabaseMetadata{
-        //         .database_type = .Fork,
-        //         .allocation_ptr = fork_db,
-        //         .allocation_size = @sizeOf(ForkDatabase),
-        //     };
-        //     try database_metadata_map.put(fork_db, metadata);
-        //
-        //     return fork_db.to_database_interface();
-        // },
-        //
-        // .File => |file_config| {
-        //     const file_db = try allocator.create(FileDatabase);
-        //     file_db.* = try FileDatabase.init(allocator, file_config.file_path, file_config.create_if_missing);
-        //
-        //     const metadata = DatabaseMetadata{
-        //         .database_type = .File,
-        //         .allocation_ptr = file_db,
-        //         .allocation_size = @sizeOf(FileDatabase),
-        //     };
-        //     try database_metadata_map.put(file_db, metadata);
-        //
-        //     return file_db.to_database_interface();
-        // },
-        //
-        // .Cached => |cached_config| {
-        //     const backend_db = try create_database(allocator, cached_config.backend_config.*);
-        //
-        //     const cached_db = try allocator.create(CachedDatabase);
-        //     cached_db.* = try CachedDatabase.init(allocator, backend_db, cached_config.cache_size);
-        //
-        //     const metadata = DatabaseMetadata{
-        //         .database_type = .Cached,
-        //         .allocation_ptr = cached_db,
-        //         .allocation_size = @sizeOf(CachedDatabase),
-        //     };
-        //     try database_metadata_map.put(cached_db, metadata);
-        //
-        //     return cached_db.to_database_interface();
-        // },
     }
 }
 
@@ -266,22 +221,6 @@ pub fn create_memory_database(allocator: std.mem.Allocator) !DatabaseInterface {
     return create_database(allocator, DatabaseConfig{ .Memory = {} });
 }
 
-// Future convenience functions:
-//
-// /// Convenience function to create a fork database
-// pub fn create_fork_database(allocator: std.mem.Allocator, remote_url: []const u8, block_number: ?u64) !DatabaseInterface {
-//     return create_database(allocator, DatabaseConfig{ .Fork = .{ .remote_url = remote_url, .block_number = block_number } });
-// }
-//
-// /// Convenience function to create a file database
-// pub fn create_file_database(allocator: std.mem.Allocator, file_path: []const u8) !DatabaseInterface {
-//     return create_database(allocator, DatabaseConfig{ .File = .{ .file_path = file_path } });
-// }
-//
-// /// Convenience function to create a cached database
-// pub fn create_cached_database(allocator: std.mem.Allocator, backend_config: DatabaseConfig, cache_size: usize) !DatabaseInterface {
-//     return create_database(allocator, DatabaseConfig{ .Cached = .{ .backend_config = &backend_config, .cache_size = cache_size } });
-// }
 
 // Tests
 const testing = std.testing;

--- a/test/evm/gas/gas_accounting_test.zig
+++ b/test/evm/gas/gas_accounting_test.zig
@@ -46,15 +46,6 @@ test "memory expansion gas calculation" {
     try testing.expectEqual(@as(u64, 98), gas_constants.memory_gas_cost(0, 1024));
 }
 
-// Test memory expansion lookup table
-test "memory expansion lookup table" {
-    // Test that LUT values match calculated values for small sizes
-    for (0..100) |words| {
-        const expected = gas_constants.MemoryGas * words + (words * words) / gas_constants.QuadCoeffDiv;
-        try testing.expectEqual(expected, gas_constants.MEMORY_EXPANSION_LUT[words]);
-    }
-}
-
 // Test edge cases for memory expansion
 test "memory expansion edge cases" {
     // Test alignment - should round up to nearest word


### PR DESCRIPTION
## Summary
- Removed MEMORY_EXPANSION_LUT (8KB lookup table) from gas_constants.zig - never referenced in production code
- Removed unused check_offset_bounds helper function from memory.zig - duplicated inline everywhere
- Removed commented future code blocks from database_factory.zig for cleaner codebase
- Removed corresponding test for deleted lookup table

## Test plan
- [x] All existing tests pass (`zig build && zig build test`)
- [x] Code compiles successfully with size optimization (`zig build -Doptimize=ReleaseSmall`)
- [x] No functionality changes - only dead code removal
- [x] Memory gas calculations still work correctly using existing `memory_gas_cost` function

Fixes #90

🤖 Generated with [Claude Code](https://claude.ai/code)