### PR TITLE
🔥 feat: Add flamegraph profiling support for EVM benchmarks

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,117 @@
+name: Performance Profiling
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark:
+        description: 'Benchmark to profile'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+        - all
+        - stack_operations
+        - memory_operations
+        - precompiles
+        - hardfork_checks
+
+jobs:
+  profile-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Zig
+      uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.14.0
+    
+    - name: Install Rust (for flamegraph tool)
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Install profiling tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r) || true
+        # Fallback if specific kernel tools aren't available
+        sudo apt-get install -y linux-tools-generic || true
+        cargo install flamegraph
+    
+    - name: Allow performance monitoring
+      run: |
+        # Allow unprivileged users to use perf
+        echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+    
+    - name: Run profiling
+      run: |
+        chmod +x ./scripts/profile.sh
+        ./scripts/profile.sh ${{ inputs.benchmark }}
+    
+    - name: Upload flamegraph
+      uses: actions/upload-artifact@v4
+      with:
+        name: flamegraph-${{ inputs.benchmark }}-linux
+        path: flamegraph-*.svg
+        retention-days: 30
+
+  profile-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Zig
+      uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.14.0
+    
+    - name: Install Rust (for flamegraph tool)
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Install flamegraph
+      run: cargo install flamegraph
+    
+    - name: Run profiling
+      run: |
+        chmod +x ./scripts/profile.sh
+        ./scripts/profile.sh ${{ inputs.benchmark }}
+    
+    - name: Upload flamegraph
+      uses: actions/upload-artifact@v4
+      with:
+        name: flamegraph-${{ inputs.benchmark }}-macos
+        path: flamegraph-*.svg
+        retention-days: 30
+
+  # Optional: Compare with baseline
+  profile-comparison:
+    if: github.event_name == 'pull_request'
+    needs: [profile-linux]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download current flamegraph
+      uses: actions/download-artifact@v4
+      with:
+        name: flamegraph-${{ inputs.benchmark }}-linux
+        path: current
+    
+    - name: Comment on PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const benchmark = '${{ inputs.benchmark }}';
+          const body = `## Flamegraph Profile Results
+          
+          Benchmark: **${benchmark}**
+          
+          The flamegraph for this PR has been generated and is available as an artifact.
+          
+          [Download Flamegraph](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          
+          To compare with the base branch, run the same workflow on the base branch and compare the SVGs.`;
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          });

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -10,10 +10,13 @@ on:
         type: choice
         options:
         - all
-        - stack_operations
-        - memory_operations
+        - arithmetic_ops
+        - memory_ops
+        - storage_ops
+        - stack_ops
+        - control_flow
         - precompiles
-        - hardfork_checks
+        - contract_calls
 
 jobs:
   profile-linux:

--- a/bench/main.zig
+++ b/bench/main.zig
@@ -1,15 +1,31 @@
 const std = @import("std");
 const root = @import("root.zig");
+const profile_runner = @import("profile_runner.zig");
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
-
-    std.log.info("Guillotine Benchmark Suite", .{});
-    std.log.info("Hello World from the bench crate!", .{});
     
-    try root.run(allocator);
+    // Check for profiling mode
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
     
-    std.log.info("Benchmark suite completed successfully!", .{});
+    if (args.len > 1 and std.mem.eql(u8, args[1], "--profile")) {
+        const profile_type = if (args.len > 2) 
+            std.meta.stringToEnum(profile_runner.BenchmarkProfile, args[2]) orelse .all
+        else 
+            .all;
+            
+        std.log.info("Running in profiling mode: {}", .{profile_type});
+        try profile_runner.run_profiling_workload(allocator, profile_type);
+    } else {
+        // Normal benchmark mode
+        std.log.info("Guillotine Benchmark Suite", .{});
+        std.log.info("Hello World from the bench crate!", .{});
+        
+        try root.run(allocator);
+        
+        std.log.info("Benchmark suite completed successfully!", .{});
+    }
 }

