### PR TITLE
fix: Require Zig 0.14.1 to resolve macOS fuzzing LLVM section error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ For applications requiring full BN254 support in WASM, consider:
 - Using WASM-compatible cryptographic libraries
 - Implementing pure Zig scalar multiplication and pairing
 
+## Prerequisites
+
+- **Zig 0.14.1 or later** (required for fuzzing support on macOS)
+
 ## Build Targets
 
 ```bash
@@ -65,6 +69,9 @@ zig build wasm
 
 # Run tests
 zig build test
+
+# Run fuzzing tests (requires Zig 0.14.1+)
+zig build test --fuzz
 ```
 
 ## Architecture

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.14.1",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.


### PR DESCRIPTION
## Summary

Properly fixes issue #2 by addressing the root cause: updating the minimum Zig version requirement to 0.14.1, which includes the upstream fix for the LLVM coverage instrumentation compatibility issue with macOS Mach-O object files.

- ✅ **Proper Solution**: Updates minimum Zig version rather than disabling fuzzing
- ✅ **Preserves Functionality**: Maintains full fuzzing capabilities on all platforms
- ✅ **Root Cause Fix**: Leverages upstream Zig PR #23504 that fixed the issue
- ✅ **Clear Documentation**: Updates README with prerequisites and fuzzing usage

## The Issue

The original error occurred because LLVM's coverage instrumentation (`-ffuzz`) generated section names incompatible with macOS's Mach-O binary format:

```
LLVM ERROR: Global variable '__sancov_gen_.0' has an invalid section specifier '__sancov_cntrs': mach-o section specifier requires a segment and section separated by a comma.
```

## The Solution

**Zig PR #23504** by @SuperAuguste fixed this exact issue by correcting the mach-o naming for sancov (sanitizer coverage) sections. This fix was included in **Zig 0.14.1**.

Rather than working around the issue by disabling fuzzing, this PR properly addresses it by ensuring users have the fixed version of Zig.

## Changes Made

### 1. Updated `build.zig.zon`
```diff
- .minimum_zig_version = "0.14.0",
+ .minimum_zig_version = "0.14.1",
```

### 2. Enhanced `README.md`
- Added **Prerequisites** section documenting Zig 0.14.1 requirement
- Added fuzzing command example: `zig build test --fuzz`
- Clear explanation of the version requirement

## Verification

**Before (Zig 0.14.0):**
```
error: LLVM ERROR: Global variable '__sancov_gen_.0' has an invalid section specifier '__sancov_cntrs'
```

**After (Zig 0.14.1):**
```bash
zig build test --fuzz
# Fuzzing starts successfully with web interface
info: web interface listening at http://127.0.0.1:55241/
```

## Benefits

- ✅ **No functionality loss** - Full fuzzing capabilities preserved
- ✅ **Clean solution** - No workarounds or build system complexity
- ✅ **Future-proof** - Works with all Zig versions 0.14.1+
- ✅ **Automatic enforcement** - Zig package manager enforces version requirement
- ✅ **Clear documentation** - Users know exactly what version they need

## Testing

- ✅ `zig build` - Compiles successfully
- ✅ `zig build test` - All tests pass
- ✅ `zig build test --fuzz` - Fuzzing works without LLVM errors
- ✅ Version enforcement works via `minimum_zig_version`

This is the correct, clean solution that addresses the root cause rather than working around it.

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)