### PR TITLE
feat: Add extremely minimal provider implementation

### DIFF
--- a/src/provider/example_mainnet.zig
+++ b/src/provider/example_mainnet.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const Provider = @import("provider.zig").Provider;
+const Address = @import("primitives").Address;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Initialize provider with mainnet RPC endpoint
+    const rpcUrl = std.os.getenv("ETH_RPC_URL") orelse "https://eth.llamarpc.com";
+    var provider = try Provider.init(allocator, rpcUrl);
+    defer provider.deinit();
+
+    // Get current block number
+    const blockNumber = try provider.getBlockNumber();
+    std.log.info("Current block number: {}", .{blockNumber});
+
+    // Get ETH balance of Vitalik's address
+    const vitalikAddress = try Address.fromString("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    const balance = try provider.getBalance(vitalikAddress);
+    std.log.info("Vitalik's balance: {} wei", .{balance});
+
+    // Get block by number
+    const block = try provider.getBlockByNumber(blockNumber, false);
+    defer block.deinit(allocator);
+    std.log.info("Block hash: {s}", .{block.hash});
+    std.log.info("Block timestamp: {}", .{block.timestamp});
+
+    // Get transaction count (nonce)
+    const nonce = try provider.getTransactionCount(vitalikAddress);
+    std.log.info("Vitalik's nonce: {}", .{nonce});
+
+    // Raw JSON-RPC request example
+    const result = try provider.request("eth_chainId", null);
+    defer allocator.free(result);
+    std.log.info("Chain ID: {s}", .{result});
+}

--- a/src/provider/provider.zig
+++ b/src/provider/provider.zig
@@ -73,7 +73,7 @@ pub const Provider = struct {
         return try std.fmt.parseInt(u64, hex, 16);
     }
 
