### PR TITLE
feat: Add Arbitrum L2 Execution Environment Support

### DIFF
--- a/L2_IMPLEMENTATION_SUMMARY.md
+++ b/L2_IMPLEMENTATION_SUMMARY.md
@@ -29,8 +29,9 @@ This implementation adds comprehensive support for Arbitrum and Optimism Layer 2
   - ArbStatistics (0x6f)
 
 - **Implementations**:
-  - `arb_sys.zig`: Implements arbBlockNumber(), arbBlockHash(), isTopLevelCall()
+  - `arb_sys.zig`: Implements arbBlockNumber(), arbChainID(), arbOSVersion(), isTopLevelCall()
   - `arb_info.zig`: Implements getBalance()
+  - `arb_gas_info.zig`: Implements getPricesInWei(), getCurrentTxL1GasFees(), getGasAccountingParams()
 
 #### Optimism Precompiles
 - **Address definitions**:
@@ -78,12 +79,13 @@ This implementation adds comprehensive support for Arbitrum and Optimism Layer 2
 
 ## Future Work
 
-1. Complete implementation of remaining Arbitrum precompiles
+1. Complete implementation of remaining Arbitrum precompiles (ArbAggregator, ArbRetryableTx, ArbAddressTable, ArbStatistics)
 2. Add more Optimism system contracts
 3. Implement Arbitrum-specific opcodes
 4. Add deposit transaction execution in VM
-5. Integrate L2-specific gas pricing models
+5. Integrate actual L2-specific gas pricing models (currently using mock values)
 6. Add cross-layer message handling
+7. Connect precompiles to actual state storage instead of returning mock values
 
 ## Testing
 

--- a/L2_IMPLEMENTATION_SUMMARY.md
+++ b/L2_IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,90 @@
+# L2 Implementation Summary
+
+## Overview
+This implementation adds comprehensive support for Arbitrum and Optimism Layer 2 execution environments to the Guillotine Zig EVM implementation.
+
+## Key Changes
+
+### 1. Chain Type Support (`src/evm/chain_type.zig`)
+- Added `ChainType` enum to identify different blockchain networks (ETHEREUM, ARBITRUM, OPTIMISM)
+- Implemented `fromChainId` function to map chain IDs to chain types
+- Supports mainnet and testnet chain IDs for all three networks
+
+### 2. Extended Chain Rules (`src/evm/hardforks/chain_rules.zig`)
+- Added `chain_type` field to ChainRules structure
+- Created `for_hardfork_and_chain` function to create chain-specific rules
+- Maintains backward compatibility with existing code
+
+### 3. L2 Precompile Infrastructure
+
+#### Arbitrum Precompiles
+- **Address definitions** (`src/evm/precompiles/l2_precompile_addresses.zig`):
+  - ArbSys (0x64)
+  - ArbInfo (0x65)
+  - ArbAddressTable (0x66)
+  - ArbOsTest (0x69)
+  - ArbRetryableTx (0x6e)
+  - ArbGasInfo (0x6c)
+  - ArbAggregator (0x6d)
+  - ArbStatistics (0x6f)
+
+- **Implementations**:
+  - `arb_sys.zig`: Implements arbBlockNumber(), arbBlockHash(), isTopLevelCall()
+  - `arb_info.zig`: Implements getBalance()
+
+#### Optimism Precompiles
+- **Address definitions**:
+  - L1Block (0x4200000000000000000000000000000000000015)
+  - L2ToL1MessagePasser (0x4200000000000000000000000000000000000016)
+  - L2CrossDomainMessenger (0x4200000000000000000000000000000000000007)
+  - L2StandardBridge (0x4200000000000000000000000000000000000010)
+  - SequencerFeeVault (0x4200000000000000000000000000000000000011)
+  - OptimismMintableERC20Factory (0x4200000000000000000000000000000000000012)
+  - GasPriceOracle (0x420000000000000000000000000000000000000f)
+
+- **Implementations**:
+  - `l1_block.zig`: Implements number(), timestamp(), basefee()
+
+### 4. Precompile Dispatcher Updates (`src/evm/precompiles/precompiles.zig`)
+- Added `is_l2_precompile` function to check L2-specific addresses
+- Updated `is_available` to check both standard and L2 precompiles
+- Extended `execute_precompile` to dispatch L2 precompile calls based on chain type
+
+### 5. VM Integration (`src/evm/evm.zig`)
+- Added `init_with_hardfork_and_chain` function to initialize VM with L2 support
+- VM now properly routes calls to L2 precompiles when configured for Arbitrum/Optimism
+
+### 6. Optimism Deposit Transactions (`src/evm/optimism/deposit_transaction.zig`)
+- Created `DepositTransaction` structure for L1->L2 deposits
+- Added `OptimismContext` for L1 block information
+- Implemented validation logic for deposit transactions
+
+### 7. Module Exports (`src/evm/root.zig`)
+- Exported `ChainType` for external use
+- Made all new components accessible through the main EVM module
+
+### 8. Comprehensive Tests
+- `test/evm/l2_integration_test.zig`: Basic L2 precompile integration tests
+- `test/evm/l2_vm_integration_test.zig`: VM-level execution tests
+- Unit tests in each precompile implementation
+
+## Architecture Benefits
+
+1. **Modular Design**: L2 support is cleanly separated and doesn't affect Ethereum mainnet execution
+2. **Zero Overhead**: L2 precompiles are only checked when running on L2 chains
+3. **Extensibility**: Easy to add new L2 chains or precompiles
+4. **Type Safety**: Strong typing ensures correct chain configuration
+5. **Performance**: Efficient dispatch using chain type switching
+
+## Future Work
+
+1. Complete implementation of remaining Arbitrum precompiles
+2. Add more Optimism system contracts
+3. Implement Arbitrum-specific opcodes
+4. Add deposit transaction execution in VM
+5. Integrate L2-specific gas pricing models
+6. Add cross-layer message handling
+
+## Testing
+
+All new functionality includes unit tests. The implementation maintains backward compatibility - existing Ethereum mainnet tests continue to pass unchanged.

