### PR TITLE
Optimize byte conversion and alignment in src/evm/execution/memory.zig

### DIFF
--- a/src/evm/execution/memory.zig
+++ b/src/evm/execution/memory.zig
@@ -25,18 +25,13 @@ fn calculate_memory_gas(frame: *Frame, new_size: usize) !void {
 
 // Helper to calculate word-aligned size
 fn word_aligned_size(size: usize) usize {
-    return ((size + 31) / 32) * 32;
+    return std.mem.alignForward(usize, size, 32);
 }
 
 // Helper to convert u256 to big-endian bytes
 fn u256_to_big_endian_bytes(value: u256) [32]u8 {
     var bytes: [32]u8 = undefined;
-    var temp = value;
-    var i: usize = 0;
-    while (i < 32) : (i += 1) {
-        bytes[31 - i] = @intCast(temp & 0xFF);
-        temp = temp >> 8;
-    }
+    std.mem.writeInt(u256, &bytes, value, .big);
     return bytes;
 }
 


### PR DESCRIPTION
## Summary

- **Optimize byte conversion**: Replace manual loop with `std.mem.writeInt` in `u256_to_big_endian_bytes`
- **Optimize word alignment**: Use `std.mem.alignForward` instead of manual calculation in `word_aligned_size`  
- **Verify existing truncation**: Confirmed `@truncate` usage in `op_mstore8` is already optimal

## Performance Impact

- Both optimizations target hot paths in memory operations (frequent in EVM execution)
- `std.mem.writeInt` is optimized and may use CPU intrinsics for better performance
- `std.mem.alignForward` provides cleaner, more idiomatic code with clear intent
- No functional changes - purely performance and code quality improvements

## Test Plan

- [x] `zig build` - Compiles successfully  
- [x] `zig build test` - All tests pass
- [x] `zig build bench` - Benchmarks pass with good performance
- [x] `zig build fuzz` - Fuzzing tests complete successfully
- [x] Manual verification of optimized functions

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)