--- a/bench/profile_runner.zig
+++ b/bench/profile_runner.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const root = @import("root.zig");
+const Allocator = std.mem.Allocator;
+
+pub const BenchmarkProfile = enum {
+    all,
+    stack_operations,
+    memory_operations,
+    precompiles,
+    hardfork_checks,
+};
+
+pub fn run_profiling_workload(allocator: Allocator, profile: BenchmarkProfile) !void {
+    // Run longer iterations for better profiling data
+    const profile_iterations = 100_000;
+    
+    switch (profile) {
+        .all => try run_all_profiles(allocator, profile_iterations),
+        .stack_operations => try profile_stack_ops(allocator, profile_iterations),
+        .memory_operations => try profile_memory_ops(allocator, profile_iterations),
+        .precompiles => try profile_precompiles(allocator, profile_iterations),
+        .hardfork_checks => try profile_hardfork_checks(allocator, profile_iterations),
+    }
+}
+
+fn run_all_profiles(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Running all profiling workloads", .{});
+    try profile_stack_ops(allocator, iterations / 4);
+    try profile_memory_ops(allocator, iterations / 4);
+    try profile_precompiles(allocator, iterations / 4);
+    try profile_hardfork_checks(allocator, iterations / 4);
+}
+
+fn profile_stack_ops(_: Allocator, iterations: usize) !void {
+    std.log.info("Profiling stack operations ({} iterations)", .{iterations});
+    
+    var stack = root.Evm.Stack{};
+    
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) {
+        // Push and pop sequence - using the optimized unsafe operations for profiling
+        stack.append_unsafe(i);
+        stack.append_unsafe(i + 1);
+        stack.append_unsafe(i + 2);
+        stack.append_unsafe(i + 3);
+        
+        _ = stack.pop_unsafe();
+        _ = stack.pop_unsafe();
+        _ = stack.pop_unsafe();
+        _ = stack.pop_unsafe();
+        
+        // DUP operations
+        stack.append_unsafe(100);
+        stack.append_unsafe(200);
+        stack.append_unsafe(300);
+        stack.append_unsafe(400);
+        
+        // Simulate DUP4
+        const dup_value = stack.data[stack.size - 4];
+        stack.append_unsafe(dup_value);
+        
+        // Simulate SWAP2
+        const temp = stack.data[stack.size - 1];
+        stack.data[stack.size - 1] = stack.data[stack.size - 3];
+        stack.data[stack.size - 3] = temp;
+        
+        // Clear stack for next iteration
+        stack.size = 0;
+    }
+}
+
+fn profile_memory_ops(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling memory operations ({} iterations)", .{iterations});
+    
+    // Simple memory allocation benchmark
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) {
+        const size = 32 + (i % 256);
+        const mem = try allocator.alloc(u8, size);
+        defer allocator.free(mem);
+        
+        // Write pattern
+        for (mem) |*byte| {
+            byte.* = @intCast(i & 0xFF);
+        }
+        
+        // Read pattern
+        var sum: u64 = 0;
+        for (mem) |byte| {
+            sum += byte;
+        }
+        // Use sum to prevent optimization
+        if (sum == 0) {
+            std.log.warn("Unexpected zero sum", .{});
+        }
+    }
+}
+
+fn profile_precompiles(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling precompile execution ({} iterations)", .{iterations});
+    
+    // Simulate precompile-like computation
+    const test_data = [_]u8{0xFF} ** 64; // 64 bytes of data
+    
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) {
+        const output = try allocator.alloc(u8, 32);
+        defer allocator.free(output);
+        
+        // Simulate hash computation
+        var hasher = std.hash.Wyhash.init(i);
+        hasher.update(&test_data);
+        const hash = hasher.final();
+        std.mem.writeInt(u64, output[0..8], hash, .big);
+    }
+}
+
+fn profile_hardfork_checks(_: Allocator, iterations: usize) !void {
+    std.log.info("Profiling hardfork checks ({} iterations)", .{iterations});
+    
+    // Simulate hardfork-like checks without using actual Hardfork types
+    const chain_id: u64 = 1;
+    
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) {
+        // Simulate various checks
+        const block_number = i % 20_000_000;
+        
+        // Simulate hardfork activation checks
+        const is_london = block_number >= 12_965_000;
+        const is_shanghai = block_number >= 17_034_870;
+        const is_cancun = block_number >= 19_426_587;
+        
+        // Simulate chain rule checks
+        const is_mainnet = chain_id == 1;
+        const is_sepolia = chain_id == 11155111;
+        
+        // Use results to prevent optimization
+        if (is_london and is_shanghai and is_cancun and is_mainnet and !is_sepolia) {
+            // Most common case - do nothing
+        }
+    }
+}

--- a/bench/profile_runner.zig
+++ b/bench/profile_runner.zig
@@ -2,142 +2,343 @@ const std = @import("std");
 const root = @import("root.zig");
 const Allocator = std.mem.Allocator;
 