--- a/src/evm/chain_type.zig
+++ b/src/evm/chain_type.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+/// Chain type enum to identify different blockchain networks
+pub const ChainType = enum {
+    /// Ethereum mainnet and testnets
+    ETHEREUM,
+    /// Arbitrum Layer 2
+    ARBITRUM,
+    /// Optimism Layer 2
+    OPTIMISM,
+
+    /// Get chain type from chain ID
+    pub fn fromChainId(chain_id: u64) ChainType {
+        return switch (chain_id) {
+            // Ethereum mainnet
+            1 => .ETHEREUM,
+            // Ethereum testnets
+            3, 4, 5, 11155111 => .ETHEREUM, // Ropsten, Rinkeby, Goerli, Sepolia
+            
+            // Arbitrum chains
+            42161 => .ARBITRUM, // Arbitrum One
+            421614 => .ARBITRUM, // Arbitrum Sepolia
+            42170 => .ARBITRUM, // Arbitrum Nova
+            
+            // Optimism chains  
+            10 => .OPTIMISM, // OP Mainnet
+            11155420 => .OPTIMISM, // OP Sepolia
+            
+            // Default to Ethereum for unknown chains
+            else => .ETHEREUM,
+        };
+    }
+};
+
+test "ChainType.fromChainId" {
+    try std.testing.expectEqual(ChainType.ETHEREUM, ChainType.fromChainId(1));
+    try std.testing.expectEqual(ChainType.ARBITRUM, ChainType.fromChainId(42161));
+    try std.testing.expectEqual(ChainType.OPTIMISM, ChainType.fromChainId(10));
+    try std.testing.expectEqual(ChainType.ETHEREUM, ChainType.fromChainId(999999));
+}

--- a/src/evm/evm.zig
+++ b/src/evm/evm.zig
@@ -21,6 +21,7 @@ pub const CallResult = @import("evm/call_result.zig").CallResult;
 pub const RunResult = @import("evm/run_result.zig").RunResult;
 const Hardfork = @import("hardforks/hardfork.zig").Hardfork;
 const precompiles = @import("precompiles/precompiles.zig");
+const ChainType = @import("chain_type.zig").ChainType;
 
 /// Virtual Machine for executing Ethereum bytecode.
 ///
@@ -186,6 +187,20 @@ pub fn init_with_state(
 pub fn init_with_hardfork(allocator: std.mem.Allocator, database: @import("state/database_interface.zig").DatabaseInterface, hardfork: Hardfork) !Evm {
     const table = JumpTable.init_from_hardfork(hardfork);
     const rules = ChainRules.for_hardfork(hardfork);
+    return try init_with_state(allocator, database, null, table, rules, null, null);
+}
+
+/// Initialize EVM with a specific hardfork and chain type (for L2 support).
+/// Creates an EVM configured for a specific Layer 2 chain (Arbitrum, Optimism).
+/// @param allocator Memory allocator for VM operations
+/// @param database Database interface for state management
+/// @param hardfork Ethereum hardfork to configure for
+/// @param chain_type Type of chain (ETHEREUM, ARBITRUM, OPTIMISM)
+/// @return Initialized EVM instance with L2 support
+/// @throws std.mem.Allocator.Error if allocation fails
+pub fn init_with_hardfork_and_chain(allocator: std.mem.Allocator, database: @import("state/database_interface.zig").DatabaseInterface, hardfork: Hardfork, chain_type: ChainType) !Evm {
+    const table = JumpTable.init_from_hardfork(hardfork);
+    const rules = ChainRules.for_hardfork_and_chain(hardfork, chain_type);
     return try init_with_state(allocator, database, null, table, rules, null, null);
 }
 

--- a/src/evm/hardforks/chain_rules.zig
+++ b/src/evm/hardforks/chain_rules.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Hardfork = @import("hardfork.zig").Hardfork;
 const Log = @import("../log.zig");
+const ChainType = @import("../chain_type.zig").ChainType;
 
 /// Configuration for Ethereum protocol rules and EIP activations across hardforks.
 ///
@@ -306,6 +307,18 @@ is_cancun: bool = true,
 /// This flag is reserved for future use and should remain
 /// false until Prague specifications are finalized.
 is_prague: bool = false,
+
+/// Chain type for L2-specific behavior.
+///
+/// ## Purpose
+/// Identifies the blockchain network type to enable chain-specific
+/// features like custom precompiles and opcodes for Layer 2 solutions.
+///
+/// ## L2 Support
+/// - ETHEREUM: Standard Ethereum execution rules
+/// - ARBITRUM: Enables Arbitrum-specific precompiles and opcodes
+/// - OPTIMISM: Enables Optimism-specific features and deposit transactions
+chain_type: ChainType = .ETHEREUM,
 
 /// Verkle trees activation flag (future upgrade).
 ///
@@ -649,7 +662,12 @@ const HARDFORK_RULES = [_]HardforkRule{
 };
 
 pub fn for_hardfork(hardfork: Hardfork) ChainRules {
+    return for_hardfork_and_chain(hardfork, .ETHEREUM);
+}
+
+pub fn for_hardfork_and_chain(hardfork: Hardfork, chain: ChainType) ChainRules {
     var rules = ChainRules{}; // All fields default to true
+    rules.chain_type = chain;
 
     // Disable features that were introduced after the target hardfork
     inline for (HARDFORK_RULES) |rule| {

--- a/src/evm/optimism/deposit_transaction.zig
+++ b/src/evm/optimism/deposit_transaction.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const primitives = @import("primitives");
+const Address = @import("Address").Address;
+
+/// Optimism deposit transaction structure
+/// Represents a transaction deposited from L1 to L2
+pub const DepositTransaction = struct {
+    /// Source hash from L1
+    source_hash: primitives.B256,
+    /// Sender address (from L1)
+    from: Address,
+    /// Recipient address (on L2)
+    to: ?Address,
+    /// Mint value (amount of ETH to mint on L2)
+    mint: u256,
+    /// Transaction value
+    value: u256,
+    /// Gas limit
+    gas: u64,
+    /// Whether this is a system transaction
+    is_system_tx: bool,
+    /// Transaction data
+    data: []const u8,
+    
+    /// Validate deposit transaction
+    pub fn validate(self: DepositTransaction) !void {
+        // Ensure gas limit is reasonable
+        if (self.gas == 0) {
+            return error.InvalidGasLimit;
+        }
+        
+        // System transactions have special rules
+        if (self.is_system_tx) {
+            // System transactions must have zero value
+            if (self.value != 0) {
+                return error.SystemTransactionWithValue;
+            }
+        }
+    }
+    
+    /// Calculate the deposit transaction hash
+    pub fn hash(self: DepositTransaction) primitives.B256 {
+        // In real implementation, this would follow Optimism's deposit tx hash algorithm
+        // For now, return a mock hash
+        var result: primitives.B256 = undefined;
+        @memset(&result, 0);
+        // Mix in some fields to make it unique
+        result[0] = @truncate(self.gas);
+        result[1] = if (self.is_system_tx) 1 else 0;
+        return result;
+    }
+};
+
+/// Optimism-specific context for deposit transactions
+pub const OptimismContext = struct {
+    /// L1 block number when deposit was made
+    l1_block_number: u64,
+    /// L1 block timestamp
+    l1_block_timestamp: u64,
+    /// L1 block hash
+    l1_block_hash: primitives.B256,
+    /// Base fee from L1
+    l1_base_fee: u256,
+    /// Blob base fee from L1 (post-4844)
+    l1_blob_base_fee: ?u256,
+    
+    /// Initialize default Optimism context
+    pub fn init() OptimismContext {
+        return .{
+            .l1_block_number = 0,
+            .l1_block_timestamp = 0,
+            .l1_block_hash = std.mem.zeroes(primitives.B256),
+            .l1_base_fee = 0,
+            .l1_blob_base_fee = null,
+        };
+    }
+};
+
+test "DepositTransaction validation" {
+    const tx = DepositTransaction{
+        .source_hash = std.mem.zeroes(primitives.B256),
+        .from = Address.ZERO,
+        .to = null,
+        .mint = 0,
+        .value = 0,
+        .gas = 100000,
+        .is_system_tx = false,
+        .data = &.{},
+    };
+    
+    try tx.validate();
+}
+
+test "System transaction validation" {
+    const tx = DepositTransaction{
+        .source_hash = std.mem.zeroes(primitives.B256),
+        .from = Address.ZERO,
+        .to = null,
+        .mint = 0,
+        .value = 100, // Invalid for system tx
+        .gas = 100000,
+        .is_system_tx = true,
+        .data = &.{},
+    };
+    
+    try std.testing.expectError(error.SystemTransactionWithValue, tx.validate());
+}

--- a/src/evm/precompiles/arbitrum/arb_aggregator.zig
+++ b/src/evm/precompiles/arbitrum/arb_aggregator.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// ArbAggregator precompile (0x6d)
+/// Provides batch and data availability information
+///
+/// Key functions:
+/// - getBatchNumber() - Get current batch number
+/// - getL1PricingData() - Get L1 pricing data for calldata
+/// - getTxBaseFee() - Get transaction base fee
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const gas_cost = 100; // Fixed gas cost for aggregator queries
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result: usize = switch (selector) {
+        // getBatchNumber()
+        0x7a7c2ecc => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock batch number
+            @memset(output[0..32], 0);
+            output[31] = 123; // Mock batch number
+            break :blk 32;
+        },
+        // getTxBaseFee()
+        0x4bdb8e5e => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock base fee
+            @memset(output[0..32], 0);
+            output[30] = 0x3b;
+            output[31] = 0x9a; // 15258 wei
+            break :blk 32;
+        },
+        // getL1PricingData() returns (uint256,uint256,uint256)
+        // posterDataCost, posterDataSize, posterDataChecksum
+        0x0c2d9c44 => blk: {
+            if (output.len < 96) { // 3 * 32 bytes
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock L1 pricing data
+            @memset(output[0..96], 0);
+            // posterDataCost: 50000 wei
+            output[27] = 0xc3;
+            output[28] = 0x50;
+            // posterDataSize: 1024 bytes
+            output[60] = 0x04;
+            output[61] = 0x00;
+            // posterDataChecksum: mock checksum
+            output[95] = 0xab;
+            break :blk 96;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "ArbAggregator getBatchNumber" {
+    // getBatchNumber() selector
+    const input = &[_]u8{ 0x7a, 0x7c, 0x2e, 0xcc };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 123), output[31]);
+}
+
+test "ArbAggregator getTxBaseFee" {
+    // getTxBaseFee() selector
+    const input = &[_]u8{ 0x4b, 0xdb, 0x8e, 0x5e };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0x3b), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x9a), output[31]);
+}
+
+test "ArbAggregator getL1PricingData" {
+    // getL1PricingData() selector
+    const input = &[_]u8{ 0x0c, 0x2d, 0x9c, 0x44 };
+    var output: [96]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 96), result.get_output_size());
+    // Check posterDataCost
+    try std.testing.expectEqual(@as(u8, 0xc3), output[27]);
+    try std.testing.expectEqual(@as(u8, 0x50), output[28]);
+}
+
+test "ArbAggregator invalid selector" {
+    const input = &[_]u8{ 0xff, 0xff, 0xff, 0xff };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_failure());
+    try std.testing.expectEqual(PrecompileError.InvalidInput, result.get_error());
+}

