### PR TITLE
🐛 fix: correct RETURN and REVERT opcode stack parameter order

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1143,6 +1143,20 @@ pub fn build(b: *std.Build) void {
     const solidity_constructor_test_step = b.step("test-solidity-constructor", "Run Solidity Constructor test");
     solidity_constructor_test_step.dependOn(&run_solidity_constructor_test.step);
 
+    // Add RETURN opcode bug test
+    const return_opcode_bug_test = b.addTest(.{
+        .name = "return-opcode-bug-test",
+        .root_source_file = b.path("test/evm/return_opcode_bug_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .single_threaded = true,
+    });
+    return_opcode_bug_test.root_module.addImport("primitives", primitives_mod);
+    return_opcode_bug_test.root_module.addImport("evm", evm_mod);
+    const run_return_opcode_bug_test = b.addRunArtifact(return_opcode_bug_test);
+    const return_opcode_bug_test_step = b.step("test-return-opcode-bug", "Run RETURN opcode bug test");
+    return_opcode_bug_test_step.dependOn(&run_return_opcode_bug_test.step);
+
     const contract_call_test = b.addTest(.{
         .name = "contract-call-test",
         .root_source_file = b.path("test/evm/contract_call_test.zig"),
@@ -1206,6 +1220,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_e2e_inheritance_test.step);
     test_step.dependOn(&run_constructor_bug_test.step);
     test_step.dependOn(&run_solidity_constructor_test.step);
+    test_step.dependOn(&run_return_opcode_bug_test.step);
     test_step.dependOn(&run_contract_call_test.step);
     // Hardfork tests removed completely
     test_step.dependOn(&run_delegatecall_test.step);

--- a/src/evm/execution/control.zig
+++ b/src/evm/execution/control.zig
@@ -112,10 +112,10 @@ pub fn op_return(pc: usize, interpreter: Operation.Interpreter, state: Operation
     std.debug.assert(frame.stack.size >= 2);
 
     // Use batch pop for performance - pop 2 values at once
-    // Stack order (top to bottom): [offset, size] with size on top
+    // Stack order (top to bottom): [offset, size] with offset on top
     const values = frame.stack.pop2_unsafe();
-    const offset = values.a; // Second from top
-    const size = values.b; // Top
+    const offset = values.b; // Top
+    const size = values.a; // Second from top
 
     Log.debug("RETURN opcode: offset={}, size={}", .{ offset, size });
 
@@ -170,10 +170,10 @@ pub fn op_revert(pc: usize, interpreter: Operation.Interpreter, state: Operation
     std.debug.assert(frame.stack.size >= 2);
 
     // Use batch pop for performance - pop 2 values at once
-    // Stack order (top to bottom): [offset, size] with size on top
+    // Stack order (top to bottom): [offset, size] with offset on top
     const values = frame.stack.pop2_unsafe();
-    const offset = values.a; // Second from top
-    const size = values.b; // Top
+    const offset = values.b; // Top
+    const size = values.a; // Second from top
 
     if (size == 0) {
         @branchHint(.unlikely);

--- a/test/evm/constructor_bug_test.zig
+++ b/test/evm/constructor_bug_test.zig
@@ -39,8 +39,8 @@ test "constructor should return runtime code" {
         0x60, 0x0c, // PUSH1 12 (offset of runtime code in this bytecode) - Stack: [10, 12]
         0x60, 0x00, // PUSH1 0 (destination in memory) - Stack: [10, 12, 0]
         0x39, // CODECOPY (copy code to memory) - pops 3, Stack: []
-        0x60, 0x00, // PUSH1 0 (offset in memory) - Stack: [0]
-        0x60, 0x0a, // PUSH1 10 (size to return) - Stack: [0, 10]
+        0x60, 0x0a, // PUSH1 10 (size to return) - Stack: [10]
+        0x60, 0x00, // PUSH1 0 (offset in memory) - Stack: [10, 0]
         0xf3, // RETURN - pops 2, returns memory[0..10]
 
         // Runtime code (10 bytes) - just returns 42
@@ -93,8 +93,8 @@ test "manual constructor execution to debug" {
         0x60, 0x0c, // PUSH1 12 (offset of runtime code)
         0x60, 0x00, // PUSH1 0 (destination in memory)
         0x39, // CODECOPY (copy code to memory)
-        0x60, 0x00, // PUSH1 0 (offset in memory)
         0x60, 0x0a, // PUSH1 10 (size to return)
+        0x60, 0x00, // PUSH1 0 (offset in memory)
         0xf3, // RETURN
         // Runtime code (starts at byte 12)
         0x60,

--- a/test/evm/contract_call_test.zig
+++ b/test/evm/contract_call_test.zig
@@ -134,16 +134,16 @@ test "contract call: simple contract execution" {
         0x60, 0x0c, // PUSH1 12 (offset)
         0x60, 0x00, // PUSH1 0 (dest)
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x0d, // PUSH1 13 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
 
         // Runtime code: return 42
         0x60, 0x42, // PUSH1 0x42
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x20, // PUSH1 32 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
     };
 
@@ -194,8 +194,8 @@ test "contract call: gas consumption tracking" {
         0x60, 0x0c, // PUSH1 12 (offset)
         0x60, 0x00, // PUSH1 0
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x18, // PUSH1 24 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
 
         // Runtime: do some operations then return
@@ -206,8 +206,8 @@ test "contract call: gas consumption tracking" {
         0x02, // MUL
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x20, // PUSH1 32 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
     };
 
@@ -262,16 +262,16 @@ test "contract call: revert handling" {
         0x60, 0x0c, // PUSH1 12 (offset)
         0x60, 0x00, // PUSH1 0
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x0e, // PUSH1 14 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
 
         // Runtime: store error code then revert
         0x61, 0xde, 0xad, // PUSH2 0xDEAD
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x1e, // PUSH1 30 (offset - last 2 bytes of word)
         0x60, 0x02, // PUSH1 2 (size)
+        0x60, 0x1e, // PUSH1 30 (offset - last 2 bytes of word)
         0xfd, // REVERT
     };
 
@@ -324,8 +324,8 @@ test "contract call: input data passing" {
         0x60, 0x0c, // PUSH1 12 (offset)
         0x60, 0x00, // PUSH1 0
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x15, // PUSH1 21 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
 
         // Runtime: copy calldata to memory and return it
@@ -333,8 +333,8 @@ test "contract call: input data passing" {
         0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x00, // PUSH1 0 (dest)
         0x37, // CALLDATACOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x36, // CALLDATASIZE (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
     };
 
@@ -415,8 +415,8 @@ test "contract call: value transfer rollback on failure" {
         0x60, 0x0c, // PUSH1 12 (offset)
         0x60, 0x00, // PUSH1 0
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x05, // PUSH1 5 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
 
         // Runtime: always revert

--- a/test/evm/e2e_simple_test.zig
+++ b/test/evm/e2e_simple_test.zig
@@ -57,8 +57,8 @@ test "E2E: Basic EVM operations" {
         0x60, 0x2A, // PUSH1 42
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x20, // PUSH1 32 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xF3, // RETURN
     };
 

--- a/test/evm/integration/control_flow_test.zig
+++ b/test/evm/integration/control_flow_test.zig
@@ -237,9 +237,9 @@ test "Integration: Return data handling" {
     _ = try vm.table.execute(0, interpreter, state, 0x52); // MSTORE
 
     // Return 32 bytes from offset 0
-    // Stack order: [offset, size] with size on top
-    try frame_ptr.stack.append(0); // offset (second from top)
-    try frame_ptr.stack.append(32); // size (top)
+    // Stack order: [size, offset] with offset on top
+    try frame_ptr.stack.append(32); // size (second from top)
+    try frame_ptr.stack.append(0); // offset (top)
 
     // RETURN will throw an error (ExecutionError.STOP) which is expected
     const result = vm.table.execute(0, interpreter, state, 0xF3); // RETURN
@@ -299,9 +299,9 @@ test "Integration: Revert with reason" {
     try frame_ptr.memory.set_data(0, error_msg);
 
     // Revert with error message
-    // Stack order: [offset, size] with size on top
-    try frame_ptr.stack.append(0); // offset (second from top)
-    try frame_ptr.stack.append(error_msg.len); // size (top)
+    // Stack order: [size, offset] with offset on top
+    try frame_ptr.stack.append(error_msg.len); // size (second from top)
+    try frame_ptr.stack.append(0); // offset (top)
 
     // REVERT will throw an error (ExecutionError.REVERT) which is expected
     const result = vm.table.execute(0, interpreter, state, 0xFD); // REVERT

--- a/test/evm/opcodes/control_system_comprehensive_test.zig
+++ b/test/evm/opcodes/control_system_comprehensive_test.zig
@@ -23,8 +23,8 @@ test "RETURN (0xF3): Return data from execution" {
     defer evm.deinit();
 
     const code = [_]u8{
-        0x60, 0x00, // PUSH1 0x00 (offset = 0)
         0x60, 0x20, // PUSH1 0x20 (size = 32 bytes)
+        0x60, 0x00, // PUSH1 0x00 (offset = 0)
         0xF3, // RETURN
     };
 
@@ -143,8 +143,8 @@ test "REVERT (0xFD): Revert with data" {
     defer evm.deinit();
 
     const code = [_]u8{
-        0x60, 0x00, // PUSH1 0x00 (offset = 0)
         0x60, 0x10, // PUSH1 0x10 (size = 16 bytes)
+        0x60, 0x00, // PUSH1 0x00 (offset = 0)
         0xFD, // REVERT
     };
 
@@ -521,8 +521,8 @@ test "Control opcodes: Gas consumption" {
     defer frame.deinit();
 
     // Return large data requiring memory expansion
-    try frame.stack.append(0); // offset
     try frame.stack.append(0x1000); // size (4096 bytes)
+    try frame.stack.append(0); // offset
 
     const gas_before = frame.gas_remaining;
     const interpreter: Evm.Operation.Interpreter = &evm;

--- a/test/evm/opcodes/control_test.zig
+++ b/test/evm/opcodes/control_test.zig
@@ -332,8 +332,8 @@ test "Control: RETURN with data" {
     // Test 1: Return with data
     const test_data = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
     try frame.memory.set_data(10, &test_data);
-    try frame.stack.append(10);
-    try frame.stack.append(4);
+    try frame.stack.append(4);  // size (first)
+    try frame.stack.append(10); // offset (second, on top)
 
     const result = evm.table.execute(0, interpreter, state, 0xF3);
     try testing.expectError(ExecutionError.Error.STOP, result); // RETURN uses STOP error
@@ -402,8 +402,8 @@ test "Control: REVERT with data" {
     // Test 1: Revert with data
     const test_data = [_]u8{ 0x08, 0xc3, 0x79, 0xa0 }; // Common revert signature
     try frame.memory.set_data(0, &test_data);
-    try frame.stack.append(0);
-    try frame.stack.append(4);
+    try frame.stack.append(4); // size (first)
+    try frame.stack.append(0); // offset (second, on top)
 
     const result = evm.table.execute(0, interpreter, state, 0xFD);
     try testing.expectError(ExecutionError.Error.REVERT, result);

--- a/test/evm/opcodes/delegatecall_test.zig
+++ b/test/evm/opcodes/delegatecall_test.zig
@@ -46,9 +46,9 @@ test "DELEGATECALL basic functionality" {
     vm.set_context(context);
 
     // Deploy callee contract that returns caller address
-    // Contract code: CALLER PUSH1 0x00 MSTORE PUSH1 0x00 PUSH1 0x20 RETURN
-    // Bytecode: 0x33 0x60 0x00 0x52 0x60 0x00 0x60 0x20 0xf3
-    const callee_code = [_]u8{ 0x33, 0x60, 0x00, 0x52, 0x60, 0x00, 0x60, 0x20, 0xf3 };
+    // Contract code: CALLER PUSH1 0x00 MSTORE PUSH1 0x20 PUSH1 0x00 RETURN
+    // Bytecode: 0x33 0x60 0x00 0x52 0x60 0x20 0x60 0x00 0xf3
+    const callee_code = [_]u8{ 0x33, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3 };
     const callee_addr = primitives.Address.from_u256(0x2222);
     try vm.state.set_code(callee_addr, &callee_code);
 
@@ -79,8 +79,8 @@ test "DELEGATECALL basic functionality" {
     try caller_code.appendSlice(&[_]u8{
         0x5a, // GAS
         0xf4, // DELEGATECALL
-        0x60, 0x00, // PUSH1 0x00 (offset)
         0x60, 0x20, // PUSH1 0x20 (size)
+        0x60, 0x00, // PUSH1 0x00 (offset)
         0xf3, // RETURN
     });
 
@@ -142,8 +142,8 @@ test "DELEGATECALL preserves sender and value" {
     const callee_code = [_]u8{
         0x33, 0x60, 0x00, 0x52, // CALLER, PUSH1 0x00, MSTORE
         0x34, 0x60, 0x20, 0x52, // CALLVALUE, PUSH1 0x20, MSTORE
-        0x60, 0x00, 0x60, 0x40,
-        0xf3, // PUSH1 0x00, PUSH1 0x40, RETURN
+        0x60, 0x40, 0x60, 0x00,
+        0xf3, // PUSH1 0x40, PUSH1 0x00, RETURN
     };
     const callee_addr = primitives.Address.from_u256(0x5555);
     try vm.state.set_code(callee_addr, &callee_code);
@@ -163,8 +163,8 @@ test "DELEGATECALL preserves sender and value" {
     try caller_code.appendSlice(&[_]u8{
         0x5a, // GAS
         0xf4, // DELEGATECALL
-        0x60, 0x00, // PUSH1 0x00 (offset)
         0x60, 0x40, // PUSH1 0x40 (size)
+        0x60, 0x00, // PUSH1 0x00 (offset)
         0xf3, // RETURN
     });
 
@@ -229,8 +229,8 @@ test "DELEGATECALL with storage access" {
         0x60, 0x42, 0x60, 0x01, 0x55, // PUSH1 0x42, PUSH1 0x01, SSTORE
         0x60, 0x01, 0x54, // PUSH1 0x01, SLOAD
         0x60, 0x00, 0x52, // PUSH1 0x00, MSTORE
-        0x60, 0x00, 0x60,
-        0x20, 0xf3, // PUSH1 0x00, PUSH1 0x20, RETURN
+        0x60, 0x20, 0x60,
+        0x00, 0xf3, // PUSH1 0x20, PUSH1 0x00, RETURN
     };
     const callee_addr = primitives.Address.from_u256(0x8888);
     try vm.state.set_code(callee_addr, &callee_code);
@@ -250,8 +250,8 @@ test "DELEGATECALL with storage access" {
     try caller_code.appendSlice(&[_]u8{
         0x5a, // GAS
         0xf4, // DELEGATECALL
-        0x60, 0x00, // PUSH1 0x00 (offset)
         0x60, 0x20, // PUSH1 0x20 (size)
+        0x60, 0x00, // PUSH1 0x00 (offset)
         0xf3, // RETURN
     });
 

--- a/test/evm/opcodes/return_output_test.zig
+++ b/test/evm/opcodes/return_output_test.zig
@@ -23,8 +23,8 @@ test "RETURN sets output correctly" {
         0x63, 0xde, 0xad, 0xbe, 0xef, // PUSH4 0xDEADBEEF
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x1c, // PUSH1 28 (offset - to get last 4 bytes of the 32-byte word)
         0x60, 0x04, // PUSH1 4 (size)
+        0x60, 0x1c, // PUSH1 28 (offset - to get last 4 bytes of the 32-byte word)
         0xf3, // RETURN
     };
 
@@ -71,8 +71,8 @@ test "constructor returns runtime code" {
         0x64, 0x48, 0x45, 0x4c, 0x4c, 0x4f, // PUSH5 "HELLO" (6 bytes) - 0x64 is PUSH5
         0x60, 0x00, // PUSH1 0 (2 bytes)
         0x52, // MSTORE (1 byte)
-        0x60, 0x1b, // PUSH1 27 (offset to get last 5 bytes) (2 bytes)
         0x60, 0x05, // PUSH1 5 (size) (2 bytes)
+        0x60, 0x1b, // PUSH1 27 (offset to get last 5 bytes) (2 bytes)
         0xf3, // RETURN (1 byte)
     };
     const deployer: Address.Address = [_]u8{0x12} ** 20;

--- a/test/evm/return_opcode_bug_test.zig
+++ b/test/evm/return_opcode_bug_test.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const Evm = @import("evm");
+const primitives = @import("primitives");
+const Address = primitives.Address;
+
+test "minimal repro - RETURN opcode returns 0 bytes during contract deployment" {
+    std.testing.log_level = .debug;
+    
+    const allocator = std.testing.allocator;
+    
+    // Create a minimal contract deployment bytecode
+    // This simulates what Solidity generates:
+    // 1. Constructor code that copies runtime code to memory
+    // 2. RETURN opcode to return the runtime code
+    
+    // Runtime code (what should be deployed): just a simple STOP
+    // const runtime_code = [_]u8{0x00}; // STOP opcode (commented out - not used directly)
+    
+    // Deployment bytecode:
+    // PUSH1 0x01    (runtime code length)
+    // PUSH1 0x0c    (offset of runtime code in bytecode)
+    // PUSH1 0x00    (destination in memory)
+    // CODECOPY      (copy runtime code to memory)
+    // PUSH1 0x01    (length to return)
+    // PUSH1 0x00    (offset in memory)
+    // RETURN        (return runtime code)
+    // [runtime code follows]
+    const deployment_bytecode = [_]u8{
+        0x60, 0x01, // PUSH1 0x01 (size)
+        0x60, 0x0c, // PUSH1 0x0c (offset in code)
+        0x60, 0x00, // PUSH1 0x00 (dest in memory)
+        0x39,       // CODECOPY
+        0x60, 0x01, // PUSH1 0x01 (size to return)
+        0x60, 0x00, // PUSH1 0x00 (offset in memory)
+        0xf3,       // RETURN
+        0x00,       // Runtime code: STOP
+    };
+    
+    std.log.debug("Deployment bytecode: {x}", .{std.fmt.fmtSliceHexLower(&deployment_bytecode)});
+    
+    // Initialize EVM
+    var memory_db = Evm.MemoryDatabase.init(allocator);
+    defer memory_db.deinit();
+    
+    const db_interface = memory_db.to_database_interface();
+    var vm = try Evm.Evm.init(allocator, db_interface);
+    defer vm.deinit();
+    
+    // Deploy the contract
+    const caller = Address.from_u256(0x1000);
+    const deploy_result = try vm.create_contract(
+        caller,
+        0, // value
+        &deployment_bytecode,
+        1_000_000, // gas
+    );
+    defer if (deploy_result.output) |output| allocator.free(output);
+    
+    std.log.debug("Deploy result: success={}, gas_left={}, address={any}", .{
+        deploy_result.success,
+        deploy_result.gas_left,
+        deploy_result.address,
+    });
+    
+    // Check if the contract was deployed with code
+    const deployed_code = vm.state.get_code(deploy_result.address);
+    std.log.debug("Deployed code length: {}", .{deployed_code.len});
+    
+    // This should fail - we expect 1 byte of runtime code, not 0
+    try std.testing.expect(deployed_code.len > 0);
+    try std.testing.expectEqual(@as(usize, 1), deployed_code.len);
+    try std.testing.expectEqual(@as(u8, 0x00), deployed_code[0]);
+}

--- a/test/evm/solidity_constructor_test.zig
+++ b/test/evm/solidity_constructor_test.zig
@@ -33,8 +33,8 @@ test "complex Solidity constructor returns full runtime code" {
         0x15, // ISZERO
         0x61, 0x00, 0x10, // PUSH2 0x0010 (16 - position of JUMPDEST)
         0x57, // JUMPI
-        0x60, 0x00, // PUSH1 0x00
         0x80, // DUP1
+        0x60, 0x00, // PUSH1 0x00
         0xfd, // REVERT
         0x5b, // JUMPDEST
         0x50, // POP
@@ -44,9 +44,9 @@ test "complex Solidity constructor returns full runtime code" {
         0x80, // DUP1
         0x60, 0x21, // PUSH1 0x21 (33 - offset of runtime code)
         0x60, 0x00, // PUSH1 0x00 (destination in memory)
-        0x39, // CODECOPY - copies code[31..35] to memory[0..4]
-        0x60, 0x00, // PUSH1 0x00 (offset in memory)
+        0x39, // CODECOPY - copies code[33..37] to memory[0..4]
         0x60, 0x04, // PUSH1 0x04 (size to return)
+        0x60, 0x00, // PUSH1 0x00 (offset in memory)
         0xf3, // RETURN
 
         // Runtime code starts here (offset 33)
@@ -92,16 +92,16 @@ test "gas metering for KECCAK256 operations" {
         0x60, 0x0c, // PUSH1 12 (offset of runtime code in this bytecode)
         0x60, 0x00, // PUSH1 0 (destination in memory)
         0x39, // CODECOPY
-        0x60, 0x00, // PUSH1 0 (offset in memory)
         0x60, 0x0d, // PUSH1 13 (size to return)
+        0x60, 0x00, // PUSH1 0 (offset in memory)
         0xf3, // RETURN
 
         // Simple runtime code that just returns 0x42
         0x60, 0x42, // PUSH1 0x42
         0x60, 0x00, // PUSH1 0
         0x52, // MSTORE
-        0x60, 0x00, // PUSH1 0 (offset)
         0x60, 0x20, // PUSH1 32 (size)
+        0x60, 0x00, // PUSH1 0 (offset)
         0xf3, // RETURN
     };
 


### PR DESCRIPTION
## Summary
- Fixed RETURN and REVERT opcodes reading stack parameters in wrong order
- Updated all tests with incorrect bytecode patterns
- Added minimal reproduction test case

## Problem
The RETURN and REVERT opcodes were incorrectly reading their stack parameters. According to the EVM specification, these opcodes expect:
- Top of stack: offset (memory location)
- Second from top: size (number of bytes)

However, the implementation was reading them in reverse order, causing contracts to return incorrect data during deployment.

## Solution
1. Fixed the parameter assignment in both `op_return` and `op_revert` functions
2. Updated all test files that had bytecode with incorrect stack ordering
3. Added a minimal reproduction test that demonstrates the bug

## Test Results
All tests now pass with the correct stack parameter order.

Closes #280

🤖 Generated with [Claude Code](https://claude.ai/code)