### PR TITLE
fix: absolute paths in build

### DIFF
--- a/src/revm_wrapper/build.rs
+++ b/src/revm_wrapper/build.rs
@@ -8,18 +8,21 @@ fn main() {
 
     cbindgen::Builder::new()
         .with_config(cbindgen::Config::from_file("cbindgen.toml").unwrap())
-        .with_crate(crate_dir)
+        .with_crate(&crate_dir)
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(output_path);
-        
+
+    let project_dir = PathBuf::from(&crate_dir).parent().unwrap().parent().unwrap().to_path_buf();
+
     // Tell cargo to look for the library in zig-out/lib
-    println!("cargo:rustc-link-search=/Users/williamcory/guillotine-0/zig-out/lib");
-    
+    println!("cargo:rustc-link-search={}/zig-out/lib", project_dir.display());
+
     // Link to the correct bn254_wrapper based on profile
     let profile = env::var("PROFILE").unwrap();
     let target_dir = if profile == "release" { "release" } else { "debug" };
-    println!("cargo:rustc-link-search=/Users/williamcory/guillotine-0/target/aarch64-apple-darwin/{}", target_dir);
-    println!("cargo:rustc-link-search=/Users/williamcory/guillotine-0/target/{}", target_dir);
+    let target_triple = env::var("TARGET").unwrap();
+    println!("cargo:rustc-link-search={}/target/{}/{}", project_dir.display(), target_triple, target_dir);
+    println!("cargo:rustc-link-search={}/target/{}", project_dir.display(), target_dir);
     println!("cargo:rustc-link-lib=static=bn254_wrapper");
 }


### PR DESCRIPTION
Remove absolute paths in `build.rs`