--- a/src/evm/precompiles/arbitrum/arb_gas_info.zig
+++ b/src/evm/precompiles/arbitrum/arb_gas_info.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// ArbGasInfo precompile (0x6c)
+/// Provides Arbitrum gas pricing information
+///
+/// Key functions:
+/// - getPricesInWei() - Get L1 and L2 gas prices in wei
+/// - getPricesInArbGas() - Get gas prices in ArbGas units
+/// - getGasAccountingParams() - Get gas accounting parameters
+/// - getCurrentTxL1GasFees() - Get L1 gas fees for current transaction
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const gas_cost = 150; // Fixed gas cost for gas info queries
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result: usize = switch (selector) {
+        // getPricesInWei() returns (uint256,uint256,uint256,uint256,uint256,uint256)
+        // perL2Tx, perL1CalldataUnit, perStorageAllocation, perArbGasBase, perArbGasCongestion, perArbGasTotal
+        0x41b247a8 => blk: {
+            if (output.len < 192) { // 6 * 32 bytes
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock gas prices
+            @memset(output[0..192], 0);
+            // perL2Tx: 100000 wei
+            output[29] = 0x01;
+            output[30] = 0x86;
+            output[31] = 0xa0;
+            // perL1CalldataUnit: 16 wei per byte
+            output[63] = 16;
+            // perStorageAllocation: 1000 wei
+            output[92] = 0x03;
+            output[95] = 0xe8;
+            // perArbGasBase: 100 wei
+            output[127] = 100;
+            // perArbGasCongestion: 0 wei (no congestion)
+            // perArbGasTotal: 100 wei (base only)
+            output[191] = 100;
+            break :blk 192;
+        },
+        // getCurrentTxL1GasFees() returns uint256
+        0xc1880f1d => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock L1 gas fees for current tx
+            @memset(output[0..32], 0);
+            output[30] = 0x27;
+            output[31] = 0x10; // 10000 wei
+            break :blk 32;
+        },
+        // getGasAccountingParams() returns (uint256,uint256,uint256)
+        // speedLimitPerSecond, gasPoolMax, maxTxGasLimit
+        0x612af178 => blk: {
+            if (output.len < 96) { // 3 * 32 bytes
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock gas accounting params
+            @memset(output[0..96], 0);
+            // speedLimitPerSecond: 1000000
+            output[26] = 0x0f;
+            output[27] = 0x42;
+            output[28] = 0x40;
+            // gasPoolMax: 10000000
+            output[57] = 0x98;
+            output[58] = 0x96;
+            output[59] = 0x80;
+            // maxTxGasLimit: 32000000
+            output[88] = 0x01;
+            output[89] = 0xe8;
+            output[90] = 0x48;
+            output[91] = 0x00;
+            break :blk 96;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "ArbGasInfo getPricesInWei" {
+    // getPricesInWei() selector
+    const input = &[_]u8{ 0x41, 0xb2, 0x47, 0xa8 };
+    var output: [192]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 192), result.get_output_size());
+    
+    // Check perL2Tx value
+    try std.testing.expectEqual(@as(u8, 0x01), output[29]);
+    try std.testing.expectEqual(@as(u8, 0x86), output[30]);
+    try std.testing.expectEqual(@as(u8, 0xa0), output[31]);
+    
+    // Check perL1CalldataUnit
+    try std.testing.expectEqual(@as(u8, 16), output[63]);
+}
+
+test "ArbGasInfo getCurrentTxL1GasFees" {
+    // getCurrentTxL1GasFees() selector
+    const input = &[_]u8{ 0xc1, 0x88, 0x0f, 0x1d };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0x27), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x10), output[31]);
+}
+
+test "ArbGasInfo getGasAccountingParams" {
+    // getGasAccountingParams() selector
+    const input = &[_]u8{ 0x61, 0x2a, 0xf1, 0x78 };
+    var output: [96]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 96), result.get_output_size());
+}
+
+test "ArbGasInfo insufficient gas" {
+    const input = &[_]u8{ 0x41, 0xb2, 0x47, 0xa8 };
+    var output: [192]u8 = undefined;
+    
+    const result = execute(input, &output, 100); // Not enough gas
+    
+    try std.testing.expect(result.is_failure());
+    try std.testing.expectEqual(PrecompileError.OutOfGas, result.get_error());
+}

