### PR TITLE
fix: Add memory leak prevention methods to EvmState

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -636,6 +636,20 @@ pub fn build(b: *std.Build) void {
     const memory_test_step = b.step("test-memory", "Run Memory tests");
     memory_test_step.dependOn(&run_memory_test.step);
 
+    // Add Memory Leak tests
+    const memory_leak_test = b.addTest(.{
+        .name = "memory-leak-test",
+        .root_source_file = b.path("test/evm/memory_leak_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    memory_leak_test.root_module.addImport("evm", evm_mod);
+    memory_leak_test.root_module.addImport("primitives", primitives_mod);
+
+    const run_memory_leak_test = b.addRunArtifact(memory_leak_test);
+    const memory_leak_test_step = b.step("test-memory-leak", "Run Memory leak prevention tests");
+    memory_leak_test_step.dependOn(&run_memory_leak_test.step);
+
     // Add Stack tests
     const stack_test = b.addTest(.{
         .name = "stack-test",

--- a/test/evm/memory_leak_test.zig
+++ b/test/evm/memory_leak_test.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+const testing = std.testing;
+const evm = @import("evm");
+const EvmState = evm.EvmState;
+const MemoryDatabase = evm.MemoryDatabase;
+const primitives = @import("primitives");
+
+// Helper function to create test addresses
+fn testAddress(value: u160) primitives.Address.Address {
+    return primitives.Address.from_u256(@as(u256, value));
+}
+
+test "Memory leak prevention: EvmState transaction clearing" {
+    const allocator = testing.allocator;
+
+    var memory_db = MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+
+    const db_interface = memory_db.to_database_interface();
+    var state = try EvmState.init(allocator, db_interface);
+    defer state.deinit();
+
+    // Simulate 1000 transactions
+    for (0..1000) |tx_num| {
+        const addr = testAddress(@as(u160, @intCast(tx_num % 256)));
+
+        // Each transaction emits logs
+        for (0..10) |i| {
+            const topics = [_]u256{tx_num, i};
+            const data = try allocator.alloc(u8, 100);
+            defer allocator.free(data);
+            @memset(data, @as(u8, @intCast(i)));
+            
+            try state.emit_log(addr, &topics, data);
+        }
+
+        // Set transient storage
+        try state.set_transient_storage(addr, 0, tx_num);
+
+        // Mark selfdestructs
+        if (tx_num % 100 == 0) {
+            const recipient = testAddress(@as(u160, @intCast(tx_num + 1)));
+            try state.mark_selfdestruct(addr, recipient);
+        }
+
+        // CRITICAL: Clear transaction state to prevent memory leaks
+        state.clear_transaction_state();
+    }
+
+    // Verify all transaction data was cleared
+    try testing.expectEqual(@as(usize, 0), state.logs.items.len);
+    try testing.expectEqual(@as(usize, 0), state.transient_storage.count());
+    try testing.expectEqual(@as(usize, 0), state.selfdestructs.count());
+}
+
+test "Memory leak stress test: logs allocation pattern" {
+    const allocator = testing.allocator;
+
+    var memory_db = MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+
+    const db_interface = memory_db.to_database_interface();
+    var state = try EvmState.init(allocator, db_interface);
+    defer state.deinit();
+
+    // Run many iterations to stress test memory management
+    for (0..500) |iter| {
+        const base_addr = @as(u160, @intCast(iter * 1000));
+
+        // State operations
+        for (0..20) |i| {
+            const addr = testAddress(base_addr + i);
+            
+            // Emit log with allocated data
+            const data_size = (i + 1) * 10;
+            const data = try allocator.alloc(u8, data_size);
+            defer allocator.free(data);
+            @memset(data, @as(u8, @intCast(i)));
+            
+            const topics = [_]u256{iter, i};
+            try state.emit_log(addr, &topics, data);
+            
+            // Set transient storage
+            try state.set_transient_storage(addr, i, iter * i);
+        }
+
+        // Mark some selfdestructs
+        if (iter % 50 == 0) {
+            const addr = testAddress(base_addr);
+            const recipient = testAddress(base_addr + 999);
+            try state.mark_selfdestruct(addr, recipient);
+        }
+
+        // Clear all transaction data
+        state.clear_transaction_state();
+    }
+
+    // Final verification
+    try testing.expectEqual(@as(usize, 0), state.logs.items.len);
+    try testing.expectEqual(@as(usize, 0), state.transient_storage.count());
+    try testing.expectEqual(@as(usize, 0), state.selfdestructs.count());
+}


### PR DESCRIPTION
## Summary
- Implements proper cleanup methods for transaction-scoped state to prevent memory leaks
- Addresses issue #3 regarding memory accumulation in long-running EVM instances
- Adds comprehensive tests to verify memory leak prevention

## Changes
- Added `clear_logs()` method that properly frees allocated memory for log topics and data
- Added `clear_selfdestructs()` method to clear selfdestruct mapping  
- Added `clear_transaction_state()` convenience method to clear all transaction data
- Added unit tests to EvmState to verify clearing methods work correctly
- Added integration tests simulating thousands of transactions to ensure no memory accumulation

## Problem
The issue was that logs and selfdestructs were not being cleared between transactions, potentially causing memory accumulation over time. Each transaction would add logs to the list, and the allocated memory for topics and data would never be freed.

## Solution
These new methods should be called at transaction boundaries to prevent memory leaks. The `clear_transaction_state()` method provides a single point to clear all transaction-scoped data.

## Test plan
- [x] Added unit tests for each clearing method
- [x] Added stress test simulating 1000 transactions 
- [x] Added memory allocation pattern test with 500 iterations
- [x] All tests pass with `zig build test`

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)