### PR TITLE
fix: Update Zig version from 0.14.0 to 0.14.1 in CI/CD pipeline

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -24,9 +24,9 @@ RUN apk add --no-cache nodejs npm && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Zig 0.14.0
-RUN curl -L https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJ -C /opt && \
-    ln -s /opt/zig-linux-x86_64-0.14.0/zig /usr/local/bin/zig
+# Install Zig 0.14.1
+RUN curl -L https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz | tar -xJ -C /opt && \
+    ln -s /opt/zig-linux-x86_64-0.14.1/zig /usr/local/bin/zig
 
 # Set working directory
 WORKDIR /workspace

--- a/.docker/Dockerfile.debian
+++ b/.docker/Dockerfile.debian
@@ -28,9 +28,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Zig 0.14.0
-RUN curl -L https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJ -C /opt && \
-    ln -s /opt/zig-linux-x86_64-0.14.0/zig /usr/local/bin/zig
+# Install Zig 0.14.1
+RUN curl -L https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz | tar -xJ -C /opt && \
+    ln -s /opt/zig-linux-x86_64-0.14.1/zig /usr/local/bin/zig
 
 # Set working directory
 WORKDIR /workspace

--- a/.docker/Dockerfile.ubuntu
+++ b/.docker/Dockerfile.ubuntu
@@ -27,9 +27,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Zig 0.14.0
-RUN curl -L https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJ -C /opt && \
-    ln -s /opt/zig-linux-x86_64-0.14.0/zig /usr/local/bin/zig
+# Install Zig 0.14.1
+RUN curl -L https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz | tar -xJ -C /opt && \
+    ln -s /opt/zig-linux-x86_64-0.14.1/zig /usr/local/bin/zig
 
 # Set working directory
 WORKDIR /workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.14.1
 
       - name: Create Zig cache directory
         run: mkdir -p ~/.cache/zig


### PR DESCRIPTION
## Summary
- Updates all CI/CD configurations from Zig 0.14.0 to 0.14.1
- Fixes version mismatch causing Ubuntu Docker build failures
- Ensures CI uses the minimum version required by build.zig.zon

## Test plan
- [x] Local build and test passes with Zig 0.14.1
- [x] Updated .github/workflows/ci.yml native build step  
- [x] Updated .docker/Dockerfile.ubuntu
- [x] Updated .docker/Dockerfile.alpine
- [x] Updated .docker/Dockerfile.debian
- [ ] CI pipeline passes after merge

Closes #219

🤖 Generated with [Claude Code](https://claude.ai/code)