--- a/src/evm/precompiles/arbitrum/arb_info.zig
+++ b/src/evm/precompiles/arbitrum/arb_info.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// ArbInfo precompile (0x65) - Provides Arbitrum chain information
+///
+/// Key functions:
+/// - getBalance(address) - gets account balance  
+/// - getCode(address) - gets contract code
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const base_gas = 100;
+    const per_word_gas = 3;
+    const gas_cost = base_gas + (input.len / 32) * per_word_gas;
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result = switch (selector) {
+        // getBalance(address)
+        0xf8b2cb4f => blk: {
+            if (input.len < 36) {
+                return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+            }
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // For now, return a mock balance
+            @memset(output[0..32], 0);
+            output[31] = 100; // Mock balance
+            break :blk 32;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "ArbInfo getBalance" {
+    // getBalance(address) selector + mock address
+    var input: [36]u8 = undefined;
+    @memcpy(input[0..4], &[_]u8{ 0xf8, 0xb2, 0xcb, 0x4f });
+    @memset(input[4..], 0);
+    var output: [32]u8 = undefined;
+    
+    const result = execute(&input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 101), result.get_gas_used()); // 100 + 1 word
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 100), output[31]);
+}

--- a/src/evm/precompiles/arbitrum/arb_retryable_tx.zig
+++ b/src/evm/precompiles/arbitrum/arb_retryable_tx.zig
@@ -1,0 +1,139 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// ArbRetryableTx precompile (0x6e)
+/// Manages retryable tickets for L1-to-L2 transactions
+///
+/// Key functions:
+/// - getLifetime() - Get default lifetime for retryable tickets
+/// - getTimeout(bytes32 ticketId) - Get timeout for specific ticket
+/// - getSubmissionPrice(uint256 dataLength) - Calculate submission price
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const gas_cost = 150; // Fixed gas cost for retryable tx queries
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result: usize = switch (selector) {
+        // getLifetime()
+        0x79552c0a => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return default lifetime (1 week in seconds)
+            @memset(output[0..32], 0);
+            output[28] = 0x00;
+            output[29] = 0x09;
+            output[30] = 0x3a;
+            output[31] = 0x80; // 604800 seconds
+            break :blk 32;
+        },
+        // getTimeout(bytes32 ticketId)
+        0x12b05d33 => blk: {
+            if (input.len < 36) { // 4 bytes selector + 32 bytes ticketId
+                return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+            }
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock timeout timestamp
+            @memset(output[0..32], 0);
+            output[28] = 0x65;
+            output[29] = 0x6e;
+            output[30] = 0xf0;
+            output[31] = 0x00; // Mock timestamp
+            break :blk 32;
+        },
+        // getSubmissionPrice(uint256 dataLength)
+        0xc8f542b1 => blk: {
+            if (input.len < 36) { // 4 bytes selector + 32 bytes dataLength
+                return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+            }
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Calculate mock submission price (base + per-byte cost)
+            // For simplicity, return fixed price
+            @memset(output[0..32], 0);
+            output[28] = 0x00;
+            output[29] = 0x0f;
+            output[30] = 0x42;
+            output[31] = 0x40; // 1000000 wei base price
+            break :blk 32;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "ArbRetryableTx getLifetime" {
+    // getLifetime() selector
+    const input = &[_]u8{ 0x79, 0x55, 0x2c, 0x0a };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    // Check lifetime value (604800 seconds)
+    try std.testing.expectEqual(@as(u8, 0x09), output[29]);
+    try std.testing.expectEqual(@as(u8, 0x3a), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x80), output[31]);
+}
+
+test "ArbRetryableTx getTimeout" {
+    // getTimeout(bytes32) selector + mock ticket ID
+    var input: [36]u8 = undefined;
+    input[0..4].* = .{ 0x12, 0xb0, 0x5d, 0x33 };
+    @memset(input[4..], 0); // Zero ticket ID
+    
+    var output: [32]u8 = undefined;
+    
+    const result = execute(&input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+}
+
+test "ArbRetryableTx getSubmissionPrice" {
+    // getSubmissionPrice(uint256) selector + data length
+    var input: [36]u8 = undefined;
+    input[0..4].* = .{ 0xc8, 0xf5, 0x42, 0xb1 };
+    @memset(input[4..], 0);
+    input[35] = 100; // 100 bytes of data
+    
+    var output: [32]u8 = undefined;
+    
+    const result = execute(&input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    // Check base price
+    try std.testing.expectEqual(@as(u8, 0x0f), output[29]);
+    try std.testing.expectEqual(@as(u8, 0x42), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x40), output[31]);
+}
+
+test "ArbRetryableTx insufficient input" {
+    // getTimeout with insufficient input
+    const input = &[_]u8{ 0x12, 0xb0, 0x5d, 0x33 }; // Missing ticket ID
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_failure());
+    try std.testing.expectEqual(PrecompileError.InvalidInput, result.get_error());
+}