+// Import EVM components
+const Evm = root.Evm;
+const Frame = Evm.Frame;
+const Contract = Evm.Contract;
+const MemoryDatabase = Evm.MemoryDatabase;
+const Operation = Evm.Operation;
+const Address = root.primitives.Address;
+
 pub const BenchmarkProfile = enum {
     all,
-    stack_operations,
-    memory_operations,
+    arithmetic_ops,
+    memory_ops,
+    storage_ops,
+    stack_ops,
+    control_flow,
     precompiles,
-    hardfork_checks,
+    contract_calls,
 };
 
 pub fn run_profiling_workload(allocator: Allocator, profile: BenchmarkProfile) !void {
     // Run longer iterations for better profiling data
-    const profile_iterations = 100_000;
+    const profile_iterations = 100;
     
     switch (profile) {
         .all => try run_all_profiles(allocator, profile_iterations),
-        .stack_operations => try profile_stack_ops(allocator, profile_iterations),
-        .memory_operations => try profile_memory_ops(allocator, profile_iterations),
+        .arithmetic_ops => try profile_arithmetic_ops(allocator, profile_iterations),
+        .memory_ops => try profile_memory_ops(allocator, profile_iterations),
+        .storage_ops => try profile_storage_ops(allocator, profile_iterations),
+        .stack_ops => try profile_stack_ops(allocator, profile_iterations),
+        .control_flow => try profile_control_flow(allocator, profile_iterations),
         .precompiles => try profile_precompiles(allocator, profile_iterations),
-        .hardfork_checks => try profile_hardfork_checks(allocator, profile_iterations),
+        .contract_calls => try profile_contract_calls(allocator, profile_iterations),
     }
 }
 
 fn run_all_profiles(allocator: Allocator, iterations: usize) !void {
     std.log.info("Running all profiling workloads", .{});
-    try profile_stack_ops(allocator, iterations / 4);
-    try profile_memory_ops(allocator, iterations / 4);
-    try profile_precompiles(allocator, iterations / 4);
-    try profile_hardfork_checks(allocator, iterations / 4);
+    const per_profile = iterations / 8;
+    try profile_arithmetic_ops(allocator, per_profile);
+    try profile_memory_ops(allocator, per_profile);
+    try profile_storage_ops(allocator, per_profile);
+    try profile_stack_ops(allocator, per_profile);
+    try profile_control_flow(allocator, per_profile);
+    try profile_precompiles(allocator, per_profile);
+    try profile_contract_calls(allocator, per_profile);
 }
 
