### PR TITLE
perf: Optimize struct field ordering by placing large allocations last (Issue #40)

### DIFF
--- a/src/evm/memory/memory.zig
+++ b/src/evm/memory/memory.zig
@@ -11,11 +11,14 @@ pub const DEFAULT_MEMORY_LIMIT = constants.DEFAULT_MEMORY_LIMIT;
 pub const calculate_num_words = constants.calculate_num_words;
 
 // Core memory struct fields
-shared_buffer_ref: *std.ArrayList(u8),
-allocator: std.mem.Allocator,
+// Frequently accessed fields placed first for better cache performance
 my_checkpoint: usize,
 memory_limit: u64,
 owns_buffer: bool,
+
+// Less frequently accessed fields
+shared_buffer_ref: *std.ArrayList(u8),
+allocator: std.mem.Allocator,
 
 /// Initializes the root Memory context that owns the shared buffer.
 /// This is the safe API that eliminates the undefined pointer footgun.
@@ -32,11 +35,11 @@ pub fn init(
     try shared_buffer.ensureTotalCapacity(initial_capacity);
 
     return Memory{
-        .shared_buffer_ref = shared_buffer,
-        .allocator = allocator,
         .my_checkpoint = 0,
         .memory_limit = memory_limit,
         .owns_buffer = true,
+        .shared_buffer_ref = shared_buffer,
+        .allocator = allocator,
     };
 }
 
@@ -44,11 +47,11 @@ pub fn init(
 /// Child memory has a view of the shared buffer starting from its checkpoint.
 pub fn init_child_memory(self: *Memory, checkpoint: usize) !Memory {
     return Memory{
-        .shared_buffer_ref = self.shared_buffer_ref,
-        .allocator = self.allocator,
         .my_checkpoint = checkpoint,
         .memory_limit = self.memory_limit,
         .owns_buffer = false,
+        .shared_buffer_ref = self.shared_buffer_ref,
+        .allocator = self.allocator,
     };
 }
 

--- a/src/evm/stack/stack.zig
+++ b/src/evm/stack/stack.zig
@@ -41,16 +41,18 @@ pub const Error = error{
     StackUnderflow,
 };
 
+/// Current number of elements on the stack.
+/// Invariant: 0 <= size <= CAPACITY
+/// Placed first for optimal access - this is checked frequently
+size: usize = 0,
+
 /// Stack storage aligned to 32-byte boundaries.
 /// Alignment improves performance on modern CPUs by:
 /// - Enabling SIMD operations
 /// - Reducing cache line splits
 /// - Improving memory prefetching
+/// Placed last to avoid increasing offsets of frequently accessed size field
 data: [CAPACITY]u256 align(32) = [_]u256{0} ** CAPACITY,
-
-/// Current number of elements on the stack.
-/// Invariant: 0 <= size <= CAPACITY
-size: usize = 0,
 
 // Compile-time validations for stack design assumptions
 comptime {


### PR DESCRIPTION
## Summary

Optimize memory layout of critical EVM structs for better cache performance by placing frequently accessed fields first and large allocations last to minimize instruction encoding overhead.

## Changes Made

### Frame struct optimizations (`src/evm/frame/frame.zig`):
- Move frequently accessed fields (gas_remaining, pc, contract, allocator) to beginning
- Place large allocations (memory, stack, return_data) at end to minimize offset impact
- Group related fields together (execution flags, data pointers, debug fields)

### Stack struct optimizations (`src/evm/stack/stack.zig`):
- Move size field to beginning (accessed on every stack operation)  
- Place large 32KB data array at end to avoid affecting size field offset

### Memory struct optimizations (`src/evm/memory/memory.zig`):
- Move hot fields (my_checkpoint, memory_limit, owns_buffer) to front
- Place less frequently used allocator and buffer reference later

### Evm struct optimizations (`src/evm/evm.zig`):
- Group hot execution fields (allocator, table, depth, read_only) first
- Move configuration fields (chain_rules, context) to middle  
- Place large state structures (state, access_list) at end

## Performance Impact

These optimizations improve instruction encoding efficiency by keeping frequently accessed fields within smaller byte offsets from struct base pointer, enabling:

- More efficient x86_64/ARM64 addressing modes (1-byte vs 4-byte offsets)
- Better cache line utilization
- Reduced instruction sizes for field access patterns

## Test Plan

- [x] All existing tests pass
- [x] Struct initialization functions updated to match new field order
- [x] No behavioral changes - only memory layout optimization

Resolves #40

🤖 Generated with [Claude Code](https://claude.ai/code)