--- a/src/evm/precompiles/arbitrum/arb_sys.zig
+++ b/src/evm/precompiles/arbitrum/arb_sys.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// ArbSys precompile (0x64) - Provides system-level functionality
+/// 
+/// Key functions:
+/// - arbBlockNumber() - returns Arbitrum block number
+/// - arbBlockHash(uint256) - returns Arbitrum block hash
+/// - withdrawEth(address) - initiates ETH withdrawal to L1
+/// - isTopLevelCall() - checks if current call is top-level
+/// - getStorageGasAvailable() - returns available storage gas
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const base_gas = 100;
+    const per_word_gas = 3;
+    const gas_cost = base_gas + (input.len / 32) * per_word_gas;
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result: usize = switch (selector) {
+        // arbBlockNumber()
+        0xa3b1b31d => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // For now, return a mock block number
+            // In real implementation, this would query the Arbitrum state
+            @memset(output[0..32], 0);
+            output[31] = 42; // Mock block number
+            break :blk 32;
+        },
+        // arbBlockHash(uint256 blockNumber)
+        0x1f90ce5b => blk: {
+            if (input.len < 36) {
+                return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+            }
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // For now, return a mock hash
+            @memset(output[0..32], 0xFF); // Mock hash
+            break :blk 32;
+        },
+        // isTopLevelCall()
+        0x08bd624c => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            @memset(output[0..32], 0);
+            output[31] = 1; // Return true for now
+            break :blk 32;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "ArbSys arbBlockNumber" {
+    // arbBlockNumber() selector
+    const input = &[_]u8{ 0xa3, 0xb1, 0xb3, 0x1d };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 42), output[31]);
+}
+
+test "ArbSys invalid selector" {
+    // Invalid selector
+    const input = &[_]u8{ 0x00, 0x00, 0x00, 0x00 };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_failure());
+}

--- a/src/evm/precompiles/arbitrum/arb_sys.zig
+++ b/src/evm/precompiles/arbitrum/arb_sys.zig
@@ -2,18 +2,17 @@ const std = @import("std");
 const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
 const PrecompileError = @import("../precompile_result.zig").PrecompileError;
 
-/// ArbSys precompile (0x64) - Provides system-level functionality
-/// 
+/// ArbSys precompile (0x64)
+/// Provides Arbitrum system information
+///
 /// Key functions:
-/// - arbBlockNumber() - returns Arbitrum block number
-/// - arbBlockHash(uint256) - returns Arbitrum block hash
-/// - withdrawEth(address) - initiates ETH withdrawal to L1
-/// - isTopLevelCall() - checks if current call is top-level
-/// - getStorageGasAvailable() - returns available storage gas
+/// - arbBlockNumber() - Current Arbitrum block number
+/// - arbChainID() - Arbitrum chain ID
+/// - arbOSVersion() - ArbOS version
+/// - isTopLevelCall() - Whether current call is top level
+/// - mapL1SenderContractAddressToL2Alias() - L1 to L2 address aliasing
 pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
-    const base_gas = 100;
-    const per_word_gas = 3;
-    const gas_cost = base_gas + (input.len / 32) * per_word_gas;
+    const gas_cost = 100; // Fixed gas cost for ArbSys queries
     
     if (gas_cost > gas_limit) {
         return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
@@ -32,22 +31,30 @@ pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput
             if (output.len < 32) {
                 return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
             }
-            // For now, return a mock block number
-            // In real implementation, this would query the Arbitrum state
+            // Return mock Arbitrum block number
             @memset(output[0..32], 0);
             output[31] = 42; // Mock block number
             break :blk 32;
         },
-        // arbBlockHash(uint256 blockNumber)
-        0x1f90ce5b => blk: {
-            if (input.len < 36) {
-                return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
-            }
+        // arbChainID()
+        0x6c94c87b => blk: {
             if (output.len < 32) {
                 return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
             }
-            // For now, return a mock hash
-            @memset(output[0..32], 0xFF); // Mock hash
+            // Return Arbitrum One chain ID
+            @memset(output[0..32], 0);
+            output[29] = 0xa4;
+            output[30] = 0xb1; // 42161 (Arbitrum One)
+            break :blk 32;
+        },
+        // arbOSVersion()
+        0x051038f2 => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock ArbOS version
+            @memset(output[0..32], 0);
+            output[31] = 11; // Version 11
             break :blk 32;
         },
         // isTopLevelCall()
@@ -55,8 +62,9 @@ pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput
             if (output.len < 32) {
                 return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
             }
+            // Return true (1) for top level call
             @memset(output[0..32], 0);
-            output[31] = 1; // Return true for now
+            output[31] = 1;
             break :blk 32;
         },
         else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
@@ -78,12 +86,26 @@ test "ArbSys arbBlockNumber" {
     try std.testing.expectEqual(@as(u8, 42), output[31]);
 }
 
-test "ArbSys invalid selector" {
-    // Invalid selector
-    const input = &[_]u8{ 0x00, 0x00, 0x00, 0x00 };
+test "ArbSys arbChainID" {
+    // arbChainID() selector
+    const input = &[_]u8{ 0x6c, 0x94, 0xc8, 0x7b };
     var output: [32]u8 = undefined;
     
     const result = execute(input, &output, 1000);
     
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0xa4), output[29]);
+    try std.testing.expectEqual(@as(u8, 0xb1), output[30]);
+}
+
+test "ArbSys insufficient gas" {
+    const input = &[_]u8{ 0xa3, 0xb1, 0xb3, 0x1d };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 50); // Not enough gas
+    
     try std.testing.expect(result.is_failure());
+    try std.testing.expectEqual(PrecompileError.OutOfGas, result.get_error());
 }

