### PR TITLE
docs: Add comprehensive library integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,122 @@ We welcome contributions of all kinds!
 
 See our [Contributing Guide](CONTRIBUTING.md) to get started.
 
+## 📚 Library Integration
+
+For external projects that want to integrate Guillotine as a library dependency.
+
+### Required Dependencies
+
+#### BN254 Rust Wrapper
+Guillotine uses a Rust-based BN254 elliptic curve implementation for production-grade scalar multiplication and pairing operations:
+
+- **Location**: `src/bn254_wrapper/`
+- **Dependencies**: arkworks ecosystem (ark-bn254, ark-ec, ark-ff, ark-serialize)
+- **Build**: Static library built from Rust using cargo
+
+#### c-kzg-4844
+KZG commitment library for EIP-4844 blob transactions:
+
+- **Dependency**: ethereum/c-kzg-4844
+- **Purpose**: KZG point evaluation precompile (0x0a)
+
+#### System Libraries
+
+**Linux**:
+```
+dl, pthread, m, rt
+```
+
+**macOS**:
+```
+Security framework, CoreFoundation framework
+```
+
+### Example build.zig Integration
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Add Guillotine as dependency
+    const guillotine = b.dependency("guillotine", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Get Guillotine modules
+    const evm_mod = guillotine.module("evm");
+    const primitives_mod = guillotine.module("primitives");
+    
+    // Your executable
+    const exe = b.addExecutable(.{
+        .name = "your-app",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    
+    // Link Guillotine modules
+    exe.root_module.addImport("evm", evm_mod);
+    exe.root_module.addImport("primitives", primitives_mod);
+    
+    // Link required libraries (automatically handled by Guillotine modules)
+    // The bn254_wrapper and c-kzg-4844 libraries are linked automatically
+    // when you import the evm module
+    
+    b.installArtifact(exe);
+}
+```
+
+### build.zig.zon Configuration
+
+```zig
+.{
+    .name = "your-project",
+    .version = "0.1.0",
+    .dependencies = .{
+        .guillotine = .{
+            .url = "https://github.com/evmts/Guillotine/archive/<commit-hash>.tar.gz",
+            .hash = "<hash>",
+        },
+    },
+    .paths = .{""},
+}
+```
+
+### Minimal Module Usage
+
+For projects that only need specific Guillotine functionality:
+
+```zig
+// Use only primitives (Address, Hex, RLP, etc.)
+const primitives = b.dependency("guillotine", .{}).module("primitives");
+exe.root_module.addImport("primitives", primitives);
+
+// Use only EVM execution (includes all dependencies)
+const evm = b.dependency("guillotine", .{}).module("evm");
+exe.root_module.addImport("evm", evm);
+```
+
+### Integration Notes
+
+1. **Automatic Linking**: When you import the `evm` module, all required libraries (BN254 wrapper, c-kzg-4844, system libraries) are automatically linked.
+
+2. **Cross-Platform**: The build system automatically detects the target platform and links appropriate system libraries (Security/CoreFoundation on macOS, dl/pthread/m/rt on Linux).
+
+3. **WASM Compatibility**: For WASM targets, BN254 operations use placeholder implementations. Full zkSNARK support requires host environment integration.
+
+4. **Memory Management**: All Guillotine operations require an allocator. Use `std.testing.allocator` for tests or your application's allocator for production.
+
+### Troubleshooting
+
+- **Signal 4 (Illegal Instruction)**: Ensure all system libraries are properly linked. This typically occurs when BN254 operations fail due to missing dependencies.
+- **Build Failures**: Verify Zig version compatibility (0.14.1+ required) and ensure Rust toolchain is available for BN254 wrapper compilation.
+- **Import Errors**: Use the module system rather than direct file imports. Import `evm` and `primitives` modules as shown above.
+
 ---
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -205,22 +205,26 @@ See our [Contributing Guide](CONTRIBUTING.md) to get started.
 
 For external projects that want to integrate Guillotine as a library dependency.
 
-### Required Dependencies
+> **⚠️ Note**: The requirements below are temporary and will be removed in upcoming releases as we migrate to pure Zig implementations.
+
+### Required Dependencies (Temporary)
 
 #### BN254 Rust Wrapper
-Guillotine uses a Rust-based BN254 elliptic curve implementation for production-grade scalar multiplication and pairing operations:
+Guillotine currently uses a Rust-based BN254 elliptic curve implementation for production-grade scalar multiplication and pairing operations:
 
 - **Location**: `src/bn254_wrapper/`
 - **Dependencies**: arkworks ecosystem (ark-bn254, ark-ec, ark-ff, ark-serialize)
 - **Build**: Static library built from Rust using cargo
+- **Status**: Will be replaced with pure Zig implementation
 
 #### c-kzg-4844
 KZG commitment library for EIP-4844 blob transactions:
 
 - **Dependency**: ethereum/c-kzg-4844
 - **Purpose**: KZG point evaluation precompile (0x0a)
+- **Status**: May be replaced with pure Zig implementation
 
-#### System Libraries
+#### System Libraries (Temporary)
 
 **Linux**:
 ```
@@ -231,6 +235,8 @@ dl, pthread, m, rt
 ```
 Security framework, CoreFoundation framework
 ```
+
+> These system library requirements will be eliminated when Rust dependencies are removed.
 
 ### Example build.zig Integration
 
@@ -311,10 +317,12 @@ exe.root_module.addImport("evm", evm);
 
 4. **Memory Management**: All Guillotine operations require an allocator. Use `std.testing.allocator` for tests or your application's allocator for production.
 
+5. **Future Simplification**: Integration will become much simpler once pure Zig implementations replace the current Rust dependencies, eliminating the need for Rust toolchain and system library requirements.
+
 ### Troubleshooting
 
-- **Signal 4 (Illegal Instruction)**: Ensure all system libraries are properly linked. This typically occurs when BN254 operations fail due to missing dependencies.
-- **Build Failures**: Verify Zig version compatibility (0.14.1+ required) and ensure Rust toolchain is available for BN254 wrapper compilation.
+- **Signal 4 (Illegal Instruction)**: Ensure all system libraries are properly linked. This typically occurs when BN254 operations fail due to missing dependencies. *Note: This issue will be resolved when pure Zig implementations are complete.*
+- **Build Failures**: Verify Zig version compatibility (0.14.1+ required) and ensure Rust toolchain is available for BN254 wrapper compilation. *Note: Rust toolchain requirement will be removed in future releases.*
 - **Import Errors**: Use the module system rather than direct file imports. Import `evm` and `primitives` modules as shown above.
 
 ---


### PR DESCRIPTION
## Summary

- Adds comprehensive documentation for external projects wanting to integrate Guillotine as a library dependency
- Documents required dependencies: BN254 Rust wrapper, c-kzg-4844, system libraries  
- Provides example build.zig configuration with proper module linking
- Includes platform-specific requirements (macOS frameworks vs Linux libraries)
- Adds troubleshooting section for common integration issues

## Addresses Issue #256

This documentation helps external developers avoid "signal 4 (illegal instruction)" crashes and other integration issues by clearly documenting:

- Required system libraries for each platform
- Automatic linking behavior when importing Guillotine modules
- Example build.zig and build.zig.zon configurations
- Minimal usage patterns for specific functionality
- Memory management requirements
- WASM compatibility notes

## Test Plan

- [x] Verify documentation accuracy against current build.zig configuration
- [x] Ensure all required dependencies are documented
- [x] Validate example configurations follow Zig best practices
- [x] README remains readable and well-organized

🤖 Generated with [Claude Code](https://claude.ai/code)