-    pub fn getBalance(self: *Provider, addr: Address) !u256 {
+    pub fn getBalance(self: *Provider, addr: Address) !primitives.u256 {
         var params = std.json.Array.init(self.allocator);
         defer params.deinit();
         
@@ -89,7 +89,7 @@ pub const Provider = struct {
         const trimmed = std.mem.trim(u8, result, "\"");
         const hex = if (std.mem.startsWith(u8, trimmed, "0x")) trimmed[2..] else trimmed;
         
-        return try std.fmt.parseInt(u256, hex, 16);
+        return try std.fmt.parseInt(primitives.u256, hex, 16);
     }
 
     pub fn getTransactionCount(self: *Provider, addr: Address) !u64 {
@@ -172,4 +172,4 @@ pub const Block = struct {
     }
 };
 
-const u256 = @import("primitives").u256;
+const primitives = @import("primitives");

--- a/src/provider/provider.zig
+++ b/src/provider/provider.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+const Address = @import("primitives").Address;
+
+pub const Provider = struct {
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    client: std.http.Client,
+
+    pub fn init(allocator: std.mem.Allocator, url: []const u8) !Provider {
+        const urlCopy = try allocator.dupe(u8, url);
+        return Provider{
+            .allocator = allocator,
+            .url = urlCopy,
+            .client = std.http.Client{ .allocator = allocator },
+        };
+    }
+
+    pub fn deinit(self: *Provider) void {
+        self.client.deinit();
+        self.allocator.free(self.url);
+    }
+
+    pub fn request(self: *Provider, method: []const u8, params: ?std.json.Value) ![]const u8 {
+        const payload = JsonRpcRequest{
+            .jsonrpc = "2.0",
+            .method = method,
+            .params = params,
+            .id = 1,
+        };
+
+        const body = try std.json.stringifyAlloc(self.allocator, payload, .{});
+        defer self.allocator.free(body);
+
+        var headers = std.http.Client.Request.Headers{};
+        const uri = try std.Uri.parse(self.url);
+
+        var req = try self.client.open(.POST, uri, &headers);
+        defer req.deinit();
+
+        req.headers.append("Content-Type", "application/json") catch {};
+        req.headers.append("Accept", "application/json") catch {};
+
+        try req.send(body);
+        try req.finish();
+        try req.wait();
+
+        const responseBody = try req.reader().readAllAlloc(self.allocator, 1024 * 1024);
+        defer self.allocator.free(responseBody);
+
+        const parsed = try std.json.parseFromSlice(JsonRpcResponse, self.allocator, responseBody, .{});
+        defer parsed.deinit();
+
+        if (parsed.value.@"error") |err| {
+            std.log.err("JSON-RPC error: {s}", .{err.message});
+            return error.JsonRpcError;
+        }
+
+        if (parsed.value.result) |result| {
+            return try self.allocator.dupe(u8, result.raw);
+        }
+
+        return error.NoResult;
+    }
+
+    pub fn getBlockNumber(self: *Provider) !u64 {
+        const result = try self.request("eth_blockNumber", null);
+        defer self.allocator.free(result);
+
+        // Remove quotes and 0x prefix
+        const trimmed = std.mem.trim(u8, result, "\"");
+        const hex = if (std.mem.startsWith(u8, trimmed, "0x")) trimmed[2..] else trimmed;
+        
+        return try std.fmt.parseInt(u64, hex, 16);
+    }
+
+    pub fn getBalance(self: *Provider, addr: Address) !u256 {
+        var params = std.json.Array.init(self.allocator);
+        defer params.deinit();
+        
+        const addrHex = try std.fmt.allocPrint(self.allocator, "0x{s}", .{std.fmt.fmtSliceHexLower(&addr.bytes)});
+        defer self.allocator.free(addrHex);
+        
+        try params.append(std.json.Value{ .string = addrHex });
+        try params.append(std.json.Value{ .string = "latest" });
+
+        const result = try self.request("eth_getBalance", std.json.Value{ .array = params });
+        defer self.allocator.free(result);
+
+        const trimmed = std.mem.trim(u8, result, "\"");
+        const hex = if (std.mem.startsWith(u8, trimmed, "0x")) trimmed[2..] else trimmed;
+        
+        return try std.fmt.parseInt(u256, hex, 16);
+    }
+
+    pub fn getTransactionCount(self: *Provider, addr: Address) !u64 {
+        var params = std.json.Array.init(self.allocator);
+        defer params.deinit();
+        
+        const addrHex = try std.fmt.allocPrint(self.allocator, "0x{s}", .{std.fmt.fmtSliceHexLower(&addr.bytes)});
+        defer self.allocator.free(addrHex);
+        
+        try params.append(std.json.Value{ .string = addrHex });
+        try params.append(std.json.Value{ .string = "latest" });
+
+        const result = try self.request("eth_getTransactionCount", std.json.Value{ .array = params });
+        defer self.allocator.free(result);
+
+        const trimmed = std.mem.trim(u8, result, "\"");
+        const hex = if (std.mem.startsWith(u8, trimmed, "0x")) trimmed[2..] else trimmed;
+        
+        return try std.fmt.parseInt(u64, hex, 16);
+    }
+
+    pub fn getBlockByNumber(self: *Provider, blockNumber: u64, fullTxs: bool) !Block {
+        var params = std.json.Array.init(self.allocator);
+        defer params.deinit();
+        
+        const blockHex = try std.fmt.allocPrint(self.allocator, "0x{x}", .{blockNumber});
+        defer self.allocator.free(blockHex);
+        
+        try params.append(std.json.Value{ .string = blockHex });
+        try params.append(std.json.Value{ .bool = fullTxs });
+
+        const result = try self.request("eth_getBlockByNumber", std.json.Value{ .array = params });
+        defer self.allocator.free(result);
+
+        const parsed = try std.json.parseFromSlice(BlockJson, self.allocator, result, .{});
+        defer parsed.deinit();
+
+        return Block{
+            .hash = try self.allocator.dupe(u8, parsed.value.hash),
+            .number = try std.fmt.parseInt(u64, parsed.value.number[2..], 16),
+            .timestamp = try std.fmt.parseInt(u64, parsed.value.timestamp[2..], 16),
+            .allocator = self.allocator,
+        };
+    }
+};
+
+const JsonRpcRequest = struct {
+    jsonrpc: []const u8,
+    method: []const u8,
+    params: ?std.json.Value,
+    id: u32,
+};
+
+const JsonRpcResponse = struct {
+    jsonrpc: []const u8,
+    result: ?std.json.RawValue = null,
+    @"error": ?JsonRpcError = null,
+    id: u32,
+};
+
+const JsonRpcError = struct {
+    code: i32,
+    message: []const u8,
+};
+
+const BlockJson = struct {
+    hash: []const u8,
+    number: []const u8,
+    timestamp: []const u8,
+};
+
+pub const Block = struct {
+    hash: []const u8,
+    number: u64,
+    timestamp: u64,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *const Block, allocator: std.mem.Allocator) void {
+        allocator.free(self.hash);
+    }
+};
+
+const u256 = @import("primitives").u256;

--- a/src/provider/root.zig
+++ b/src/provider/root.zig
@@ -111,19 +111,6 @@
 //! 4. **Simplicity**: Clean API that's easy to use and understand
 //! 5. **Extensibility**: Easy to add new RPC methods and features
 
-// Working simple provider implementation (replaces broken provider.zig)
-pub const Provider = @import("simple_provider.zig").Provider;
-pub const ProviderError = @import("simple_provider.zig").ProviderError;
-
-// Working JSON-RPC types and transport
-pub const JsonRpc = @import("transport/json_rpc.zig");
-pub const Transport = @import("transport/http_simple.zig");
-
-// Legacy broken exports (commented out to prevent compilation errors)
-// pub const Provider = @import("provider.zig");
-// pub const Config = @import("config.zig");
-// pub const Blockchain = @import("blockchain.zig");
-// pub const Db = @import("db.zig");
-// pub const GenesisState = @import("genesis_state.zig");
-// pub const JsonRpcMethods = @import("jsonrpc/methods.zig");
-// pub const Transport = @import("transport/mod.zig");
+// Simple provider implementation
+pub const Provider = @import("provider.zig").Provider;
+pub const Block = @import("provider.zig").Block;

--- a/src/provider/test_provider.zig
+++ b/src/provider/test_provider.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const Provider = @import("provider.zig").Provider;
+
+test "provider initialization" {
+    const allocator = std.testing.allocator;
+    
+    var provider = try Provider.init(allocator, "https://eth.llamarpc.com");
+    defer provider.deinit();
+
+    // Just test initialization works
+    try std.testing.expect(provider.url.len > 0);
+}
+
+test "parse hex numbers" {
+    const allocator = std.testing.allocator;
+    
+    var provider = try Provider.init(allocator, "https://eth.llamarpc.com");
+    defer provider.deinit();
+
+    // Test hex parsing with common values
+    const cases = [_]struct { hex: []const u8, expected: u64 }{
+        .{ .hex = "\"0x0\"", .expected = 0 },
+        .{ .hex = "\"0x1\"", .expected = 1 },
+        .{ .hex = "\"0xff\"", .expected = 255 },
+        .{ .hex = "\"0x100\"", .expected = 256 },
+        .{ .hex = "\"0x539\"", .expected = 1337 },
+    };
+
+    for (cases) |case| {
+        const trimmed = std.mem.trim(u8, case.hex, "\"");
+        const hex = if (std.mem.startsWith(u8, trimmed, "0x")) trimmed[2..] else trimmed;
+        const result = try std.fmt.parseInt(u64, hex, 16);
+        try std.testing.expectEqual(case.expected, result);
+    }
+}


### PR DESCRIPTION
### TL;DR

Added a new Ethereum JSON-RPC provider implementation with core functionality for interacting with Ethereum nodes.

### What changed?

- Created a new `Provider` struct in `provider.zig` with methods for common Ethereum RPC calls:
  - `getBlockNumber()` - retrieves the latest block number
  - `getBalance()` - gets an address's ETH balance
  - `getTransactionCount()` - retrieves an address's nonce
  - `getBlockByNumber()` - fetches block data by block number
  - `request()` - allows raw JSON-RPC requests

- Added a mainnet example in `example_mainnet.zig` demonstrating how to:
  - Initialize the provider with an RPC URL
  - Query blockchain data (blocks, balances, etc.)
  - Make raw JSON-RPC calls

- Added unit tests in `test_provider.zig` to verify provider initialization and hex parsing

- Updated `root.zig` to export the new Provider implementation

### How to test?

1. Run the example with an RPC URL:
   ```
   ETH_RPC_URL=https://eth.llamarpc.com zig run src/provider/example_mainnet.zig
   ```

2. Run the unit tests:
   ```
   zig test src/provider/test_provider.zig
   ```

### Why make this change?

This implementation provides a clean, simple interface for Ethereum JSON-RPC interactions in Zig. It handles the complexities of HTTP requests, JSON serialization/deserialization, and hex value parsing. The provider is a foundational component for any Ethereum-related functionality, enabling applications to query blockchain state and submit transactions.