--- a/src/evm/precompiles/l2_precompile_addresses.zig
+++ b/src/evm/precompiles/l2_precompile_addresses.zig
@@ -1,0 +1,63 @@
+const primitives = @import("primitives");
+
+/// Arbitrum L2 precompile addresses
+pub const ARBITRUM = struct {
+    /// ArbSys - System configuration and chain info
+    pub const ARB_SYS = primitives.Address.from_hex("0x0000000000000000000000000000000000000064") catch unreachable;
+    
+    /// ArbInfo - Chain metadata  
+    pub const ARB_INFO = primitives.Address.from_hex("0x0000000000000000000000000000000000000065") catch unreachable;
+    
+    /// ArbAddressTable - Address aliasing for L1->L2 messages
+    pub const ARB_ADDRESS_TABLE = primitives.Address.from_hex("0x0000000000000000000000000000000000000066") catch unreachable;
+    
+    /// ArbosTest - Testing utilities
+    pub const ARB_OS_TEST = primitives.Address.from_hex("0x0000000000000000000000000000000000000069") catch unreachable;
+    
+    /// ArbRetryableTx - Retryable transaction management
+    pub const ARB_RETRYABLE_TX = primitives.Address.from_hex("0x000000000000000000000000000000000000006e") catch unreachable;
+    
+    /// ArbGasInfo - Gas pricing information
+    pub const ARB_GAS_INFO = primitives.Address.from_hex("0x000000000000000000000000000000000000006c") catch unreachable;
+    
+    /// ArbAggregator - Batch and data availability info
+    pub const ARB_AGGREGATOR = primitives.Address.from_hex("0x000000000000000000000000000000000000006d") catch unreachable;
+    
+    /// ArbStatistics - Chain statistics
+    pub const ARB_STATISTICS = primitives.Address.from_hex("0x000000000000000000000000000000000000006f") catch unreachable;
+};
+
+/// Optimism L2 precompile addresses  
+pub const OPTIMISM = struct {
+    /// L1Block - L1 block information
+    pub const L1_BLOCK = primitives.Address.from_hex("0x4200000000000000000000000000000000000015") catch unreachable;
+    
+    /// L2ToL1MessagePasser - Message passing to L1
+    pub const L2_TO_L1_MESSAGE_PASSER = primitives.Address.from_hex("0x4200000000000000000000000000000000000016") catch unreachable;
+    
+    /// L2CrossDomainMessenger - Cross-domain messaging
+    pub const L2_CROSS_DOMAIN_MESSENGER = primitives.Address.from_hex("0x4200000000000000000000000000000000000007") catch unreachable;
+    
+    /// L2StandardBridge - Token bridging
+    pub const L2_STANDARD_BRIDGE = primitives.Address.from_hex("0x4200000000000000000000000000000000000010") catch unreachable;
+    
+    /// SequencerFeeVault - Sequencer fee collection
+    pub const SEQUENCER_FEE_VAULT = primitives.Address.from_hex("0x4200000000000000000000000000000000000011") catch unreachable;
+    
+    /// OptimismMintableERC20Factory - Token factory
+    pub const OPTIMISM_MINTABLE_ERC20_FACTORY = primitives.Address.from_hex("0x4200000000000000000000000000000000000012") catch unreachable;
+    
+    /// GasPriceOracle - Gas price information
+    pub const GAS_PRICE_ORACLE = primitives.Address.from_hex("0x420000000000000000000000000000000000000f") catch unreachable;
+};
+
+test "L2 precompile addresses" {
+    const std = @import("std");
+    
+    // Test Arbitrum addresses
+    try std.testing.expectEqual(@as(u160, 0x64), ARBITRUM.ARB_SYS.to_u160());
+    try std.testing.expectEqual(@as(u160, 0x65), ARBITRUM.ARB_INFO.to_u160());
+    
+    // Test Optimism addresses  
+    try std.testing.expectEqual(@as(u160, 0x4200000000000000000000000000000000000015), OPTIMISM.L1_BLOCK.to_u160());
+}

--- a/src/evm/precompiles/optimism/l1_block.zig
+++ b/src/evm/precompiles/optimism/l1_block.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const PrecompileOutput = @import("../precompile_result.zig").PrecompileOutput;
+const PrecompileError = @import("../precompile_result.zig").PrecompileError;
+
+/// L1Block precompile (0x4200000000000000000000000000000000000015)
+/// Provides information about the L1 chain
+///
+/// Key functions:
+/// - number() - L1 block number
+/// - timestamp() - L1 block timestamp  
+/// - basefee() - L1 base fee
+/// - hash() - L1 block hash
+/// - sequenceNumber() - L2 block number within epoch
+pub fn execute(input: []const u8, output: []u8, gas_limit: u64) PrecompileOutput {
+    const gas_cost = 100; // Fixed gas cost for L1Block queries
+    
+    if (gas_cost > gas_limit) {
+        return PrecompileOutput.failure_result(PrecompileError.OutOfGas);
+    }
+    
+    if (input.len < 4) {
+        return PrecompileOutput.failure_result(PrecompileError.InvalidInput);
+    }
+    
+    // Get function selector (first 4 bytes)
+    const selector = std.mem.readInt(u32, input[0..4], .big);
+    
+    const result: usize = switch (selector) {
+        // number()
+        0x8381f58a => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock L1 block number
+            @memset(output[0..32], 0);
+            output[30] = 0x01;
+            output[31] = 0x00; // 256
+            break :blk 32;
+        },
+        // timestamp()
+        0xb80777ea => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock timestamp
+            @memset(output[0..32], 0);
+            // Mock timestamp (approx 2024)
+            output[28] = 0x65;
+            output[29] = 0x00;
+            output[30] = 0x00;
+            output[31] = 0x00;
+            break :blk 32;
+        },
+        // basefee()
+        0x5cf24969 => blk: {
+            if (output.len < 32) {
+                return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
+            }
+            // Return mock base fee
+            @memset(output[0..32], 0);
+            output[31] = 30; // 30 gwei
+            break :blk 32;
+        },
+        else => return PrecompileOutput.failure_result(PrecompileError.InvalidInput),
+    };
+    
+    return PrecompileOutput.success_result(gas_cost, result);
+}
+
+test "L1Block number" {
+    // number() selector
+    const input = &[_]u8{ 0x83, 0x81, 0xf5, 0x8a };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0x01), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x00), output[31]);
+}
+
+test "L1Block timestamp" {
+    // timestamp() selector
+    const input = &[_]u8{ 0xb8, 0x07, 0x77, 0xea };
+    var output: [32]u8 = undefined;
+    
+    const result = execute(input, &output, 1000);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0x65), output[28]);
+}

--- a/src/evm/precompiles/precompiles.zig
+++ b/src/evm/precompiles/precompiles.zig
@@ -24,6 +24,7 @@ const kzg_point_evaluation = @import("kzg_point_evaluation.zig");
 // Import L2 precompile modules
 const arb_sys = @import("arbitrum/arb_sys.zig");
 const arb_info = @import("arbitrum/arb_info.zig");
+const arb_gas_info = @import("arbitrum/arb_gas_info.zig");
 const l1_block = @import("optimism/l1_block.zig");
 
 /// Compile-time flag to disable all precompiles
@@ -206,6 +207,8 @@ pub fn execute_precompile(address: primitives.Address.Address, input: []const u8
                     return arb_sys.execute(input, output, gas_limit);
                 } else if (std.mem.eql(u8, &address, &l2_addresses.ARBITRUM.ARB_INFO)) {
                     return arb_info.execute(input, output, gas_limit);
+                } else if (std.mem.eql(u8, &address, &l2_addresses.ARBITRUM.ARB_GAS_INFO)) {
+                    return arb_gas_info.execute(input, output, gas_limit);
                 }
                 // Add other Arbitrum precompiles as they're implemented
                 return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);

--- a/src/evm/precompiles/precompiles.zig
+++ b/src/evm/precompiles/precompiles.zig
@@ -25,6 +25,8 @@ const kzg_point_evaluation = @import("kzg_point_evaluation.zig");
 const arb_sys = @import("arbitrum/arb_sys.zig");
 const arb_info = @import("arbitrum/arb_info.zig");
 const arb_gas_info = @import("arbitrum/arb_gas_info.zig");
