### PR TITLE
feat: macos menubar & shortcuts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -922,6 +922,8 @@ pub fn build(b: *std.Build) void {
         .name = "guillotine-devtool",
         .root_module = devtool_mod,
     });
+    devtool_exe.addCSourceFile(.{ .file = b.path("src/devtool/native_menu.c"), .flags = &[_][]const u8{"-ObjC"} });
+    devtool_exe.addIncludePath(webui.path("src"));
 
     // Link webui library
     devtool_exe.linkLibrary(webui.artifact("webui"));
@@ -930,6 +932,8 @@ pub fn build(b: *std.Build) void {
     devtool_exe.linkLibC();
     if (target.result.os.tag == .macos) {
         devtool_exe.linkFramework("WebKit");
+        devtool_exe.linkFramework("AppKit");
+        devtool_exe.linkFramework("Foundation");
     }
 
     // Make devtool build depend on asset generation

--- a/src/devtool/assets.zig
+++ b/src/devtool/assets.zig
@@ -47,14 +47,14 @@ pub const assets = [_]Self{
         "image/svg+xml",
     ),
     Self.init(
-        "/assets/index-BmWFzvvN.js",
-        @embedFile("dist/assets/index-BmWFzvvN.js"),
-        "application/javascript",
-    ),
-    Self.init(
         "/assets/index-xsFNff4r.css",
         @embedFile("dist/assets/index-xsFNff4r.css"),
         "text/css",
+    ),
+    Self.init(
+        "/assets/index-Btvp9dKX.js",
+        @embedFile("dist/assets/index-Btvp9dKX.js"),
+        "application/javascript",
     ),
     Self.init(
         "/tauri.svg",

--- a/src/devtool/main.zig
+++ b/src/devtool/main.zig
@@ -1,12 +1,22 @@
 const std = @import("std");
 const App = @import("app.zig");
 
+extern fn createApplicationMenu() void;
+
+pub export var main_window: usize = 0;
+
 pub fn main() !void {
+    if (@import("builtin").target.os.tag == .macos) {
+        createApplicationMenu();
+    }
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     
     var app = try App.init(allocator);
     defer app.deinit();
+
+    main_window = app.window.window_handle;
+
     try app.run();
 }

--- a/src/devtool/native_menu.c
+++ b/src/devtool/native_menu.c
@@ -1,0 +1,175 @@
+#import <AppKit/AppKit.h>
+#include "webui.h"
+
+// Reference to the main window
+extern size_t main_window;
+
+@interface NSApplication (GuillotineMenu)
+- (void)setupMainMenu;
+- (void)about_action:(id)sender;
+- (void)preferences_action:(id)sender;
+- (void)new_window_action:(id)sender;
+- (void)load_bytecode_action:(id)sender;
+- (void)save_state_action:(id)sender;
+- (void)find_action:(id)sender;
+- (void)toggle_dark_mode_action:(id)sender;
+- (void)run_pause_action:(id)sender;
+- (void)step_forward_action:(id)sender;
+- (void)reset_evm_action:(id)sender;
+- (void)help_action:(id)sender;
+- (void)github_action:(id)sender;
+@end
+
+
+void createApplicationMenu(void) {
+    @autoreleasepool {
+        NSApplication *app = [NSApplication sharedApplication];
+        if ([NSThread isMainThread]) {
+            [app setupMainMenu];
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                [app setupMainMenu];
+            });
+        }
+    }
+}
+
+@implementation NSApplication (GuillotineMenu)
+
+- (void)about_action:(id)sender { (void)sender; NSLog(@"About menu item clicked"); }
+- (void)preferences_action:(id)sender { (void)sender; NSLog(@"Preferences menu item clicked"); }
+- (void)new_window_action:(id)sender { (void)sender; NSLog(@"New Window menu item clicked"); }
+- (void)load_bytecode_action:(id)sender { (void)sender; NSLog(@"Load Bytecode menu item clicked"); }
+- (void)save_state_action:(id)sender { (void)sender; NSLog(@"Save EVM State menu item clicked"); }
+- (void)find_action:(id)sender { (void)sender; NSLog(@"Find menu item clicked"); }
+- (void)toggle_dark_mode_action:(id)sender { (void)sender; NSLog(@"Toggle Dark Mode menu item clicked"); }
+
+- (void)run_pause_action:(id)sender {
+    (void)sender;
+    if (main_window) {
+        webui_run(main_window, "handleRunPause()");
+    }
+}
+
+- (void)step_forward_action:(id)sender {
+    (void)sender;
+    if (main_window) {
+        webui_run(main_window, "handleStep()");
+    }
+}
+
+- (void)reset_evm_action:(id)sender {
+    (void)sender;
+    if (main_window) {
+        webui_run(main_window, "handleReset()");
+    }
+}
+
+- (void)help_action:(id)sender { (void)sender; NSLog(@"Help menu item clicked"); }
+- (void)github_action:(id)sender {
+    (void)sender;
+    NSURL *url = [NSURL URLWithString:@"https://github.com/evmts/guillotine"];
+    [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
+- (void)setupMainMenu {
+    NSMenu *mainMenu = [[NSMenu alloc] initWithTitle:@"MainMenu"];
+    [self setMainMenu:mainMenu];
+
+    // Application Menu
+    NSMenuItem *appMenuItem = [[NSMenuItem alloc] initWithTitle:@"Guillotine" action:nil keyEquivalent:@""];
+    [mainMenu addItem:appMenuItem];
+    NSMenu *appMenu = [[NSMenu alloc] initWithTitle:@"Guillotine"];
+    [appMenuItem setSubmenu:appMenu];
+
+    [appMenu addItem:[[NSMenuItem alloc] initWithTitle:@"About Guillotine" action:nil keyEquivalent:@""]];
+    [appMenu addItem:[NSMenuItem separatorItem]];
+    [appMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Preferences..." action:@selector(preferences_action:) keyEquivalent:@","]];
+    [appMenu addItem:[NSMenuItem separatorItem]];
+    [appMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Hide Guillotine" action:@selector(hide:) keyEquivalent:@"h"]];
+    NSMenuItem *hideOthers = [[NSMenuItem alloc] initWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
+    [hideOthers setKeyEquivalentModifierMask:(NSEventModifierFlagOption | NSEventModifierFlagCommand)];
+    [appMenu addItem:hideOthers];
+    [appMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""]];
+    [appMenu addItem:[NSMenuItem separatorItem]];
+    [appMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Quit Guillotine" action:@selector(terminate:) keyEquivalent:@"q"]];
+
+    // File Menu
+    NSMenuItem *fileMenuItem = [[NSMenuItem alloc] initWithTitle:@"File" action:nil keyEquivalent:@""];
+    [mainMenu addItem:fileMenuItem];
+    NSMenu *fileMenu = [[NSMenu alloc] initWithTitle:@"File"];
+    [fileMenuItem setSubmenu:fileMenu];
+    
+    [fileMenu addItem:[[NSMenuItem alloc] initWithTitle:@"New Window" action:nil keyEquivalent:@"n"]];
+    [fileMenu addItem:[NSMenuItem separatorItem]];
+    [fileMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Load Bytecode..." action:nil keyEquivalent:@"o"]];
+    [fileMenu addItem:[NSMenuItem separatorItem]];
+    [fileMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Save EVM State..." action:nil keyEquivalent:@"s"]];
+
+    // Edit Menu
+    NSMenuItem *editMenuItem = [[NSMenuItem alloc] initWithTitle:@"Edit" action:nil keyEquivalent:@""];
+    [mainMenu addItem:editMenuItem];
+    NSMenu *editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    [editMenuItem setSubmenu:editMenu];
+
+    [editMenu addItemWithTitle:@"Undo" action:@selector(undo:) keyEquivalent:@"z"];
+    [editMenu addItemWithTitle:@"Redo" action:@selector(redo:) keyEquivalent:@"Z"];
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    [editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
+    [editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
+    [editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
+    [editMenu addItemWithTitle:@"Paste and Match Style" action:@selector(pasteAsPlainText:) keyEquivalent:@"V"];
+    [editMenu addItemWithTitle:@"Delete" action:@selector(delete:) keyEquivalent:@""];
+    [editMenu addItemWithTitle:@"Select All" action:@selector(selectAll:) keyEquivalent:@"a"];
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    [editMenu addItemWithTitle:@"Find..." action:nil keyEquivalent:@"f"];
+
+    // View Menu
+    NSMenuItem *viewMenuItem = [[NSMenuItem alloc] initWithTitle:@"View" action:nil keyEquivalent:@""];
+    [mainMenu addItem:viewMenuItem];
+    NSMenu *viewMenu = [[NSMenu alloc] initWithTitle:@"View"];
+    [viewMenuItem setSubmenu:viewMenu];
+    [viewMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Toggle Dark Mode" action:nil keyEquivalent:@"d"]];
+
+    // Execution Menu
+    NSMenuItem *executionMenuItem = [[NSMenuItem alloc] initWithTitle:@"Execution" action:nil keyEquivalent:@""];
+    [mainMenu addItem:executionMenuItem];
+    NSMenu *executionMenu = [[NSMenu alloc] initWithTitle:@"Execution"];
+    [executionMenuItem setSubmenu:executionMenu];
+
+    NSMenuItem *runPauseItem = [[NSMenuItem alloc] initWithTitle:@"Run/Pause" action:@selector(run_pause_action:) keyEquivalent:@"␣"];
+    [runPauseItem setKeyEquivalentModifierMask:0];
+    [executionMenu addItem:runPauseItem];
+    
+    NSMenuItem *stepItem = [[NSMenuItem alloc] initWithTitle:@"Step Forward" action:@selector(step_forward_action:) keyEquivalent:@"s"];
+    [stepItem setKeyEquivalentModifierMask:0];
+    [executionMenu addItem:stepItem];
+
+    NSMenuItem *resetItem = [[NSMenuItem alloc] initWithTitle:@"Reset EVM" action:@selector(reset_evm_action:) keyEquivalent:@"r"];
+    [resetItem setKeyEquivalentModifierMask:0];
+    [executionMenu addItem:resetItem];
+    
+    // Window Menu
+    NSMenuItem *windowMenuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
+    [mainMenu addItem:windowMenuItem];
+    NSMenu *windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
+    [windowMenuItem setSubmenu:windowMenu];
+    
+    [windowMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"m"]];
+    [windowMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Zoom" action:@selector(performZoom:) keyEquivalent:@""]];
+    [windowMenu addItem:[NSMenuItem separatorItem]];
+    [windowMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Bring All to Front" action:@selector(arrangeInFront:) keyEquivalent:@""]];
+    
+    // Help Menu
+    NSMenuItem *helpMenuItem = [[NSMenuItem alloc] initWithTitle:@"Help" action:nil keyEquivalent:@""];
+    [mainMenu addItem:helpMenuItem];
+    NSMenu *helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
+    [helpMenuItem setSubmenu:helpMenu];
+    
+    [helpMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Guillotine Help" action:nil keyEquivalent:@"?"]];
+    [helpMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Release Notes" action:nil keyEquivalent:@""]];
+    [helpMenu addItem:[NSMenuItem separatorItem]];
+    [helpMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Guillotine on GitHub" action:@selector(github_action:) keyEquivalent:@""]];
+}
+
+@end

--- a/src/devtool/solid/App.tsx
+++ b/src/devtool/solid/App.tsx
@@ -1,11 +1,79 @@
 import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
+import { createStore } from "solid-js/store";
 import EvmDebugger from "~/components/evm-debugger/EvmDebugger";
 import { Toaster } from "~/components/ui/sonner";
+import { resetEvm, stepEvm } from "~/lib/actions";
+import type { EvmState } from "./components/evm-debugger/types";
+import { sampleContracts } from "./components/evm-debugger/types";
+
+declare global {
+	interface Window {
+		hello_world: (name: string) => Promise<string>;
+		load_bytecode: (bytecode: string) => Promise<string>;
+		reset_evm: () => Promise<string>;
+		step_evm: () => Promise<string>;
+		get_evm_state: () => Promise<string>;
+		handleRunPause: () => void;
+		handleStep: () => void;
+		handleReset: () => void;
+	}
+}
 
 function App() {
 	const [isDarkMode, setIsDarkMode] = createSignal(false);
+	const [isRunning, setIsRunning] = createSignal(false);
+	const [error, setError] = createSignal<string>("");
+	const [bytecode, setBytecode] = createSignal(sampleContracts[7].bytecode);
+	const [state, setState] = createStore<EvmState>({
+		pc: 0,
+		opcode: "-",
+		gasLeft: 0,
+		depth: 0,
+		stack: [],
+		memory: "0x",
+		storage: [],
+		logs: [],
+		returnData: "0x",
+	});
+
+	const handleRunPause = () => {
+		setIsRunning(!isRunning());
+	};
+
+	const handleStep = async () => {
+		try {
+			setError("");
+			const newState = await stepEvm();
+			setState(newState);
+		} catch (err) {
+			setError(`${err}`);
+		}
+	};
+
+	const handleReset = async () => {
+		try {
+			setError("");
+			setIsRunning(false);
+			const newState = await resetEvm();
+			setState(newState);
+		} catch (err) {
+			setError(`${err}`);
+		}
+	};
 
 	onMount(() => {
+		window.handleRunPause = handleRunPause;
+		window.handleStep = handleStep;
+		window.handleReset = handleReset;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.code === "Space") {
+				event.preventDefault();
+				handleRunPause();
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+
 		const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 		setIsDarkMode(mediaQuery.matches);
 		const listener = (event: MediaQueryListEvent) => {
@@ -13,8 +81,29 @@ function App() {
 		};
 		mediaQuery.addEventListener("change", listener);
 		onCleanup(() => {
+			window.removeEventListener("keydown", handleKeyDown);
 			mediaQuery.removeEventListener("change", listener);
 		});
+	});
+
+	createEffect(() => {
+		if (isRunning() && bytecode()) {
+			const intervalId = setInterval(async () => {
+				try {
+					const newState = await stepEvm();
+					if (newState.pc === 0 && newState.opcode === "COMPLETE") {
+						setIsRunning(false);
+					}
+					setState(newState);
+				} catch (err) {
+					setError(`${err}`);
+					setIsRunning(false);
+				}
+			}, 200);
+			onCleanup(() => {
+				clearInterval(intervalId);
+			});
+		}
 	});
 
 	createEffect(() => {
@@ -27,7 +116,21 @@ function App() {
 
 	return (
 		<>
-			<EvmDebugger isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
+			<EvmDebugger
+				isDarkMode={isDarkMode}
+				setIsDarkMode={setIsDarkMode}
+				isRunning={isRunning}
+				setIsRunning={setIsRunning}
+				error={error}
+				setError={setError}
+				state={state}
+				setState={setState}
+				bytecode={bytecode}
+				setBytecode={setBytecode}
+				handleRunPause={handleRunPause}
+				handleStep={handleStep}
+				handleReset={handleReset}
+			/>
 			<Toaster />
 		</>
 	);

--- a/src/devtool/solid/components/evm-debugger/BytecodeLoader.tsx
+++ b/src/devtool/solid/components/evm-debugger/BytecodeLoader.tsx
@@ -1,68 +1,52 @@
-import UploadIcon from "lucide-solid/icons/upload";
-import { type Component, createSignal, type Setter } from "solid-js";
-import type { EvmState } from "~/components/evm-debugger/types";
-import { sampleContracts } from "~/components/evm-debugger/types";
-import { loadBytecode, resetEvm } from "~/components/evm-debugger/utils";
-import { Button } from "~/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "~/components/ui/card";
-import {
-	Combobox,
-	ComboboxContent,
-	ComboboxInput,
-	ComboboxItem,
-	ComboboxTrigger,
-} from "~/components/ui/combobox";
-import { TextArea } from "~/components/ui/textarea";
-import { TextFieldRoot } from "~/components/ui/textfield";
+import UploadIcon from 'lucide-solid/icons/upload'
+import { type Component, createSignal, type Setter } from 'solid-js'
+import { sampleContracts } from '~/components/evm-debugger/types'
+import { loadBytecode, resetEvm } from '~/components/evm-debugger/utils'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
+import { Combobox, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxTrigger } from '~/components/ui/combobox'
+import { TextArea } from '~/components/ui/textarea'
+import { TextFieldRoot } from '~/components/ui/textfield'
+import type { EvmState } from './types'
 
 interface BytecodeLoaderProps {
-	bytecode: string;
-	setBytecode: Setter<string>;
-	setError: Setter<string>;
-	setIsRunning: Setter<boolean>;
-	setState: Setter<EvmState>;
+	bytecode: string
+	setBytecode: Setter<string>
+	setError: Setter<string>
+	setIsRunning: Setter<boolean>
+	setState: Setter<EvmState>
 }
 
 const BytecodeLoader: Component<BytecodeLoaderProps> = (props) => {
-	const [selectedContract, setSelectedContract] = createSignal(
-		sampleContracts[7].name,
-	);
+	const [selectedContract, setSelectedContract] = createSignal(sampleContracts[7].name)
 
 	const handleLoadBytecode = async () => {
 		try {
-			props.setError("");
-			await loadBytecode(props.bytecode);
-			props.setIsRunning(false);
-			const state = await resetEvm();
-			props.setState(state);
+			props.setError('')
+			await loadBytecode(props.bytecode)
+			props.setIsRunning(false)
+			const state = await resetEvm()
+			props.setState(state)
 		} catch (err) {
-			props.setError(`${err}`);
+			props.setError(`${err}`)
 		}
-	};
+	}
 
 	return (
 		<Card class="mx-auto mt-6 max-w-7xl rounded-sm border-none bg-transparent shadow-none">
 			<CardHeader class="flex flex-col justify-between gap-2 px-3 pb-2 sm:flex-row sm:items-center sm:px-6">
 				<div class="space-y-1">
 					<CardTitle>Bytecode</CardTitle>
-					<CardDescription>
-						Enter EVM bytecode to debug or select a sample contract
-					</CardDescription>
+					<CardDescription>Enter EVM bytecode to debug or select a sample contract</CardDescription>
 				</div>
 				{/** For some reason this Combobox is breaking the build. Currently it's not rendering at all*/}
 				<Combobox
 					value={selectedContract()}
 					onChange={(value) => {
-						setSelectedContract(value || "");
-						const contract = sampleContracts.find((c) => c.name === value);
+						setSelectedContract(value || '')
+						const contract = sampleContracts.find((c) => c.name === value)
 						if (contract) {
-							props.setBytecode(contract.bytecode);
+							props.setBytecode(contract.bytecode)
 						}
 					}}
 					options={sampleContracts.map((c) => c.name)}
@@ -72,19 +56,13 @@ const BytecodeLoader: Component<BytecodeLoaderProps> = (props) => {
 							<div class="flex flex-col items-start">
 								<span class="font-medium">{props.item.rawValue}</span>
 								<span class="text-muted-foreground text-xs">
-									{
-										sampleContracts.find((c) => c.name === props.item.rawValue)
-											?.description
-									}
+									{sampleContracts.find((c) => c.name === props.item.rawValue)?.description}
 								</span>
 							</div>
 						</ComboboxItem>
 					)}
 				>
-					<ComboboxTrigger
-						class="w-[250px]"
-						aria-label="Select sample contract"
-					>
+					<ComboboxTrigger class="w-[250px]" aria-label="Select sample contract">
 						<div class="flex items-center">
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -117,19 +95,13 @@ const BytecodeLoader: Component<BytecodeLoaderProps> = (props) => {
 						aria-label="EVM bytecode input"
 					/>
 				</TextFieldRoot>
-				<Button
-					variant="secondary"
-					size="sm"
-					onClick={handleLoadBytecode}
-					aria-label="Load bytecode"
-					class="gap-2"
-				>
+				<Button variant="secondary" size="sm" onClick={handleLoadBytecode} aria-label="Load bytecode" class="gap-2">
 					<UploadIcon class="h-4 w-4" />
 					Load Bytecode
 				</Button>
 			</CardContent>
 		</Card>
-	);
-};
+	)
+}
 
-export default BytecodeLoader;
+export default BytecodeLoader

--- a/src/devtool/solid/components/evm-debugger/Controls.tsx
+++ b/src/devtool/solid/components/evm-debugger/Controls.tsx
@@ -5,10 +5,9 @@ import PlayIcon from 'lucide-solid/icons/play'
 import RotateCcwIcon from 'lucide-solid/icons/rotate-ccw'
 import StepForwardIcon from 'lucide-solid/icons/step-forward'
 import { type Component, type Setter, Show } from 'solid-js'
-import type { EvmState } from '~/components/evm-debugger/types'
-import { resetEvm, stepEvm, toggleRunPause } from '~/components/evm-debugger/utils'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
+import type { EvmState } from './types'
 
 interface ControlsProps {
 	isRunning: boolean
@@ -19,44 +18,16 @@ interface ControlsProps {
 	setIsUpdating: Setter<boolean>
 	executionSpeed: number
 	setExecutionSpeed: Setter<number>
+	handleRunPause: () => void
+	handleStep: () => void
+	handleReset: () => void
+	bytecode: string
 }
 
 const Controls: Component<ControlsProps> = (props) => {
-	const handleResetEvm = async () => {
-		try {
-			props.setError('')
-			props.setIsRunning(false)
-			const state = await resetEvm()
-			props.setState(state)
-		} catch (err) {
-			props.setError(`${err}`)
-		}
-	}
-
-	const handleStepEvm = async () => {
-		try {
-			props.setError('')
-			props.setIsUpdating(true)
-			const state = await stepEvm()
-			props.setState(state)
-			setTimeout(() => props.setIsUpdating(false), 50)
-		} catch (err) {
-			props.setError(`${err}`)
-			props.setIsUpdating(false)
-		}
-	}
-
-	const handleToggleRunPause = async () => {
-		try {
-			props.setError('')
-			props.setIsRunning(!props.isRunning)
-			const state = await toggleRunPause()
-			props.setState(state)
-		} catch (err) {
-			props.setError(`${err}`)
-			props.setIsRunning(false)
-		}
-	}
+	const onReset = () => props.handleReset()
+	const onStep = () => props.handleStep()
+	const onRunPause = () => props.handleRunPause()
 
 	return (
 		<div class="sticky top-18 z-50 flex w-full justify-center px-4">
@@ -64,7 +35,8 @@ const Controls: Component<ControlsProps> = (props) => {
 				<Button
 					variant="outline"
 					size="sm"
-					onClick={handleResetEvm}
+					onClick={onReset}
+					disabled={!props.bytecode}
 					aria-label="Reset EVM (R)"
 					class="flex items-center gap-2"
 				>
@@ -79,8 +51,8 @@ const Controls: Component<ControlsProps> = (props) => {
 				<Button
 					variant="outline"
 					size="sm"
-					onClick={handleStepEvm}
-					disabled={props.isRunning}
+					onClick={onStep}
+					disabled={props.isRunning || !props.bytecode}
 					aria-label="Step EVM (S)"
 					class="flex items-center gap-2"
 				>
@@ -95,7 +67,8 @@ const Controls: Component<ControlsProps> = (props) => {
 				<Button
 					variant={props.isRunning ? 'secondary' : 'outline'}
 					size="sm"
-					onClick={handleToggleRunPause}
+					onClick={onRunPause}
+					disabled={!props.bytecode}
 					aria-label={props.isRunning ? 'Pause EVM (Space)' : 'Run EVM (Space)'}
 					class="flex items-center gap-2"
 				>
@@ -112,8 +85,8 @@ const Controls: Component<ControlsProps> = (props) => {
 				<Button
 					variant="outline"
 					size="sm"
-					disabled={!props.isRunning}
-					onClick={handleToggleRunPause}
+					disabled={!props.isRunning || !props.bytecode}
+					onClick={onRunPause}
 					aria-label="Speed"
 					class="flex items-center gap-2"
 				>

--- a/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
+++ b/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
@@ -1,134 +1,37 @@
-import {
-	type Accessor,
-	createEffect,
-	createSignal,
-	onCleanup,
-	type Setter,
-	Show,
-} from "solid-js";
-import BytecodeLoader from "~/components/evm-debugger/BytecodeLoader";
-import Controls from "~/components/evm-debugger/Controls";
-import ErrorAlert from "~/components/evm-debugger/ErrorAlert";
-import Header from "~/components/evm-debugger/Header";
-import LogsAndReturn from "~/components/evm-debugger/LogsAndReturn";
-import Memory from "~/components/evm-debugger/Memory";
-import Stack from "~/components/evm-debugger/Stack";
-import StateSummary from "~/components/evm-debugger/StateSummary";
-import Storage from "~/components/evm-debugger/Storage";
-import {
-	type EvmState,
-	sampleContracts,
-} from "~/components/evm-debugger/types";
-import BytecodeView from "./BytecodeView";
-import GasUsage from "./GasUsage";
-import { stepEvm } from "./utils";
+import { type Accessor, createSignal, type Setter, Show } from 'solid-js'
+import BytecodeLoader from '~/components/evm-debugger/BytecodeLoader'
+import Controls from '~/components/evm-debugger/Controls'
+import ErrorAlert from '~/components/evm-debugger/ErrorAlert'
+import Header from '~/components/evm-debugger/Header'
+import LogsAndReturn from '~/components/evm-debugger/LogsAndReturn'
+import Memory from '~/components/evm-debugger/Memory'
+import Stack from '~/components/evm-debugger/Stack'
+import StateSummary from '~/components/evm-debugger/StateSummary'
+import Storage from '~/components/evm-debugger/Storage'
+import BytecodeView from './BytecodeView'
+import GasUsage from './GasUsage'
+import type { EvmState } from './types'
 
 interface EvmDebuggerProps {
-	isDarkMode: Accessor<boolean>;
-	setIsDarkMode: Setter<boolean>;
+	isDarkMode: Accessor<boolean>
+	setIsDarkMode: Setter<boolean>
+	isRunning: Accessor<boolean>
+	setIsRunning: Setter<boolean>
+	error: Accessor<string>
+	setError: Setter<string>
+	state: EvmState
+	setState: Setter<EvmState>
+	bytecode: Accessor<string>
+	setBytecode: Setter<string>
+	handleRunPause: () => void
+	handleStep: () => void
+	handleReset: () => void
 }
 
 const EvmDebugger = (props: EvmDebuggerProps) => {
-	const [bytecode, setBytecode] = createSignal(sampleContracts[7].bytecode);
-	const [state, setState] = createSignal<EvmState>({
-		pc: 0,
-		opcode: "-",
-		gasLeft: 0,
-		depth: 0,
-		stack: [],
-		memory: "0x",
-		storage: [],
-		logs: [],
-		returnData: "0x",
-	});
-	const [isRunning, setIsRunning] = createSignal(false);
-	const [error, setError] = createSignal("");
-	const [isUpdating, setIsUpdating] = createSignal(false);
-	const [activePanel, setActivePanel] = createSignal("all");
-	const [executionSpeed, setExecutionSpeed] = createSignal(100); // milliseconds between steps
-
-	createEffect(() => {
-		if (!isRunning()) return;
-		const runStep = async () => {
-			try {
-				setIsUpdating(true);
-				const freshState = await stepEvm();
-				setState(freshState);
-				setIsUpdating(false);
-
-				// Stop running if execution is complete or an error occurred
-				if (freshState.pc === 0 && freshState.opcode === "COMPLETE") {
-					setIsRunning(false);
-				}
-			} catch (err) {
-				setError(`Failed to step: ${err}`);
-				setIsRunning(false);
-			}
-		};
-
-		const interval = setInterval(runStep, executionSpeed()); // Step at configured speed
-
-		onCleanup(() => {
-			clearInterval(interval);
-		});
-	});
-
-	const handleKeyDown = (e: KeyboardEvent) => {
-		if (
-			e.target instanceof HTMLInputElement ||
-			e.target instanceof HTMLTextAreaElement
-		) {
-			return;
-		}
-
-		if (e.key === "r" || e.key === "R") {
-			const handleResetEvm = async () => {
-				try {
-					setError("");
-					setIsRunning(false);
-				} catch (err) {
-					setError(`${err}`);
-				}
-			};
-
-			handleResetEvm();
-		} else if (e.key === "s" || e.key === "S") {
-			const handleStepEvm = async () => {
-				try {
-					setError("");
-					setIsUpdating(true);
-				} catch (err) {
-					setError(`${err}`);
-					setIsUpdating(false);
-				}
-			};
-
-			handleStepEvm();
-		} else if (e.key === " ") {
-			e.preventDefault();
-			const handleToggleRunPause = async () => {
-				try {
-					setError("");
-					setIsRunning(!isRunning());
-				} catch (err) {
-					setError(`${err}`);
-					setIsRunning(false);
-				}
-			};
-
-			handleToggleRunPause();
-		} else if (e.key === "d" && e.ctrlKey) {
-			e.preventDefault();
-			props.setIsDarkMode(!props.isDarkMode());
-		}
-	};
-
-	createEffect(() => {
-		window.addEventListener("keydown", handleKeyDown);
-		onCleanup(() => {
-			window.removeEventListener("keydown", handleKeyDown);
-		});
-	});
+	const [isUpdating, setIsUpdating] = createSignal(false)
+	const [activePanel, setActivePanel] = createSignal('all')
+	const [executionSpeed, setExecutionSpeed] = createSignal(100)
 
 	return (
 		<div class="min-h-screen bg-background text-foreground">
@@ -139,48 +42,52 @@ const EvmDebugger = (props: EvmDebuggerProps) => {
 				setActivePanel={setActivePanel}
 			/>
 			<Controls
-				isRunning={isRunning()}
-				setIsRunning={setIsRunning}
-				setError={setError}
-				setState={setState}
+				isRunning={props.isRunning()}
+				setIsRunning={props.setIsRunning}
+				setError={props.setError}
+				setState={props.setState as Setter<EvmState>}
 				isUpdating={isUpdating()}
 				setIsUpdating={setIsUpdating}
 				executionSpeed={executionSpeed()}
 				setExecutionSpeed={setExecutionSpeed}
+				handleRunPause={props.handleRunPause}
+				handleStep={props.handleStep}
+				handleReset={props.handleReset}
+				bytecode={props.bytecode()}
 			/>
 			<BytecodeLoader
-				bytecode={bytecode()}
-				setBytecode={setBytecode}
-				setError={setError}
-				setIsRunning={setIsRunning}
-				setState={setState}
+				bytecode={props.bytecode()}
+				setBytecode={props.setBytecode}
+				setError={props.setError}
+				setIsRunning={props.setIsRunning}
+				setState={props.setState as Setter<EvmState>}
 			/>
 			<div class="mx-auto flex max-w-7xl flex-col gap-6 px-3 pb-6 sm:px-6">
-				<ErrorAlert error={error()} setError={setError} />
-				<StateSummary state={state()} isUpdating={isUpdating()} />
-				<Show when={activePanel() === "all" || activePanel() === "bytecode"}>
-					<BytecodeView bytecode={bytecode()} pc={state().pc} />
+				<ErrorAlert error={props.error()} setError={props.setError} />
+				<StateSummary state={props.state as EvmState} isUpdating={isUpdating()} />
+				<Show when={activePanel() === 'all' || activePanel() === 'bytecode'}>
+					<BytecodeView bytecode={props.bytecode()} pc={props.state.pc} />
 				</Show>
-				<Show when={activePanel() === "all" || activePanel() === "gas"}>
-					<GasUsage state={state()} />
+				<Show when={activePanel() === 'all' || activePanel() === 'gas'}>
+					<GasUsage state={props.state as EvmState} />
 				</Show>
 				<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-					<Show when={activePanel() === "all" || activePanel() === "stack"}>
-						<Stack state={state()} />
+					<Show when={activePanel() === 'all' || activePanel() === 'stack'}>
+						<Stack state={props.state as EvmState} />
 					</Show>
-					<Show when={activePanel() === "all" || activePanel() === "memory"}>
-						<Memory state={state()} />
+					<Show when={activePanel() === 'all' || activePanel() === 'memory'}>
+						<Memory state={props.state as EvmState} />
 					</Show>
-					<Show when={activePanel() === "all" || activePanel() === "storage"}>
-						<Storage state={state()} />
+					<Show when={activePanel() === 'all' || activePanel() === 'storage'}>
+						<Storage state={props.state as EvmState} />
 					</Show>
-					<Show when={activePanel() === "all" || activePanel() === "logs"}>
-						<LogsAndReturn state={state()} />
+					<Show when={activePanel() === 'all' || activePanel() === 'logs'}>
+						<LogsAndReturn state={props.state as EvmState} />
 					</Show>
 				</div>
 			</div>
 		</div>
-	);
-};
+	)
+}
 
-export default EvmDebugger;
+export default EvmDebugger

--- a/src/devtool/solid/components/ui/combobox.tsx
+++ b/src/devtool/solid/components/ui/combobox.tsx
@@ -1,160 +1,145 @@
 import type {
-  ComboboxContentProps,
-  ComboboxInputProps,
-  ComboboxItemProps,
-  ComboboxTriggerProps,
-} from "@kobalte/core/combobox";
+	ComboboxContentProps,
+	ComboboxInputProps,
+	ComboboxItemProps,
+	ComboboxTriggerProps,
+} from '@kobalte/core/combobox'
 // for some reason this import is breaking the build
 // import { Combobox as ComboboxPrimitive } from "@kobalte/core/combobox";
-import type { PolymorphicProps } from "@kobalte/core/polymorphic";
-import type { ParentProps, ValidComponent, VoidProps } from "solid-js";
-import { splitProps } from "solid-js";
-import { cn } from "~/lib/cn";
+import type { PolymorphicProps } from '@kobalte/core/polymorphic'
+import type { ParentProps, ValidComponent, VoidProps } from 'solid-js'
+import { splitProps } from 'solid-js'
+import { cn } from '~/lib/cn'
 
 // For some reason this import is breaking the build
-export const Combobox = () => <></>; // ComboboxPrimitive;
-export const ComboboxDescription = () => <></>; // ComboboxPrimitive.Description;
-export const ComboboxErrorMessage = () => <></>; // ComboboxPrimitive.ErrorMessage;
-export const ComboboxItemDescription = () => <></>; // ComboboxPrimitive.ItemDescription;
-export const ComboboxHiddenSelect = () => <></>; // ComboboxPrimitive.HiddenSelect;
+export const Combobox = () => <></> // ComboboxPrimitive;
+export const ComboboxDescription = () => <></> // ComboboxPrimitive.Description;
+export const ComboboxErrorMessage = () => <></> // ComboboxPrimitive.ErrorMessage;
+export const ComboboxItemDescription = () => <></> // ComboboxPrimitive.ItemDescription;
+export const ComboboxHiddenSelect = () => <></> // ComboboxPrimitive.HiddenSelect;
 
-type comboboxInputProps<T extends ValidComponent = "input"> = VoidProps<
-  ComboboxInputProps<T> & {
-    class?: string;
-  }
->;
+type comboboxInputProps<T extends ValidComponent = 'input'> = VoidProps<
+	ComboboxInputProps<T> & {
+		class?: string
+	}
+>
 
-export const ComboboxInput = <T extends ValidComponent = "input">(
-  props: PolymorphicProps<T, comboboxInputProps<T>>,
+export const ComboboxInput = <T extends ValidComponent = 'input'>(
+	props: PolymorphicProps<T, comboboxInputProps<T>>,
 ) => {
-  const [local, rest] = splitProps(props as comboboxInputProps, ["class"]);
+	const [_local, _rest] = splitProps(props as comboboxInputProps, ['class'])
 
-  return (
-    <></>
-    // <ComboboxPrimitive.Input
-    // 		class={cn(
-    // 		"h-full bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-    // 	local.class,
-    // 			)}
-    // 			{...rest}
-    // 		/>
-  );
-};
+	return (
+		<></>
+		// <ComboboxPrimitive.Input
+		// 		class={cn(
+		// 		"h-full bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+		// 	local.class,
+		// 			)}
+		// 			{...rest}
+		// 		/>
+	)
+}
 
-type comboboxTriggerProps<T extends ValidComponent = "button"> = ParentProps<
-  ComboboxTriggerProps<T> & {
-    class?: string;
-  }
->;
+type comboboxTriggerProps<T extends ValidComponent = 'button'> = ParentProps<
+	ComboboxTriggerProps<T> & {
+		class?: string
+	}
+>
 
-export const ComboboxTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, comboboxTriggerProps<T>>,
+export const ComboboxTrigger = <T extends ValidComponent = 'button'>(
+	props: PolymorphicProps<T, comboboxTriggerProps<T>>,
 ) => {
-  const [local, rest] = splitProps(props as comboboxTriggerProps, [
-    "class",
-    "children",
-  ]);
+	const [_local, _rest] = splitProps(props as comboboxTriggerProps, ['class', 'children'])
 
-  return (
-    <></>
-    // 		<ComboboxPrimitive.Control>
-    // 			<ComboboxPrimitive.Trigger
-    // 				class={cn(
-    // 					"flex h-9 w-full items-center justify-between rounded-sm border border-input px-2 shadow-sm",
-    // 					local.class,
-    // 				)}
-    // 				{...rest}
-    // 			>
-    // 				{local.children}
-    // 				<ComboboxPrimitive.Icon class="flex h-3.5 w-3.5 items-center justify-center">
-    // 					<svg
-    // 						xmlns="http://www.w3.org/2000/svg"
-    // 						viewBox="0 0 24 24"
-    // 						class="h-4 w-4 opacity-50"
-    // 					>
-    // 						<path
-    // 							fill="none"
-    // 							stroke="currentColor"
-    // 							stroke-linecap="round"
-    // 							stroke-linejoin="round"
-    // 							stroke-width="2"
-    // 							d="m8 9l4-4l4 4m0 6l-4 4l-4-4"
-    // 						/>
-    // 						<title>Arrow</title>
-    // 					</svg>
-    // 				</ComboboxPrimitive.Icon>
-    // 			</ComboboxPrimitive.Trigger>
-    // 		</ComboboxPrimitive.Control>
-  );
-};
+	return (
+		<></>
+		// 		<ComboboxPrimitive.Control>
+		// 			<ComboboxPrimitive.Trigger
+		// 				class={cn(
+		// 					"flex h-9 w-full items-center justify-between rounded-sm border border-input px-2 shadow-sm",
+		// 					local.class,
+		// 				)}
+		// 				{...rest}
+		// 			>
+		// 				{local.children}
+		// 				<ComboboxPrimitive.Icon class="flex h-3.5 w-3.5 items-center justify-center">
+		// 					<svg
+		// 						xmlns="http://www.w3.org/2000/svg"
+		// 						viewBox="0 0 24 24"
+		// 						class="h-4 w-4 opacity-50"
+		// 					>
+		// 						<path
+		// 							fill="none"
+		// 							stroke="currentColor"
+		// 							stroke-linecap="round"
+		// 							stroke-linejoin="round"
+		// 							stroke-width="2"
+		// 							d="m8 9l4-4l4 4m0 6l-4 4l-4-4"
+		// 						/>
+		// 						<title>Arrow</title>
+		// 					</svg>
+		// 				</ComboboxPrimitive.Icon>
+		// 			</ComboboxPrimitive.Trigger>
+		// 		</ComboboxPrimitive.Control>
+	)
+}
 
-type comboboxContentProps<T extends ValidComponent = "div"> =
-  ComboboxContentProps<T> & {
-    class?: string;
-  };
+type comboboxContentProps<T extends ValidComponent = 'div'> = ComboboxContentProps<T> & {
+	class?: string
+}
 
-export const ComboboxContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, comboboxContentProps<T>>,
+export const ComboboxContent = <T extends ValidComponent = 'div'>(
+	props: PolymorphicProps<T, comboboxContentProps<T>>,
 ) => {
-  const [local, rest] = splitProps(props as comboboxContentProps, ["class"]);
+	const [local, rest] = splitProps(props as comboboxContentProps, ['class'])
 
-  return (
-    <ComboboxPrimitive.Portal>
-      <ComboboxPrimitive.Content
-        class={cn(
-          "data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 relative z-50 min-w-[8rem] origin-[--kb-combobox-content-transform-origin] overflow-hidden rounded-sm border bg-popover text-popover-foreground shadow-md data-[closed]:animate-out data-[expanded]:animate-in",
-          local.class,
-        )}
-        {...rest}
-      >
-        <ComboboxPrimitive.Listbox class="p-1" />
-      </ComboboxPrimitive.Content>
-    </ComboboxPrimitive.Portal>
-  );
-};
+	return (
+		<ComboboxPrimitive.Portal>
+			<ComboboxPrimitive.Content
+				class={cn(
+					'data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 relative z-50 min-w-[8rem] origin-[--kb-combobox-content-transform-origin] overflow-hidden rounded-sm border bg-popover text-popover-foreground shadow-md data-[closed]:animate-out data-[expanded]:animate-in',
+					local.class,
+				)}
+				{...rest}
+			>
+				<ComboboxPrimitive.Listbox class="p-1" />
+			</ComboboxPrimitive.Content>
+		</ComboboxPrimitive.Portal>
+	)
+}
 
-type comboboxItemProps<T extends ValidComponent = "li"> = ParentProps<
-  ComboboxItemProps<T> & {
-    class?: string;
-  }
->;
+type comboboxItemProps<T extends ValidComponent = 'li'> = ParentProps<
+	ComboboxItemProps<T> & {
+		class?: string
+	}
+>
 
-export const ComboboxItem = <T extends ValidComponent = "li">(
-  props: PolymorphicProps<T, comboboxItemProps<T>>,
-) => {
-  const [local, rest] = splitProps(props as comboboxItemProps, [
-    "class",
-    "children",
-  ]);
+export const ComboboxItem = <T extends ValidComponent = 'li'>(props: PolymorphicProps<T, comboboxItemProps<T>>) => {
+	const [local, rest] = splitProps(props as comboboxItemProps, ['class', 'children'])
 
-  return (
-    <ComboboxPrimitive.Item
-      class={cn(
-        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
-        local.class,
-      )}
-      {...rest}
-    >
-      <ComboboxPrimitive.ItemIndicator class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          class="h-4 w-4"
-        >
-          <path
-            fill="none"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="m5 12l5 5L20 7"
-          />
-          <title>Checked</title>
-        </svg>
-      </ComboboxPrimitive.ItemIndicator>
-      <ComboboxPrimitive.ItemLabel>
-        {local.children}
-      </ComboboxPrimitive.ItemLabel>
-    </ComboboxPrimitive.Item>
-  );
-};
+	return (
+		<ComboboxPrimitive.Item
+			class={cn(
+				'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50',
+				local.class,
+			)}
+			{...rest}
+		>
+			<ComboboxPrimitive.ItemIndicator class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4">
+					<path
+						fill="none"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="m5 12l5 5L20 7"
+					/>
+					<title>Checked</title>
+				</svg>
+			</ComboboxPrimitive.ItemIndicator>
+			<ComboboxPrimitive.ItemLabel>{local.children}</ComboboxPrimitive.ItemLabel>
+		</ComboboxPrimitive.Item>
+	)
+}

--- a/src/devtool/solid/index.tsx
+++ b/src/devtool/solid/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
-import { render } from "solid-js/web";
-import App from "~/App";
-import "~/app.css";
+import { render } from 'solid-js/web'
+import App from '~/App'
+import '~/app.css'
 
-render(() => <App />, document.getElementById("root") as HTMLElement);
+render(() => <App />, document.getElementById('root') as HTMLElement)

--- a/src/devtool/webui/types.zig
+++ b/src/devtool/webui/types.zig
@@ -89,6 +89,8 @@ pub const EventKind = enum(usize) {
     event_navigation,
     /// 4. Function call event
     event_callback,
+    /// 5. Key press event
+    event_key_press,
 };
 
 pub const Config = enum(c_int) {


### PR DESCRIPTION
- Add mac os native menu with usual options + guillotine specific ones
- Make shortcuts work (both native, e.g. copy, paste, and guillotine ones)

<img width="532" height="43" alt="image" src="https://github.com/user-attachments/assets/d85f47fb-484a-46f8-9437-cdaf38ad4a25" />
<img width="243" height="152" alt="image" src="https://github.com/user-attachments/assets/ed00841a-0ac2-496c-b396-42ddca8891b2" />
<img width="199" height="132" alt="image" src="https://github.com/user-attachments/assets/0eab81d4-6919-4e8b-a083-9cd14f89c974" />
<img width="404" height="171" alt="image" src="https://github.com/user-attachments/assets/96c077b6-01f6-4871-bcda-bbc5ff67d8fb" />