-fn profile_stack_ops(_: Allocator, iterations: usize) !void {
-    std.log.info("Profiling stack operations ({} iterations)", .{iterations});
+// Profile arithmetic operations (ADD, MUL, DIV, MOD, EXP)
+fn profile_arithmetic_ops(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling arithmetic operations ({} iterations)", .{iterations});
     
-    var stack = root.Evm.Stack{};
+    // Bytecode: Complex arithmetic operations
+    const bytecode = [_]u8{
+        // Push operands and perform various arithmetic
+        0x60, 0xFF, // PUSH1 255
+        0x60, 0x02, // PUSH1 2
+        0x02,       // MUL
+        0x60, 0x03, // PUSH1 3
+        0x01,       // ADD
+        0x60, 0x04, // PUSH1 4
+        0x04,       // DIV
+        0x60, 0x05, // PUSH1 5
+        0x06,       // MOD
+        0x60, 0x02, // PUSH1 2
+        0x60, 0x08, // PUSH1 8
+        0x0A,       // EXP
+        0x01,       // ADD
+        0x00,       // STOP
+    };
     
-    var i: usize = 0;
-    while (i < iterations) : (i += 1) {
-        // Push and pop sequence - using the optimized unsafe operations for profiling
-        stack.append_unsafe(i);
-        stack.append_unsafe(i + 1);
-        stack.append_unsafe(i + 2);
-        stack.append_unsafe(i + 3);
-        
-        _ = stack.pop_unsafe();
-        _ = stack.pop_unsafe();
-        _ = stack.pop_unsafe();
-        _ = stack.pop_unsafe();
-        
-        // DUP operations
-        stack.append_unsafe(100);
-        stack.append_unsafe(200);
-        stack.append_unsafe(300);
-        stack.append_unsafe(400);
-        
-        // Simulate DUP4
-        const dup_value = stack.data[stack.size - 4];
-        stack.append_unsafe(dup_value);
-        
-        // Simulate SWAP2
-        const temp = stack.data[stack.size - 1];
-        stack.data[stack.size - 1] = stack.data[stack.size - 3];
-        stack.data[stack.size - 3] = temp;
-        
-        // Clear stack for next iteration
-        stack.size = 0;
-    }
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
 }
 
+// Profile memory operations (MLOAD, MSTORE, MSTORE8)
 fn profile_memory_ops(allocator: Allocator, iterations: usize) !void {
     std.log.info("Profiling memory operations ({} iterations)", .{iterations});
     
-    // Simple memory allocation benchmark
-    var i: usize = 0;
-    while (i < iterations) : (i += 1) {
-        const size = 32 + (i % 256);
-        const mem = try allocator.alloc(u8, size);
-        defer allocator.free(mem);
+    // Bytecode: Memory read/write patterns
+    const bytecode = [_]u8{
+        // Store values at different memory locations
+        0x60, 0x42, // PUSH1 66
+        0x60, 0x00, // PUSH1 0
+        0x52,       // MSTORE
         
-        // Write pattern
-        for (mem) |*byte| {
-            byte.* = @intCast(i & 0xFF);
-        }
+        0x60, 0x99, // PUSH1 153
+        0x60, 0x20, // PUSH1 32
+        0x52,       // MSTORE
         
-        // Read pattern
-        var sum: u64 = 0;
-        for (mem) |byte| {
-            sum += byte;
-        }
-        // Use sum to prevent optimization
-        if (sum == 0) {
-            std.log.warn("Unexpected zero sum", .{});
-        }
-    }
+        // Load and manipulate
+        0x60, 0x00, // PUSH1 0
+        0x51,       // MLOAD
+        0x60, 0x20, // PUSH1 32
+        0x51,       // MLOAD
+        0x01,       // ADD
+        0x60, 0x40, // PUSH1 64
+        0x52,       // MSTORE
+        
+        // MSTORE8 test
+        0x60, 0xFF, // PUSH1 255
+        0x60, 0x80, // PUSH1 128
+        0x53,       // MSTORE8
+        
+        0x00,       // STOP
+    };
+    
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
 }
 
+// Profile storage operations (SLOAD, SSTORE)
+fn profile_storage_ops(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling storage operations ({} iterations)", .{iterations});
+    
+    // Bytecode: Storage read/write patterns
+    const bytecode = [_]u8{
+        // Store values in storage slots
+        0x60, 0x42, // PUSH1 66
+        0x60, 0x00, // PUSH1 0
+        0x55,       // SSTORE
+        
+        0x60, 0x99, // PUSH1 153
+        0x60, 0x01, // PUSH1 1
+        0x55,       // SSTORE
+        
+        // Load and manipulate
+        0x60, 0x00, // PUSH1 0
+        0x54,       // SLOAD
+        0x60, 0x01, // PUSH1 1
+        0x54,       // SLOAD
+        0x01,       // ADD
+        0x60, 0x02, // PUSH1 2
+        0x55,       // SSTORE
+        
+        0x00,       // STOP
+    };
+    
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
+}
+
+// Profile stack operations (PUSH, POP, DUP, SWAP)
+fn profile_stack_ops(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling stack operations ({} iterations)", .{iterations});
+    
+    // Bytecode: Intensive stack manipulation
+    const bytecode = [_]u8{
+        // Push multiple values
+        0x60, 0x01, // PUSH1 1
+        0x60, 0x02, // PUSH1 2
+        0x60, 0x03, // PUSH1 3
+        0x60, 0x04, // PUSH1 4
+        0x60, 0x05, // PUSH1 5
+        0x60, 0x06, // PUSH1 6
+        
+        // DUP operations
+        0x80,       // DUP1
+        0x81,       // DUP2
+        0x82,       // DUP3
+        
+        // SWAP operations
+        0x90,       // SWAP1
+        0x91,       // SWAP2
+        0x92,       // SWAP3
+        
+        // POP to clean up
+        0x50,       // POP
+        0x50,       // POP
+        0x50,       // POP
+        0x50,       // POP
+        0x50,       // POP
+        0x50,       // POP
+        
+        0x00,       // STOP
+    };
+    
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
+}
+
+// Profile control flow operations (JUMP, JUMPI, PC)
+fn profile_control_flow(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling control flow operations ({} iterations)", .{iterations});
+    
+    // Bytecode: Loops and conditional jumps
+    const bytecode = [_]u8{
+        // Counter setup
+        0x60, 0x00, // PUSH1 0 (counter)
+        
+        // Loop start (JUMPDEST at position 2)
+        0x5B,       // JUMPDEST
+        
+        // Increment counter
+        0x60, 0x01, // PUSH1 1
+        0x01,       // ADD
+        
+        // Check if counter < 10
+        0x80,       // DUP1
+        0x60, 0x0A, // PUSH1 10
+        0x10,       // LT
+        
+        // Jump back if true
+        0x60, 0x02, // PUSH1 2 (jump destination)
+        0x57,       // JUMPI
+        
+        // End
+        0x50,       // POP (clear counter)
+        0x00,       // STOP
+    };
+    
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
+}
+
+// Profile precompile calls
 fn profile_precompiles(allocator: Allocator, iterations: usize) !void {
-    std.log.info("Profiling precompile execution ({} iterations)", .{iterations});
+    std.log.info("Profiling precompile calls ({} iterations)", .{iterations});
     
-    // Simulate precompile-like computation
-    const test_data = [_]u8{0xFF} ** 64; // 64 bytes of data
-    
-    var i: usize = 0;
-    while (i < iterations) : (i += 1) {
-        const output = try allocator.alloc(u8, 32);
-        defer allocator.free(output);
+    // Bytecode: Call SHA256 precompile (address 0x02)
+    const bytecode = [_]u8{
+        // Prepare input data in memory
+        0x7F, // PUSH32
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0x60, 0x00, // PUSH1 0
+        0x52,       // MSTORE
         
-        // Simulate hash computation
-        var hasher = std.hash.Wyhash.init(i);
-        hasher.update(&test_data);
-        const hash = hasher.final();
-        std.mem.writeInt(u64, output[0..8], hash, .big);
-    }
+        // Call precompile
+        0x60, 0x20, // PUSH1 32 (output size)
+        0x60, 0x00, // PUSH1 0 (output offset)
+        0x60, 0x20, // PUSH1 32 (input size)
+        0x60, 0x00, // PUSH1 0 (input offset)
+        0x60, 0x00, // PUSH1 0 (value)
+        0x60, 0x02, // PUSH1 2 (SHA256 address)
+        0x61, 0xFF, 0xFF, // PUSH2 65535 (gas)
+        0xF1,       // CALL
+        
+        0x50,       // POP (clear return value)
+        0x00,       // STOP
+    };
+    
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
 }
 
-fn profile_hardfork_checks(_: Allocator, iterations: usize) !void {
-    std.log.info("Profiling hardfork checks ({} iterations)", .{iterations});
+// Profile contract calls (CALL, DELEGATECALL, STATICCALL)
+fn profile_contract_calls(allocator: Allocator, iterations: usize) !void {
+    std.log.info("Profiling contract calls ({} iterations)", .{iterations});
     
-    // Simulate hardfork-like checks without using actual Hardfork types
-    const chain_id: u64 = 1;
+    // This requires setting up a target contract first
+    // For now, we'll use a simpler bytecode that prepares for calls
+    const bytecode = [_]u8{
+        // Prepare call data
+        0x60, 0x00, // PUSH1 0 (return data size)
+        0x60, 0x00, // PUSH1 0 (return data offset)
+        0x60, 0x00, // PUSH1 0 (input size)
+        0x60, 0x00, // PUSH1 0 (input offset)
+        0x60, 0x00, // PUSH1 0 (value)
+        0x73, // PUSH20 (address)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x61, 0x27, 0x10, // PUSH2 10000 (gas)
+        0xF1,       // CALL
+        0x50,       // POP
+        0x00,       // STOP
+    };
     
+    try execute_bytecode_iterations(allocator, &bytecode, iterations);
+}
+
+// Helper function to execute bytecode for a given number of iterations
+fn execute_bytecode_iterations(allocator: Allocator, bytecode: []const u8, iterations: usize) !void {
+    // Set up EVM once
+    var memory_db = MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+    
+    const db_interface = memory_db.to_database_interface();
+    var evm = try Evm.Evm.init(allocator, db_interface);
+    defer evm.deinit();
+    
+    // Set up contract with bytecode
+    const caller_address = Address.ZERO;
+    const contract_address: Address.Address = [_]u8{0x01} ** 20;
+    
+    // Store contract code
+    try evm.state.set_code(contract_address, bytecode);
+    
+    // Execute multiple times
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
-        // Simulate various checks
-        const block_number = i % 20_000_000;
+        // Create contract instance
+        var contract = Contract.init_at_address(
+            caller_address,
+            contract_address,
+            0, // value
+            1_000_000, // gas_limit
+            bytecode,
+            &.{}, // input_data
+            false // is_static
+        );
+        defer contract.deinit(allocator, null);
         
-        // Simulate hardfork activation checks
-        const is_london = block_number >= 12_965_000;
-        const is_shanghai = block_number >= 17_034_870;
-        const is_cancun = block_number >= 19_426_587;
+        // Create frame
+        var frame_builder = Frame.builder(allocator);
+        var frame = try frame_builder
+            .withVm(&evm)
+            .withContract(&contract)
+            .withGas(1_000_000)
+            .build();
+        defer frame.deinit();
         
-        // Simulate chain rule checks
-        const is_mainnet = chain_id == 1;
-        const is_sepolia = chain_id == 11155111;
+        // Execute bytecode
+        var interpreter = Operation.Interpreter{ .vm = &evm };
+        var state = Operation.State{ .frame = &frame };
         
-        // Use results to prevent optimization
-        if (is_london and is_shanghai and is_cancun and is_mainnet and !is_sepolia) {
-            // Most common case - do nothing
+        // Execute until STOP or error
+        while (frame.pc < bytecode.len and !frame.stop) {
+            const opcode = bytecode[frame.pc];
+            const old_pc = frame.pc;
+            
+            const result = evm.table.execute(frame.pc, &interpreter, &state, opcode) catch |err| {
+                // Handle expected errors
+                switch (err) {
+                    error.InvalidJump,
+                    error.OutOfGas,
+                    error.STOP,
+                    error.StackUnderflow,
+                    error.InvalidOpcode => break,
+                    else => return err,
+                }
+            };
+            
+            // Check if execution should halt
+            if (result.output.len > 0) {
+                break;
+            }
+            
+            // Advance PC if not modified by instruction (JUMP/JUMPI modify it)
+            if (frame.pc == old_pc) {
+                frame.pc += result.bytes_consumed;
+            }
         }
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -537,6 +537,55 @@ pub fn build(b: *std.Build) void {
     
     const bench_step = b.step("bench", "Run benchmarks");
     bench_step.dependOn(&run_bench_cmd.step);
+    
+    // Flamegraph profiling support
+    const flamegraph_step = b.step("flamegraph", "Run benchmarks with flamegraph profiling");
+    
+    // Build bench executable with debug symbols for profiling
+    const profile_bench_exe = b.addExecutable(.{
+        .name = "guillotine-bench-profile",
+        .root_source_file = b.path("bench/main.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,  // Always use optimized build for profiling
+    });
+    profile_bench_exe.root_module.addImport("bench", bench_mod);
+    profile_bench_exe.root_module.addImport("zbench", zbench_dep.module("zbench"));
+    profile_bench_exe.root_module.addImport("evm", bench_evm_mod);
+    profile_bench_exe.root_module.addImport("primitives", primitives_mod);
+    
+    // CRITICAL: Include debug symbols for profiling
+    profile_bench_exe.root_module.strip = false;  // Keep symbols
+    profile_bench_exe.root_module.omit_frame_pointer = false;  // Keep frame pointers
+    
+    // Platform-specific profiling commands
+    if (target.result.os.tag == .linux) {
+        const perf_cmd = b.addSystemCommand(&[_][]const u8{
+            "perf", "record", "-F", "997", "-g", "--call-graph", "dwarf",
+            "-o", "perf.data",
+        });
+        perf_cmd.addArtifactArg(profile_bench_exe);
+        perf_cmd.addArg("--profile");
+        
+        const flamegraph_cmd = b.addSystemCommand(&[_][]const u8{
+            "flamegraph", "--perfdata", "perf.data", "-o", "guillotine-bench.svg",
+        });
+        flamegraph_cmd.step.dependOn(&perf_cmd.step);
+        flamegraph_step.dependOn(&flamegraph_cmd.step);
+    } else if (target.result.os.tag == .macos) {
+        // Use cargo-flamegraph which handles xctrace internally
+        const flamegraph_cmd = b.addSystemCommand(&[_][]const u8{
+            "flamegraph", "-o", "guillotine-bench.svg", "--",
+        });
+        flamegraph_cmd.addArtifactArg(profile_bench_exe);
+        flamegraph_cmd.addArg("--profile");
+        flamegraph_step.dependOn(&flamegraph_cmd.step);
+    } else {
+        // For other platforms, inform the user
+        const warn_cmd = b.addSystemCommand(&[_][]const u8{
+            "echo", "Flamegraph profiling is only supported on Linux and macOS",
+        });
+        flamegraph_step.dependOn(&warn_cmd.step);
+    }
 
     // Devtool executable
     // Add webui dependency

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,180 @@
+# Profiling Guillotine with Flamegraphs
+
+## Overview
+
+Flamegraph profiling support enables visualization of CPU time spent in different functions during benchmark execution. This helps identify performance bottlenecks and guide optimization efforts.
+
+## Quick Start
+
+### Linux
+```bash
+# Install dependencies
+sudo apt-get install linux-tools-common linux-tools-generic linux-tools-$(uname -r)
+cargo install flamegraph
+
+# Run profiling
+./scripts/profile.sh stack_operations
+
+# View results
+firefox flamegraph-stack_operations.svg
+```
+
+### macOS
+```bash
+# Install dependencies
+brew install --cask xcode  # If not already installed
+cargo install flamegraph
+
+# Run profiling
+./scripts/profile.sh stack_operations
+
+# View results
+open flamegraph-stack_operations.svg
+```
+
+## Available Profiling Targets
+
+The profiling system supports the following benchmark profiles:
+
+- `all` - Run all profiling workloads
+- `stack_operations` - Profile stack push/pop/dup/swap operations
+- `memory_operations` - Profile memory allocation patterns
+- `precompiles` - Profile cryptographic operations
+- `hardfork_checks` - Profile hardfork activation checks
+
+## Using the Flamegraph Build Target
+
+```bash
+# Build and run with flamegraph profiling
+zig build flamegraph
+
+# The flamegraph will be saved as guillotine-bench.svg
+```
+
+## Manual Profiling
+
+### Running benchmarks in profile mode
+```bash
+# Build the benchmark executable
+zig build -Doptimize=ReleaseFast
+
+# Run with profiling flag
+./zig-out/bin/guillotine-bench --profile stack_operations
+```
+
+### Platform-specific commands
+
+#### Linux (using perf)
+```bash
+# Record performance data
+sudo perf record -F 997 -g --call-graph dwarf ./zig-out/bin/guillotine-bench --profile
+
+# Generate flamegraph
+flamegraph --perfdata perf.data -o output.svg
+```
+
+#### macOS (using flamegraph)
+```bash
+# Record and generate in one step
+flamegraph -o output.svg -- ./zig-out/bin/guillotine-bench --profile
+```
+
+## Interpreting Flamegraphs
+
+### Visual Elements
+- **Width**: Represents the percentage of CPU time spent in a function (inclusive of children)
+- **Height**: Shows the call stack depth
+- **Colors**: Random assignment for visual distinction (not meaningful)
+
+### Interactive Features
+- Click on any box to zoom into that call stack
+- Search for function names using Ctrl+F
+- Reset zoom by clicking the root element
+
+### Key Areas to Focus On
+1. **Wide bars at the top**: Functions consuming the most CPU time
+2. **Tall stacks**: Deep call chains that might benefit from optimization
+3. **Repeated patterns**: Functions called frequently in loops
+
+## Performance Tips
+
+### Stack Operations
+The stack is one of the most performance-critical components. Look for:
+- `append_unsafe` and `pop_unsafe` calls in hot paths
+- Unnecessary bounds checking in validated contexts
+- Memory access patterns in stack manipulation
+
+### Memory Operations
+Memory management can be a bottleneck. Watch for:
+- Frequent allocations/deallocations
+- Memory expansion costs
+- Suboptimal access patterns
+
+### Precompiles
+Cryptographic operations are inherently expensive. Consider:
+- Caching results when possible
+- Batch operations
+- Hardware acceleration opportunities
+
+## Comparing Performance
+
+### Before/After Optimization
+1. Generate a baseline flamegraph before changes
+2. Implement optimizations
+3. Generate a new flamegraph
+4. Compare the two to verify improvements
+
+### Comparing with revm
+To profile revm (Rust EVM) for comparison:
+```bash
+# Clone revm
+git clone https://github.com/bluealloy/revm
+cd revm
+
+# Run their benchmarks with flamegraph
+cargo flamegraph --bench bench_name
+
+# Compare the generated SVGs side-by-side
+```
+
+## Continuous Integration
+
+Flamegraph generation can be triggered in CI using GitHub Actions:
+```yaml
+# Trigger manually from Actions tab
+workflow_dispatch:
+  inputs:
+    benchmark:
+      description: 'Benchmark to profile'
+      required: true
+      default: 'all'
+```
+
+## Troubleshooting
+
+### "Permission denied" on Linux
+- Ensure you have permissions for perf: `sudo sysctl kernel.perf_event_paranoid=-1`
+- Or run with sudo: `sudo ./scripts/profile.sh`
+
+### Missing symbols in flamegraph
+- Ensure debug symbols are included: Build with `ReleaseFast` mode
+- Check that `strip = false` is set in build configuration
+
+### Empty or small flamegraphs
+- Increase the number of iterations in the profiling workload
+- Ensure the benchmark runs for at least 1-2 seconds
+
+## Best Practices
+
+1. **Profile Release Builds**: Always use optimized builds (`ReleaseFast`) for realistic results
+2. **Sufficient Duration**: Ensure benchmarks run long enough for good sampling (>1 second)
+3. **Multiple Runs**: Generate multiple flamegraphs to ensure consistency
+4. **Focus Areas**: Start with the widest bars and work your way down
+5. **Document Changes**: Keep notes on what optimizations were applied
+
+## References
+
+- [Brendan Gregg's Flamegraph](http://www.brendangregg.com/flamegraphs.html)
+- [cargo-flamegraph Documentation](https://github.com/flamegraph-rs/flamegraph)
+- [Zig Performance Guide](https://ziglang.org/documentation/master/#Performance-and-Safety)
+- [Linux perf Tutorial](https://perf.wiki.kernel.org/index.php/Tutorial)

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -43,6 +43,22 @@ profile_benchmark() {
     echo "Flamegraph saved to: flamegraph-$output_name.svg"
 }
 
+# Print available profiles if no argument
+if [ -z "$1" ]; then
+    echo "Available profiles:"
+    echo "  - all"
+    echo "  - arithmetic_ops"
+    echo "  - memory_ops"
+    echo "  - storage_ops"
+    echo "  - stack_ops"
+    echo "  - control_flow"
+    echo "  - precompiles"
+    echo "  - contract_calls"
+    echo ""
+    echo "Usage: $0 <profile_name>"
+    echo "Default: all"
+fi
+
 # Main
 install_deps
 profile_benchmark "${1:-all}"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+# Install dependencies if needed
+install_deps() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if ! command -v perf &> /dev/null; then
+            echo "Installing perf tools..."
+            sudo apt-get update
+            sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
+        fi
+    fi
+    
+    if ! command -v flamegraph &> /dev/null; then
+        echo "Installing flamegraph tool..."
+        cargo install flamegraph
+    fi
+}
+
+# Run profiling
+profile_benchmark() {
+    local benchmark="$1"
+    local output_name="${2:-$benchmark}"
+    
+    echo "Building optimized benchmark binary with debug symbols..."
+    zig build -Doptimize=ReleaseFast
+    
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "Running perf profiling on Linux..."
+        sudo perf record -F 997 -g --call-graph dwarf \
+            -o "perf-$output_name.data" \
+            ./zig-out/bin/guillotine-bench --profile "$benchmark"
+        
+        echo "Generating flamegraph..."
+        flamegraph --perfdata "perf-$output_name.data" \
+            -o "flamegraph-$output_name.svg"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Running profiling on macOS..."
+        flamegraph -o "flamegraph-$output_name.svg" \
+            -- ./zig-out/bin/guillotine-bench --profile "$benchmark"
+    fi
+    
+    echo "Flamegraph saved to: flamegraph-$output_name.svg"
+}
+
+# Main
+install_deps
+profile_benchmark "${1:-all}"


### PR DESCRIPTION
## Summary

This PR implements flamegraph profiling support for Guillotine's benchmark suite as described in #271. This enables visualization of performance hotspots in **actual EVM execution** and helps guide optimization efforts.

## Changes

- ✅ Added flamegraph build target in `build.zig` with platform-specific commands
- ✅ Created `profile_runner.zig` with **real EVM execution workloads**
- ✅ Updated `bench/main.zig` to support `--profile` mode for targeted benchmarking
- ✅ Added `scripts/profile.sh` for easy flamegraph generation on Linux/macOS
- ✅ Added comprehensive documentation in `docs/profiling.md`
- ✅ Added GitHub Actions workflow for automated profiling in CI

## Key Improvement: Real EVM Execution

The profiling now executes actual EVM bytecode through the jump table, providing accurate performance insights:

### Profiling Workloads
- **Arithmetic Operations**: ADD, MUL, DIV, MOD, EXP operations
- **Memory Operations**: MLOAD, MSTORE, MSTORE8 with various access patterns
- **Storage Operations**: SLOAD, SSTORE state modifications
- **Stack Operations**: PUSH, POP, DUP, SWAP intensive workloads
- **Control Flow**: JUMP, JUMPI loops and conditional execution
- **Precompiles**: SHA256 precompile calls
- **Contract Calls**: CALL operation setup

Each workload:
- Sets up a complete EVM environment (MemoryDatabase, Evm, Contract, Frame)
- Executes real bytecode through `evm.table.execute()`
- Properly handles the execution loop with PC management
- Gracefully handles expected errors (STOP, InvalidJump, etc.)

### Platform Support
- **Linux**: Uses `perf` for sampling with DWARF call graphs
- **macOS**: Uses `cargo-flamegraph` with xctrace backend (requires elevated privileges)
- **CI Integration**: GitHub Actions workflow for both platforms

## Usage

### Local Profiling
```bash
# Quick start - profiles specific EVM operations
./scripts/profile.sh arithmetic_ops
./scripts/profile.sh stack_ops
./scripts/profile.sh memory_ops

# Or use the build target
zig build flamegraph

# Or run manually
./zig-out/bin/guillotine-bench --profile all
```

### Available Profiles
- `all` - Run all profiling workloads
- `arithmetic_ops` - Profile arithmetic operations
- `memory_ops` - Profile memory operations
- `storage_ops` - Profile storage operations
- `stack_ops` - Profile stack operations
- `control_flow` - Profile control flow operations
- `precompiles` - Profile precompile calls
- `contract_calls` - Profile contract calls

### CI Profiling
The workflow can be triggered manually from the Actions tab with a dropdown to select which benchmark to profile.

## Testing

- ✅ Build system changes compile successfully
- ✅ Benchmark executable runs with real EVM bytecode
- ✅ Profile script executes (though macOS requires elevated privileges for dtrace)
- ✅ All existing tests continue to pass
- ✅ Execution properly handles opcodes and expected errors

## Example Flamegraph Areas

When profiling is successful, the flamegraph will show:
- `evm.table.execute` - The main opcode dispatch
- Individual opcode implementations (e.g., `op_add`, `op_push1`)
- Stack operations (`append_unsafe`, `pop_unsafe`)
- Memory management (`Memory.write`, `Memory.read`)
- State operations (`MemoryDatabase.get_storage`)

## Notes

- On macOS, System Integrity Protection prevents dtrace from working without elevated privileges
- Linux users may need to adjust `kernel.perf_event_paranoid` sysctl
- The iteration count can be increased for longer profiling runs (currently set to 100 for quick testing)

Closes #271

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>