+const arb_aggregator = @import("arbitrum/arb_aggregator.zig");
+const arb_retryable_tx = @import("arbitrum/arb_retryable_tx.zig");
 const l1_block = @import("optimism/l1_block.zig");
 
 /// Compile-time flag to disable all precompiles
@@ -209,6 +211,10 @@ pub fn execute_precompile(address: primitives.Address.Address, input: []const u8
                     return arb_info.execute(input, output, gas_limit);
                 } else if (std.mem.eql(u8, &address, &l2_addresses.ARBITRUM.ARB_GAS_INFO)) {
                     return arb_gas_info.execute(input, output, gas_limit);
+                } else if (std.mem.eql(u8, &address, &l2_addresses.ARBITRUM.ARB_AGGREGATOR)) {
+                    return arb_aggregator.execute(input, output, gas_limit);
+                } else if (std.mem.eql(u8, &address, &l2_addresses.ARBITRUM.ARB_RETRYABLE_TX)) {
+                    return arb_retryable_tx.execute(input, output, gas_limit);
                 }
                 // Add other Arbitrum precompiles as they're implemented
                 return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);

--- a/src/evm/root.zig
+++ b/src/evm/root.zig
@@ -172,6 +172,9 @@ pub const bitvec = @import("frame/bitvec.zig");
 /// Chain-specific validation rules
 pub const chain_rules = @import("hardforks/chain_rules.zig");
 
+/// Chain type enumeration for L2 support
+pub const ChainType = @import("chain_type.zig").ChainType;
+
 /// Hardforks namespace for easier access
 pub const hardforks = struct {
     pub const chain_rules = @import("hardforks/chain_rules.zig");

--- a/test/evm/l2_integration_test.zig
+++ b/test/evm/l2_integration_test.zig
@@ -26,6 +26,31 @@ test "Arbitrum ArbSys precompile integration" {
     try std.testing.expectEqual(@as(u8, 42), output[31]); // Mock block number
 }
 
+test "Arbitrum ArbGasInfo precompile integration" {
+    const allocator = std.testing.allocator;
+    
+    // Create Arbitrum chain rules
+    const chain_rules = Evm.chain_rules.for_hardfork_and_chain(.CANCUN, .ARBITRUM);
+    
+    // ArbGasInfo address
+    const arb_gas_info_address = Address.from_hex("0x000000000000000000000000000000000000006c") catch unreachable;
+    
+    // Check that ArbGasInfo is available on Arbitrum
+    try std.testing.expect(Evm.Precompiles.is_available(arb_gas_info_address, chain_rules));
+    
+    // getPricesInWei() selector
+    const input = &[_]u8{ 0x41, 0xb2, 0x47, 0xa8 };
+    var output: [192]u8 = undefined;
+    
+    const result = Evm.Precompiles.execute_precompile(arb_gas_info_address, input, &output, 1000, chain_rules);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 150), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 192), result.get_output_size());
+    // Check one of the return values
+    try std.testing.expectEqual(@as(u8, 16), output[63]); // perL1CalldataUnit
+}
+
 test "Optimism L1Block precompile integration" {
     const allocator = std.testing.allocator;
     

--- a/test/evm/l2_integration_test.zig
+++ b/test/evm/l2_integration_test.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const Evm = @import("evm");
+const Address = @import("Address");
+
+test "Arbitrum ArbSys precompile integration" {
+    const allocator = std.testing.allocator;
+    
+    // Create Arbitrum chain rules
+    const chain_rules = Evm.chain_rules.for_hardfork_and_chain(.CANCUN, .ARBITRUM);
+    
+    // ArbSys address
+    const arb_sys_address = Address.from_hex("0x0000000000000000000000000000000000000064") catch unreachable;
+    
+    // Check that ArbSys is available on Arbitrum
+    try std.testing.expect(Evm.Precompiles.is_available(arb_sys_address, chain_rules));
+    
+    // arbBlockNumber() selector
+    const input = &[_]u8{ 0xa3, 0xb1, 0xb3, 0x1d };
+    var output: [32]u8 = undefined;
+    
+    const result = Evm.Precompiles.execute_precompile(arb_sys_address, input, &output, 1000, chain_rules);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 42), output[31]); // Mock block number
+}
+
+test "Optimism L1Block precompile integration" {
+    const allocator = std.testing.allocator;
+    
+    // Create Optimism chain rules
+    const chain_rules = Evm.chain_rules.for_hardfork_and_chain(.CANCUN, .OPTIMISM);
+    
+    // L1Block address
+    const l1_block_address = Address.from_hex("0x4200000000000000000000000000000000000015") catch unreachable;
+    
+    // Check that L1Block is available on Optimism
+    try std.testing.expect(Evm.Precompiles.is_available(l1_block_address, chain_rules));
+    
+    // number() selector
+    const input = &[_]u8{ 0x83, 0x81, 0xf5, 0x8a };
+    var output: [32]u8 = undefined;
+    
+    const result = Evm.Precompiles.execute_precompile(l1_block_address, input, &output, 1000, chain_rules);
+    
+    try std.testing.expect(result.is_success());
+    try std.testing.expectEqual(@as(u64, 100), result.get_gas_used());
+    try std.testing.expectEqual(@as(usize, 32), result.get_output_size());
+    try std.testing.expectEqual(@as(u8, 0x01), output[30]);
+    try std.testing.expectEqual(@as(u8, 0x00), output[31]);
+}
+
+test "L2 precompiles not available on Ethereum" {
+    const allocator = std.testing.allocator;
+    
+    // Create Ethereum chain rules
+    const chain_rules = Evm.chain_rules.for_hardfork(.CANCUN); // Defaults to ETHEREUM
+    
+    // ArbSys address
+    const arb_sys_address = Address.from_hex("0x0000000000000000000000000000000000000064") catch unreachable;
+    
+    // L1Block address
+    const l1_block_address = Address.from_hex("0x4200000000000000000000000000000000000015") catch unreachable;
+    
+    // Check that L2 precompiles are NOT available on Ethereum
+    try std.testing.expect(!Evm.Precompiles.is_available(arb_sys_address, chain_rules));
+    try std.testing.expect(!Evm.Precompiles.is_available(l1_block_address, chain_rules));
+}
+
+test "ChainType from chain ID" {
+    try std.testing.expectEqual(Evm.ChainType.ETHEREUM, Evm.ChainType.fromChainId(1));
+    try std.testing.expectEqual(Evm.ChainType.ARBITRUM, Evm.ChainType.fromChainId(42161));
+    try std.testing.expectEqual(Evm.ChainType.OPTIMISM, Evm.ChainType.fromChainId(10));
+    
+    // Test testnets
+    try std.testing.expectEqual(Evm.ChainType.ETHEREUM, Evm.ChainType.fromChainId(11155111)); // Sepolia
+    try std.testing.expectEqual(Evm.ChainType.ARBITRUM, Evm.ChainType.fromChainId(421614)); // Arbitrum Sepolia
+    try std.testing.expectEqual(Evm.ChainType.OPTIMISM, Evm.ChainType.fromChainId(11155420)); // OP Sepolia
+}

--- a/test/evm/l2_vm_integration_test.zig
+++ b/test/evm/l2_vm_integration_test.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const Evm = @import("evm");
+const Address = @import("Address");
+const primitives = @import("primitives");
+
+test "VM executes Arbitrum precompile calls" {
+    const allocator = std.testing.allocator;
+    
+    // Create a memory database
+    var memory_db = Evm.MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+    
+    const db_interface = memory_db.to_database_interface();
+    
+    // Initialize VM with Arbitrum chain type
+    var vm = try Evm.Evm.init_with_hardfork_and_chain(allocator, db_interface, .CANCUN, .ARBITRUM);
+    defer vm.deinit();
+    
+    // Create a contract that calls ArbSys.arbBlockNumber()
+    // PUSH20 <ArbSys address>
+    // PUSH1 0x00  // value
+    // PUSH1 0x20  // output size
+    // PUSH1 0x00  // output offset
+    // PUSH1 0x04  // input size
+    // PUSH1 0x00  // input offset
+    // PUSH2 0x1000 // gas
+    // STATICCALL
+    // PUSH1 0x00  // return data offset
+    // MLOAD       // load result
+    const bytecode = [_]u8{
+        // PUSH20 ArbSys address (0x64)
+        0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64,
+        // PUSH1 0x00 (value)
+        0x60, 0x00,
+        // PUSH1 0x20 (output size)
+        0x60, 0x20,
+        // PUSH1 0x00 (output offset)
+        0x60, 0x00,
+        // PUSH1 0x04 (input size)
+        0x60, 0x04,
+        // PUSH1 0x00 (input offset)
+        0x60, 0x00,
+        // PUSH2 0x1000 (gas)
+        0x61, 0x10, 0x00,
+        // STATICCALL
+        0xFA,
+        // PUSH1 0x00
+        0x60, 0x00,
+        // MLOAD
+        0x51,
+    };
+    
+    // First store the function selector in memory
+    // arbBlockNumber() = 0xa3b1b31d
+    const caller = Address.from_hex("0x1234567890123456789012345678901234567890") catch unreachable;
+    var contract = try Evm.Contract.init(allocator, bytecode[0..], .{
+        .address = caller,
+        .gas = 100000,
+    });
+    defer contract.deinit(allocator, null);
+    
+    var frame = try Evm.Frame.init(allocator, &vm, 100000, contract, caller, &.{});
+    defer frame.deinit();
+    
+    // Store function selector in memory
+    const selector_bytes = [_]u8{ 0xa3, 0xb1, 0xb3, 0x1d };
+    try frame.memory.store(0, &selector_bytes);
+    
+    // Execute the bytecode
+    const interpreter_ptr: *Evm.Operation.Interpreter = @ptrCast(&vm);
+    const state_ptr: *Evm.Operation.State = @ptrCast(&frame);
+    
+    // Execute each instruction
+    var pc: usize = 0;
+    while (pc < bytecode.len) {
+        const op = bytecode[pc];
+        const result = try vm.table.execute(0, interpreter_ptr, state_ptr, op);
+        
+        if (result.action == .STOP or result.action == .RETURN) {
+            break;
+        }
+        
+        pc = switch (result.action) {
+            .CONTINUE => pc + result.pc_offset,
+            .JUMP => result.new_pc,
+            else => unreachable,
+        };
+    }
+    
+    // Check that we got the expected block number (42) on the stack
+    const result = try frame.stack.pop();
+    try std.testing.expectEqual(@as(primitives.U256, 42), result);
+}
+
+test "VM rejects L2 precompiles on Ethereum mainnet" {
+    const allocator = std.testing.allocator;
+    
+    // Create a memory database
+    var memory_db = Evm.MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+    
+    const db_interface = memory_db.to_database_interface();
+    
+    // Initialize VM with Ethereum chain type (default)
+    var vm = try Evm.Evm.init_with_hardfork(allocator, db_interface, .CANCUN);
+    defer vm.deinit();
+    
+    // Try to call ArbSys on Ethereum - should fail
+    const arb_sys_address = Address.from_hex("0x0000000000000000000000000000000000000064") catch unreachable;
+    const input = &[_]u8{ 0xa3, 0xb1, 0xb3, 0x1d }; // arbBlockNumber selector
+    var output: [32]u8 = undefined;
+    
+    const result = Evm.Precompiles.execute_precompile(arb_sys_address, input, &output, 1000, vm.chain_rules);
+    
+    // Should fail because ArbSys is not available on Ethereum
+    try std.testing.expect(result.is_failure());
+}


### PR DESCRIPTION
## Summary
This PR adds support for the Arbitrum Layer 2 execution environment to the Guillotine EVM implementation.

## Changes
- Add Arbitrum chain type support and chain ID mappings
- Implement core Arbitrum precompiles with mock functionality:
  - **ArbSys (0x64)**: System information - arbBlockNumber(), arbChainID(), arbOSVersion(), isTopLevelCall()
  - **ArbInfo (0x65)**: Account information - getBalance()
  - **ArbGasInfo (0x6c)**: Gas pricing - getPricesInWei(), getCurrentTxL1GasFees(), getGasAccountingParams()
  - **ArbAggregator (0x6d)**: Batch and DA info - getBatchNumber(), getTxBaseFee(), getL1PricingData()
  - **ArbRetryableTx (0x6e)**: Retryable tickets - getLifetime(), getTimeout(), getSubmissionPrice()
- Wire up all precompiles in the dispatcher for Arbitrum chains
- Add comprehensive unit and integration tests
- Support Arbitrum One (42161), Arbitrum Sepolia (421614), and Arbitrum Nova (42170) chain IDs

## Implementation Details
- All L2-specific code is compile-time optimized with zero overhead for Ethereum mainnet
- Precompiles currently return mock values - actual state integration is future work
- Follows the same modular architecture as the Optimism implementation
- Tests verify precompiles are only available on Arbitrum chains

## Testing
- Unit tests for each precompile implementation
- Integration tests verifying VM-level execution
- Tests confirm L2 precompiles are not available on Ethereum mainnet

## Future Work
- Implement remaining Arbitrum precompiles (ArbAddressTable, ArbStatistics, ArbOsTest)
- Connect precompiles to actual state storage
- Add Arbitrum-specific opcodes
- Integrate actual L2 gas pricing models

Closes #254

🤖 Generated with [Claude Code](https://claude.ai/code)