### PR TITLE
❇️ feat: init zig bn254 crypto native

### DIFF
--- a/src/crypto/bn254.zig
+++ b/src/crypto/bn254.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+pub const Fp = @import("bn254/Fp.zig").Fp;
+pub const Fp2 = @import("bn254/Fp2.zig").Fp2;
+pub const Fp6 = @import("bn254/Fp6.zig").Fp6;
+pub const Fp12 = @import("bn254/Fp12.zig").Fp12;
+pub const Fr = @import("bn254/Fr.zig").Fr;
+
+pub const FP_MOD = Fp.FP_MOD;
+pub const FR_MOD = Fr.FR_MOD;
+pub const G1 = @import("bn254/g1.zig").G1;
+pub const G2 = @import("bn254/g2.zig").G2;
+pub const pairing = @import("bn254/pairing.zig").pairing;

--- a/src/crypto/bn254/Fp.zig
+++ b/src/crypto/bn254/Fp.zig
@@ -1,0 +1,380 @@
+const std = @import("std");
+
+pub const FP_MOD = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;
+
+pub const Fp = struct {
+    value: u256,
+
+    pub const ZERO = Fp{ .value = 0 };
+    pub const ONE = Fp{ .value = 1 };
+
+    pub fn init(value: u256) Fp {
+        return Fp{
+            .value = value % FP_MOD,
+        };
+    }
+
+    pub fn add(self: *const Fp, other: *const Fp) Fp {
+        const sum = self.value + other.value;
+        return Fp{
+            .value = if (sum >= FP_MOD) sum - FP_MOD else sum,
+        };
+    }
+
+    pub fn addAssign(self: *Fp, other: *const Fp) void {
+        self.* = self.add(other);
+    }
+
+    pub fn neg(self: *const Fp) Fp {
+        return Fp{
+            .value = if (self.value == 0) 0 else FP_MOD - self.value,
+        };
+    }
+
+    pub fn negAssign(self: *Fp) void {
+        self.* = self.neg();
+    }
+
+    pub fn sub(self: *const Fp, other: *const Fp) Fp {
+        return self.add(&other.neg());
+    }
+
+    pub fn subAssign(self: *Fp, other: *const Fp) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn mul(self: *const Fp, other: *const Fp) Fp {
+        const product = @as(u512, self.value) * @as(u512, other.value);
+        return Fp{
+            .value = @intCast(product % FP_MOD),
+        };
+    }
+
+    pub fn mulAssign(self: *Fp, other: *const Fp) void {
+        self.* = self.mul(other);
+    }
+
+    //we use double and add to multiply by a small integer
+    pub fn mulBySmallInt(self: *const Fp, other: u64) Fp {
+        var result = ZERO;
+        var base = self.*;
+        var exp = other;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.addAssign(&base);
+        }
+        return result;
+    }
+
+    pub fn mulBySmallIntAssign(self: *Fp, other: u64) void {
+        self.* = self.mulBySmallInt(other);
+    }
+
+    pub fn square(self: *const Fp) Fp {
+        return self.mul(self);
+    }
+
+    pub fn pow(self: *const Fp, exponent: u256) Fp {
+        var result = ONE;
+        var base = self.*;
+        var exp = exponent;
+        while (exp > 0) {
+            if (exp & 1 == 1) {
+                result.mulAssign(&base);
+            }
+            base.mulAssign(&base);
+            exp >>= 1;
+        }
+        return result;
+    }
+
+    pub fn powAssign(self: *Fp, exponent: u256) void {
+        self.* = self.pow(exponent);
+    }
+
+    // Fermat's little theorem: a^(p-1) = 1 (mod p)
+    // disgustingly slow, temporary solution
+    pub fn inv(self: *const Fp) Fp {
+        return self.pow(FP_MOD - 2);
+    }
+
+    pub fn invAssign(self: *Fp) void {
+        self.* = self.inv();
+    }
+
+    pub fn equal(self: *const Fp, other: *const Fp) bool {
+        return self.value == other.value;
+    }
+};
+
+test "Fp.mulBySmallInt basic multiplication" {
+    const a = Fp{ .value = 2 };
+    const result = a.mulBySmallInt(3);
+    try std.testing.expect(result.value == 6);
+}
+
+test "Fp.add basic addition" {
+    const a = Fp{ .value = 10 };
+    const b = Fp{ .value = 20 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fp.add with modular reduction" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const b = Fp{ .value = 5 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 4);
+}
+
+test "Fp.add with zero" {
+    const a = Fp{ .value = 100 };
+    const b = Fp{ .value = 0 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 100);
+}
+
+test "Fp.add resulting in modulus" {
+    const a = Fp{ .value = FP_MOD - 10 };
+    const b = Fp{ .value = 10 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fp.neg basic negation" {
+    const a = Fp{ .value = 100 };
+    const result = a.neg();
+    try std.testing.expect(result.value == FP_MOD - 100);
+}
+
+test "Fp.neg of zero" {
+    const a = Fp{ .value = 0 };
+    const result = a.neg();
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fp.neg of maximum value" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const result = a.neg();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.sub basic subtraction" {
+    const a = Fp{ .value = 50 };
+    const b = Fp{ .value = 20 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fp.sub with underflow" {
+    const a = Fp{ .value = 10 };
+    const b = Fp{ .value = 20 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == FP_MOD - 10);
+}
+
+test "Fp.sub with zero" {
+    const a = Fp{ .value = 100 };
+    const b = Fp{ .value = 0 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == 100);
+}
+
+test "Fp.sub from zero" {
+    const a = Fp{ .value = 0 };
+    const b = Fp{ .value = 25 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == FP_MOD - 25);
+}
+
+test "Fp.mul basic multiplication" {
+    const a = Fp{ .value = 6 };
+    const b = Fp{ .value = 5 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fp.mul with zero" {
+    const a = Fp{ .value = 100 };
+    const b = Fp{ .value = 0 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fp.mul with one" {
+    const a = Fp{ .value = 123 };
+    const b = Fp{ .value = 1 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 123);
+}
+
+test "Fp.mul with modular reduction" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const b = Fp{ .value = 2 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == FP_MOD - 2);
+}
+
+test "Fp.mul large values" {
+    const a = Fp{ .value = 0x1000000000000000000000000000000000000000000000000000000000000000 };
+    const b = Fp{ .value = 0x2000000000000000000000000000000000000000000000000000000000000000 };
+    const result = a.mul(&b);
+    // This will test the modular reduction behavior with large numbers
+    try std.testing.expect(result.value < FP_MOD);
+}
+
+test "Fp.pow basic power" {
+    const a = Fp{ .value = 2 };
+    const result = a.pow(3);
+    try std.testing.expect(result.value == 8);
+}
+
+test "Fp.pow to power of zero" {
+    const a = Fp{ .value = 123 };
+    const result = a.pow(0);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.pow to power of one" {
+    const a = Fp{ .value = 456 };
+    const result = a.pow(1);
+    try std.testing.expect(result.value == 456);
+}
+
+test "Fp.pow with base zero" {
+    const a = Fp{ .value = 0 };
+    const result = a.pow(5);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fp.pow with base one" {
+    const a = Fp{ .value = 1 };
+    const result = a.pow(100);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.pow large exponent" {
+    const a = Fp{ .value = 3 };
+    const result = a.pow(10);
+    try std.testing.expect(result.value == 59049);
+}
+
+test "Fp.pow with modular reduction" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const result = a.pow(2);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.inv basic inverse" {
+    const a = Fp{ .value = 2 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fp.inv of one" {
+    const a = Fp{ .value = 1 };
+    const result = a.inv();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.inv double inverse" {
+    const a = Fp{ .value = 17 };
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try std.testing.expect(a_double_inv.value == a.value);
+}
+
+test "Fp.inv with known value" {
+    const a = Fp{ .value = 3 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fp.inv large value" {
+    const a = Fp{ .value = 12345678 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fp.equal basic equality" {
+    const a = Fp{ .value = 123 };
+    const b = Fp{ .value = 123 };
+    try std.testing.expect(a.equal(&b));
+}
+
+test "Fp.equal different values" {
+    const a = Fp{ .value = 123 };
+    const b = Fp{ .value = 456 };
+    try std.testing.expect(!a.equal(&b));
+}
+
+test "Fp.init basic initialization" {
+    const a = Fp.init(123);
+    try std.testing.expect(a.value == 123);
+}
+
+test "Fp.init with modular reduction" {
+    const a = Fp.init(FP_MOD + 5);
+    try std.testing.expect(a.value == 5);
+}
+
+test "Fp.mul near modulus boundary" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const b = Fp{ .value = FP_MOD - 1 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp.mul maximum values causing overflow" {
+    const a = Fp{ .value = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF };
+    const b = Fp{ .value = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value < FP_MOD);
+}
+
+test "Fp.mul distributive property" {
+    const a = Fp{ .value = 123 };
+    const b = Fp{ .value = 456 };
+    const c = Fp{ .value = 789 };
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try std.testing.expect(left.equal(&right));
+}
+
+test "Fp.mul associative property" {
+    const a = Fp{ .value = 123 };
+    const b = Fp{ .value = 456 };
+    const c = Fp{ .value = 789 };
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b).mul(&c);
+    try std.testing.expect(left.equal(&right));
+}
+
+test "Fp.add modular wraparound edge case" {
+    const a = Fp{ .value = FP_MOD - 1 };
+    const b = Fp{ .value = FP_MOD - 1 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == FP_MOD - 2);
+}
+
+test "Fp.pow edge case with large exponent" {
+    const a = Fp{ .value = 2 };
+    const result = a.pow(256);
+    // 2^256 mod FP_MOD should be computed correctly
+    try std.testing.expect(result.value < FP_MOD);
+}
+
+test "Fp.inv mathematical property a * a^-1 = 1" {
+    const values = [_]u256{ 2, 3, 7, 11, 13, 17, 65537, FP_MOD - 1 };
+    for (values) |val| {
+        const a = Fp{ .value = val };
+        const a_inv = a.inv();
+        const product = a.mul(&a_inv);
+        try std.testing.expect(product.value == 1);
+    }
+}

--- a/src/crypto/bn254/Fp12.zig
+++ b/src/crypto/bn254/Fp12.zig
@@ -1,0 +1,344 @@
+const Fp6_mod = @import("Fp6.zig");
+const Fp6 = Fp6_mod.Fp6;
+const Fp = Fp6_mod.Fp;
+const Fp2_mod = @import("Fp2.zig");
+const Fp2 = Fp2_mod.Fp2;
+
+pub const Fp12 = struct {
+    w0: Fp6,
+    w1: Fp6,
+
+    pub const ZERO = Fp12{ .w0 = Fp6.ZERO, .w1 = Fp6.ZERO };
+    pub const ONE = Fp12{ .w0 = Fp6.ONE, .w1 = Fp6.ZERO };
+
+    const FROBENIUS_COEFF_Fp6 = Fp6{
+        .v0 = Fp2.init_from_int(8376118865763821496583973867626364092589906065868298776909617916018768340080, 16469823323077808223889137241176536799009286646108169935659301613961712198316),
+        .v1 = Fp2.ZERO,
+        .v2 = Fp2.ZERO,
+    };
+
+    pub fn init(w0: *const Fp6, w1: *const Fp6) Fp12 {
+        return Fp12{ .w0 = w0.*, .w1 = w1.* };
+    }
+
+    pub fn init_from_int(w0_v0_real: u256, w0_v0_imag: u256, w0_v1_real: u256, w0_v1_imag: u256, w0_v2_real: u256, w0_v2_imag: u256, w1_v0_real: u256, w1_v0_imag: u256, w1_v1_real: u256, w1_v1_imag: u256, w1_v2_real: u256, w1_v2_imag: u256) Fp12 {
+        const w0 = Fp6.init_from_int(w0_v0_real, w0_v0_imag, w0_v1_real, w0_v1_imag, w0_v2_real, w0_v2_imag);
+        const w1 = Fp6.init_from_int(w1_v0_real, w1_v0_imag, w1_v1_real, w1_v1_imag, w1_v2_real, w1_v2_imag);
+        return Fp12{
+            .w0 = w0,
+            .w1 = w1,
+        };
+    }
+
+    pub fn add(self: *const Fp12, other: *const Fp12) Fp12 {
+        return Fp12{
+            .w0 = self.w0.add(&other.w0),
+            .w1 = self.w1.add(&other.w1),
+        };
+    }
+
+    pub fn addAssign(self: *Fp12, other: *const Fp12) void {
+        self.* = self.add(other);
+    }
+
+    pub fn neg(self: *const Fp12) Fp12 {
+        return Fp12{
+            .w0 = self.w0.neg(),
+            .w1 = self.w1.neg(),
+        };
+    }
+
+    pub fn negAssign(self: *Fp12) void {
+        self.* = self.neg();
+    }
+
+    pub fn sub(self: *const Fp12, other: *const Fp12) Fp12 {
+        return Fp12{
+            .w0 = self.w0.sub(&other.w0),
+            .w1 = self.w1.sub(&other.w1),
+        };
+    }
+
+    pub fn subAssign(self: *Fp12, other: *const Fp12) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn mul(self: *const Fp12, other: *const Fp12) Fp12 {
+        const v = Fp6.init_from_int(0, 0, 1, 0, 0, 0);
+
+        const w0_mul_w0 = self.w0.mul(&other.w0);
+        const w1_mul_w1 = self.w1.mul(&other.w1);
+        const result_w0 = w0_mul_w0.add(&v.mul(&w1_mul_w1));
+
+        const result_w1 = self.w1.mul(&other.w0).add(&self.w0.mul(&other.w1));
+
+        return Fp12{
+            .w0 = result_w0,
+            .w1 = result_w1,
+        };
+    }
+
+    pub fn mulAssign(self: *Fp12, other: *const Fp12) void {
+        self.* = self.mul(other);
+    }
+
+    //we use double and add to multiply by a small integer
+    pub fn mulBySmallInt(self: *const Fp12, other: u64) Fp12 {
+        var result = ZERO;
+        var base = self.*;
+        var exp = other;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.addAssign(&base);
+        }
+        return result;
+    }
+
+    pub fn mulBySmallIntAssign(self: *Fp12, other: u64) void {
+        self.* = self.mulBySmallInt(other);
+    }
+
+    // TODO: optimize this
+    pub fn square(self: *const Fp12) Fp12 {
+        return self.mul(self);
+    }
+
+    pub fn squareAssign(self: *Fp12) void {
+        self.* = self.square();
+    }
+
+    pub fn pow(self: *const Fp12, exponent: u256) Fp12 {
+        var result = ONE;
+        var base = self.*;
+        var exp = exponent;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.mulAssign(&base);
+            }
+            base.mulAssign(&base);
+        }
+        return result;
+    }
+
+    pub fn powAssign(self: *Fp12, exponent: u256) void {
+        self.* = self.pow(exponent);
+    }
+
+    pub fn inv(self: *const Fp12) Fp12 {
+        const v = Fp6.init_from_int(0, 0, 1, 0, 0, 0);
+
+        const w0_squared = self.w0.mul(&self.w0);
+        const w1_squared = self.w1.mul(&self.w1);
+        const norm = w0_squared.sub(&v.mul(&w1_squared));
+        const norm_inv = norm.inv();
+
+        return Fp12{
+            .w0 = self.w0.mul(&norm_inv),
+            .w1 = self.w1.mul(&norm_inv).neg(),
+        };
+    }
+
+    pub fn invAssign(self: *Fp12) void {
+        self.* = self.inv();
+    }
+
+    pub fn equal(self: *const Fp12, other: *const Fp12) bool {
+        return self.w0.equal(&other.w0) and self.w1.equal(&other.w1);
+    }
+
+    pub fn frobeniusMap(self: *const Fp12) Fp12 {
+        return Fp12{
+            .w0 = self.w0.frobeniusMap(),
+            .w1 = self.w1.frobeniusMap().mul(&FROBENIUS_COEFF_Fp6),
+        };
+    }
+
+    pub fn frobeniusMapAssign(self: *Fp12) void {
+        self.* = self.frobeniusMap();
+    }
+};
+
+const std = @import("std");
+const FP_MOD = Fp6_mod.FP_MOD;
+
+// Helper function to create Fp12 from Fp6 values
+fn fp12(w0: Fp6, w1: Fp6) Fp12 {
+    return Fp12.init(w0, w1);
+}
+
+// Helper function to check Fp12 equality
+fn expectFp12Equal(expected: Fp12, actual: Fp12) !void {
+    try std.testing.expect(expected.equal(&actual));
+}
+
+test "Fp12.add basic addition" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const result = a.add(&b);
+    const expected = Fp12.init_from_int(14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36);
+    try expectFp12Equal(expected, result);
+}
+
+test "Fp12.mul distributive property over addition" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const c = Fp12.init_from_int(25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36);
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try expectFp12Equal(left, right);
+}
+
+test "Fp12.mul associative property" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const c = Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b.mul(&c));
+    try expectFp12Equal(left, right);
+}
+
+test "Fp12.mul with zero" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const zero = Fp12.ZERO;
+    const result = a.mul(&zero);
+    try expectFp12Equal(zero, result);
+}
+
+test "Fp12.mul with one" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const one = Fp12.ONE;
+    const result = a.mul(&one);
+    try expectFp12Equal(a, result);
+}
+
+test "Fp12.pow to power of zero" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.pow(0);
+    const one = Fp12.ONE;
+    try expectFp12Equal(one, result);
+}
+
+test "Fp12.pow to power of one" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.pow(1);
+    try expectFp12Equal(a, result);
+}
+
+test "Fp12.pow basic squaring" {
+    const a = Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+    const result = a.pow(2);
+    const manual_square = a.mul(&a);
+    try expectFp12Equal(manual_square, result);
+}
+
+test "Fp12.neg verification" {
+    const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
+    const neg_a = a.neg();
+    const sum = a.add(&neg_a);
+    const zero = Fp12.ZERO;
+    try expectFp12Equal(zero, sum);
+}
+
+// FERMAT'S LITTLE THEOREM TEST FOR Fp12
+test "Fp12.pow fermat's little theorem" {
+    const test_elements = [_]Fp12{
+        Fp12.ZERO, // zero
+        Fp12.ONE, // one
+        Fp12.init_from_int(2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), // simple element
+        Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // all ones
+        Fp12.init_from_int(5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43), // mixed values
+    };
+
+    for (test_elements) |a| {
+        // Test a^(p^12) == a using pow (Fermat's Little Theorem for Fp12)
+        var pow_result = a.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+
+        try expectFp12Equal(pow_result, a);
+    }
+}
+
+test "Fp12.inv basic inverse" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    const one = Fp12.ONE;
+    try expectFp12Equal(one, product);
+}
+
+test "Fp12.inv double inverse" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try expectFp12Equal(a, a_double_inv);
+}
+
+test "Fp12.inv multiplication verification" {
+    const test_elements = [_]Fp12{
+        Fp12.ONE,
+        Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+        Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+        Fp12.init_from_int(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        Fp12.init_from_int(0, 0, 0, 0, 0, 0, 3, 7, 0, 0, 0, 0),
+    };
+
+    for (test_elements) |a| {
+        const a_inv = a.inv();
+        const product1 = a.mul(&a_inv);
+        const product2 = a_inv.mul(&a);
+        const one = Fp12.ONE;
+
+        // Both a * a^-1 and a^-1 * a should equal 1
+        try expectFp12Equal(one, product1);
+        try expectFp12Equal(one, product2);
+    }
+}
+
+test "Fp12.sub basic subtraction" {
+    const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
+    const b = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.sub(&b);
+    const expected = Fp12.init_from_int(9, 18, 27, 36, 45, 54, 63, 72, 81, 90, 99, 108);
+    try expectFp12Equal(expected, result);
+}
+
+test "Fp12.mul commutativity" {
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const left = a.mul(&b);
+    const right = b.mul(&a);
+    try expectFp12Equal(left, right);
+}
+
+test "Fp12.frobeniusMap" {
+    const pts = [_]Fp12{
+        Fp12.init_from_int(3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41),
+        Fp12.init_from_int(123, 456, 789, 1011, 1213, 1415, 1617, 1819, 2021, 2223, 2425, 2627),
+        Fp12.init_from_int(999, 888, 777, 666, 555, 444, 333, 222, 111, 100, 99, 88),
+        Fp12.init_from_int(31415, 92653, 58979, 32384, 62643, 38327, 95028, 84197, 16939, 93751, 5820, 9749),
+        Fp12.init_from_int(17, 23, 31, 47, 53, 61, 67, 71, 73, 79, 83, 89),
+        Fp12.init_from_int(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+        Fp12.init_from_int(1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0),
+        Fp12.init_from_int(2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033, 2034),
+        Fp12.init_from_int(123456, 654321, 111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999, 101010),
+        Fp12.init_from_int(7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6),
+    };
+
+    for (pts) |pt| {
+        const frob_pow = pt.pow(FP_MOD);
+        const frob_map = pt.frobeniusMap();
+        try expectFp12Equal(frob_pow, frob_map);
+    }
+}

--- a/src/crypto/bn254/Fp2.zig
+++ b/src/crypto/bn254/Fp2.zig
@@ -1,0 +1,562 @@
+const fp_mod = @import("Fp.zig");
+pub const Fp = fp_mod.Fp;
+pub const FP_MOD = fp_mod.FP_MOD;
+
+pub const Fp2 = struct {
+    u0: Fp,
+    u1: Fp,
+
+    pub const ZERO = Fp2{ .u0 = Fp.ZERO, .u1 = Fp.ZERO };
+    pub const ONE = Fp2{ .u0 = Fp.ONE, .u1 = Fp.ZERO };
+
+    pub fn init(val_u0: *const Fp, val_u1: *const Fp) Fp2 {
+        return Fp2{
+            .u0 = val_u0.*,
+            .u1 = val_u1.*,
+        };
+    }
+
+    pub fn init_from_int(real: u256, imag: u256) Fp2 {
+        return Fp2{
+            .u0 = Fp.init(real),
+            .u1 = Fp.init(imag),
+        };
+    }
+
+    pub fn add(self: *const Fp2, other: *const Fp2) Fp2 {
+        return Fp2{
+            .u0 = self.u0.add(&other.u0),
+            .u1 = self.u1.add(&other.u1),
+        };
+    }
+
+    pub fn addAssign(self: *Fp2, other: *const Fp2) void {
+        self.* = self.add(other);
+    }
+
+    pub fn neg(self: *const Fp2) Fp2 {
+        return Fp2{
+            .u0 = self.u0.neg(),
+            .u1 = self.u1.neg(),
+        };
+    }
+
+    pub fn negAssign(self: *Fp2) void {
+        self.* = self.neg();
+    }
+
+    pub fn sub(self: *const Fp2, other: *const Fp2) Fp2 {
+        return Fp2{
+            .u0 = self.u0.sub(&other.u0),
+            .u1 = self.u1.sub(&other.u1),
+        };
+    }
+
+    pub fn subAssign(self: *Fp2, other: *const Fp2) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn mul(self: *const Fp2, other: *const Fp2) Fp2 {
+        const ac = self.u0.mul(&other.u0);
+        const bd = self.u1.mul(&other.u1);
+        const ad = self.u0.mul(&other.u1);
+        const bc = self.u1.mul(&other.u0);
+        const result_u0 = ac.sub(&bd);
+        const result_u1 = ad.add(&bc);
+
+        return Fp2{
+            .u0 = result_u0,
+            .u1 = result_u1,
+        };
+    }
+
+    pub fn mulAssign(self: *Fp2, other: *const Fp2) void {
+        self.* = self.mul(other);
+    }
+
+    //we use double and add to multiply by a small integer
+    pub fn mulBySmallInt(self: *const Fp2, other: u64) Fp2 {
+        var result = ZERO;
+        var base = self.*;
+        var exp = other;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.addAssign(&base);
+        }
+        return result;
+    }
+
+    pub fn mulBySmallIntAssign(self: *Fp2, other: u64) void {
+        self.* = self.mulBySmallInt(other);
+    }
+
+    // TODO: optimize this
+    pub fn square(self: *const Fp2) Fp2 {
+        return self.mul(self);
+    }
+
+    pub fn squareAssign(self: *Fp2) void {
+        self.* = self.square();
+    }
+
+    pub fn pow(self: *const Fp2, exponent: u256) Fp2 {
+        var result = ONE;
+        var base = self.*;
+        var exp = exponent;
+        while (exp > 0) {
+            if (exp & 1 == 1) {
+                result.mulAssign(&base);
+            }
+            base.mulAssign(&base);
+            exp >>= 1;
+        }
+        return result;
+    }
+
+    pub fn powAssign(self: *Fp2, exponent: u256) void {
+        self.* = self.pow(exponent);
+    }
+
+    pub fn norm(self: *const Fp2) Fp {
+        const real_sq = self.u0.mul(&self.u0);
+        const imag_sq = self.u1.mul(&self.u1);
+        return real_sq.add(&imag_sq);
+    }
+
+    pub fn conj(self: *const Fp2) Fp2 {
+        return Fp2{
+            .u0 = self.u0,
+            .u1 = self.u1.neg(),
+        };
+    }
+
+    pub fn conjAssign(self: *Fp2) void {
+        self.* = self.conj();
+    }
+
+    pub fn scalarMul(self: *const Fp2, scalar: *const Fp) Fp2 {
+        return Fp2{
+            .u0 = self.u0.mul(scalar),
+            .u1 = self.u1.mul(scalar),
+        };
+    }
+
+    pub fn scalarMulAssign(self: *Fp2, scalar: *const Fp) void {
+        self.* = self.scalarMul(scalar);
+    }
+
+    pub fn inv(self: *const Fp2) Fp2 {
+        const norm_val = self.norm();
+        const norm_inv = norm_val.inv();
+        const conj_val = self.conj();
+        return conj_val.scalarMul(&norm_inv);
+    }
+
+    pub fn invAssign(self: *Fp2) void {
+        self.* = self.inv();
+    }
+
+    pub fn equal(self: *const Fp2, other: *const Fp2) bool {
+        return self.u0.equal(&other.u0) and self.u1.equal(&other.u1);
+    }
+
+    pub fn frobeniusMap(self: *const Fp2) Fp2 {
+        return self.conj();
+    }
+
+    pub fn frobeniusMapAssign(self: *Fp2) void {
+        self.* = self.frobeniusMap();
+    }
+};
+
+const std = @import("std");
+
+// Helper function to create Fp2 from integers
+fn fp2(real: u256, imag: u256) Fp2 {
+    return Fp2{ .u0 = Fp{ .value = real }, .u1 = Fp{ .value = imag } };
+}
+
+// Helper function to check Fp2 equality
+fn expectFp2Equal(expected: Fp2, actual: Fp2) !void {
+    try std.testing.expect(expected.u0.value == actual.u0.value);
+    try std.testing.expect(expected.u1.value == actual.u1.value);
+}
+
+test "Fp2.add basic addition" {
+    const a = fp2(10, 20);
+    const b = fp2(30, 40);
+    const result = a.add(&b);
+    try expectFp2Equal(fp2(40, 60), result);
+}
+
+test "Fp2.add with zero" {
+    const a = fp2(100, 200);
+    const zero = fp2(0, 0);
+    const result = a.add(&zero);
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.add commutative property" {
+    const a = fp2(15, 25);
+    const b = fp2(35, 45);
+    const result1 = a.add(&b);
+    const result2 = b.add(&a);
+    try expectFp2Equal(result1, result2);
+}
+
+test "Fp2.neg basic negation" {
+    const a = fp2(100, 200);
+    const result = a.neg();
+    const expected = fp2(FP_MOD - 100, FP_MOD - 200);
+    try expectFp2Equal(expected, result);
+}
+
+test "Fp2.neg double negation" {
+    const a = fp2(123, 456);
+    const result = a.neg().neg();
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.neg of zero" {
+    const zero = fp2(0, 0);
+    const result = zero.neg();
+    const expected = fp2(0, 0);
+    try expectFp2Equal(expected, result);
+}
+
+test "Fp2.sub basic subtraction" {
+    const a = fp2(50, 80);
+    const b = fp2(20, 30);
+    const result = a.sub(&b);
+    try expectFp2Equal(fp2(30, 50), result);
+}
+
+test "Fp2.sub with zero" {
+    const a = fp2(100, 200);
+    const zero = fp2(0, 0);
+    const result = a.sub(&zero);
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.sub from zero" {
+    const a = fp2(25, 35);
+    const zero = fp2(0, 0);
+    const result = zero.sub(&a);
+    try expectFp2Equal(a.neg(), result);
+}
+
+test "Fp2.mul basic multiplication" {
+    const a = fp2(3, 4);
+    const b = fp2(1, 2);
+    const result = a.mul(&b);
+    // (3 + 4i)(1 + 2i) = 3 + 6i + 4i + 8i^2 = 3 + 10i - 8 = -5 + 10i
+    const expected = fp2(FP_MOD - 5, 10);
+    try expectFp2Equal(expected, result);
+}
+
+test "Fp2.mul with zero" {
+    const a = fp2(100, 200);
+    const zero = fp2(0, 0);
+    const result = a.mul(&zero);
+    try expectFp2Equal(zero, result);
+}
+
+test "Fp2.mul with one" {
+    const a = fp2(123, 456);
+    const one = fp2(1, 0);
+    const result = a.mul(&one);
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.mul with i" {
+    const a = fp2(5, 7);
+    const i = fp2(0, 1);
+    const result = a.mul(&i);
+    // (5 + 7i)(0 + 1i) = 0 + 5i + 0 + 7i^2 = 5i - 7 = -7 + 5i
+    const expected = fp2(FP_MOD - 7, 5);
+    try expectFp2Equal(expected, result);
+}
+
+test "Fp2.mul commutative property" {
+    const a = fp2(6, 8);
+    const b = fp2(3, 5);
+    const result1 = a.mul(&b);
+    const result2 = b.mul(&a);
+    try expectFp2Equal(result1, result2);
+}
+
+test "Fp2.pow to power of zero" {
+    const a = fp2(123, 456);
+    const result = a.pow(0);
+    try expectFp2Equal(fp2(1, 0), result);
+}
+
+test "Fp2.pow to power of one" {
+    const a = fp2(123, 456);
+    const result = a.pow(1);
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.pow basic power" {
+    const a = fp2(2, 1);
+    const result = a.pow(2);
+    // (2 + i)^2 = 4 + 4i + i^2 = 4 + 4i - 1 = 3 + 4i
+    try expectFp2Equal(fp2(3, 4), result);
+}
+
+test "Fp2.pow of i" {
+    const i = fp2(0, 1);
+    const result = i.pow(2);
+    // i^2 = -1
+    try expectFp2Equal(fp2(FP_MOD - 1, 0), result);
+}
+
+test "Fp2.norm basic norm" {
+    const a = fp2(3, 4);
+    const result = a.norm();
+    // norm(3 + 4i) = 3^2 + 4^2 = 9 + 16 = 25
+    try std.testing.expect(result.value == 25);
+}
+
+test "Fp2.norm of zero" {
+    const zero = fp2(0, 0);
+    const result = zero.norm();
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fp2.norm of one" {
+    const one = fp2(1, 0);
+    const result = one.norm();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp2.norm of i" {
+    const i = fp2(0, 1);
+    const result = i.norm();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fp2.conj basic conjugate" {
+    const a = fp2(5, 7);
+    const result = a.conj();
+    try expectFp2Equal(fp2(5, FP_MOD - 7), result);
+}
+
+test "Fp2.conj double conjugate" {
+    const a = fp2(123, 456);
+    const result = a.conj().conj();
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.conj of real number" {
+    const a = fp2(100, 0);
+    const result = a.conj();
+    const expected = fp2(100, 0); // neg(0) = FP_MOD in finite field
+    try expectFp2Equal(expected, result);
+}
+
+test "Fp2.conj mathematical property" {
+    const a = fp2(50, 75);
+    const conj_a = a.conj();
+    const product = a.mul(&conj_a);
+    const norm_squared = a.norm();
+    // a * conj(a) should equal norm(a)
+    try expectFp2Equal(fp2(norm_squared.value, 0), product);
+}
+
+test "Fp2.scalarMul basic scalar multiplication" {
+    const a = fp2(3, 4);
+    const scalar = Fp{ .value = 5 };
+    const result = a.scalarMul(&scalar);
+    try expectFp2Equal(fp2(15, 20), result);
+}
+
+test "Fp2.scalarMul with zero" {
+    const a = fp2(10, 20);
+    const zero = Fp{ .value = 0 };
+    const result = a.scalarMul(&zero);
+    try expectFp2Equal(fp2(0, 0), result);
+}
+
+test "Fp2.scalarMul with one" {
+    const a = fp2(123, 456);
+    const one = Fp{ .value = 1 };
+    const result = a.scalarMul(&one);
+    try expectFp2Equal(a, result);
+}
+
+test "Fp2.inv basic inverse" {
+    const a = fp2(3, 4);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    // Should be approximately (1, 0)
+    try expectFp2Equal(fp2(1, 0), product);
+}
+
+test "Fp2.inv of one" {
+    const one = fp2(1, 0);
+    const result = one.inv();
+    try expectFp2Equal(one, result);
+}
+
+test "Fp2.inv double inverse" {
+    const a = fp2(17, 23);
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try expectFp2Equal(a, a_double_inv);
+}
+
+test "Fp2.inv of i" {
+    const i = fp2(0, 1);
+    const i_inv = i.inv();
+    const product = i.mul(&i_inv);
+    try expectFp2Equal(fp2(1, 0), product);
+}
+
+test "Fp2.equal basic equality" {
+    const a = fp2(123, 456);
+    const b = fp2(123, 456);
+    try std.testing.expect(a.equal(&b));
+}
+
+test "Fp2.equal different values" {
+    const a = fp2(123, 456);
+    const b = fp2(789, 456);
+    try std.testing.expect(!a.equal(&b));
+}
+
+test "Fp2.equal different imaginary parts" {
+    const a = fp2(123, 456);
+    const b = fp2(123, 789);
+    try std.testing.expect(!a.equal(&b));
+}
+
+test "Fp2.equal with zero" {
+    const a = fp2(0, 0);
+    const b = fp2(0, 0);
+    try std.testing.expect(a.equal(&b));
+}
+
+test "Fp2.equal reflexive property" {
+    const a = fp2(111, 222);
+    try std.testing.expect(a.equal(&a));
+}
+
+test "Fp2.equal symmetric property" {
+    const a = fp2(333, 444);
+    const b = fp2(333, 444);
+    try std.testing.expect(a.equal(&b));
+    try std.testing.expect(b.equal(&a));
+}
+
+test "Fp2.equal one component different" {
+    const a = fp2(100, 200);
+    const b = fp2(100, 201);
+    const c = fp2(101, 200);
+    try std.testing.expect(!a.equal(&b));
+    try std.testing.expect(!a.equal(&c));
+}
+
+test "Fp2.init basic initialization" {
+    const a = Fp2.init_from_int(123, 456);
+    try std.testing.expect(a.u0.value == 123);
+    try std.testing.expect(a.u1.value == 456);
+}
+
+test "Fp2.init with modular reduction" {
+    const a = Fp2.init_from_int(FP_MOD + 5, FP_MOD + 10);
+    try std.testing.expect(a.u0.value == 5);
+    try std.testing.expect(a.u1.value == 10);
+}
+
+test "Fp2.mul complex edge cases near modulus" {
+    const a = fp2(FP_MOD - 1, FP_MOD - 1);
+    const b = fp2(FP_MOD - 1, FP_MOD - 1);
+    const result = a.mul(&b);
+    // (FP_MOD-1 + (FP_MOD-1)i)^2 = (FP_MOD-1)^2 - (FP_MOD-1)^2 + 2(FP_MOD-1)^2 i = 2(FP_MOD-1)^2 i
+    try std.testing.expect(result.u0.value == 0);
+    try std.testing.expect(result.u1.value == 2); // Since (FP_MOD-1)^2 ≡ 1 (mod FP_MOD)
+}
+
+test "Fp2.mul distributive property over addition" {
+    const a = fp2(123, 456);
+    const b = fp2(789, 321);
+    const c = fp2(654, 987);
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try expectFp2Equal(left, right);
+}
+
+test "Fp2.mul associative property" {
+    const a = fp2(12, 34);
+    const b = fp2(56, 78);
+    const c = fp2(91, 23);
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b).mul(&c);
+    try expectFp2Equal(left, right);
+}
+
+test "Fp2.mul by complex conjugate gives norm" {
+    const a = fp2(123, 456);
+    const conj_a = a.conj();
+    const product = a.mul(&conj_a);
+    const norm_a = a.norm();
+    try expectFp2Equal(fp2(norm_a.value, 0), product);
+}
+
+test "Fp2.mul i properties" {
+    const i = fp2(0, 1);
+    const i_squared = i.mul(&i);
+    try expectFp2Equal(fp2(FP_MOD - 1, 0), i_squared); // i^2 = -1
+
+    const i_cubed = i_squared.mul(&i);
+    try expectFp2Equal(fp2(0, FP_MOD - 1), i_cubed); // i^3 = -i
+
+    const i_fourth = i_cubed.mul(&i);
+    try expectFp2Equal(fp2(1, 0), i_fourth); // i^4 = 1
+}
+
+test "Fp2.pow complex exponentiation edge cases" {
+    const a = fp2(2, 3);
+    const a_256 = a.pow(256);
+    // Should compute correctly without overflow
+    try std.testing.expect(a_256.u0.value < FP_MOD);
+    try std.testing.expect(a_256.u1.value < FP_MOD);
+
+    // Test that a^0 = 1 for any non-zero a
+    const a_zero = a.pow(0);
+    try expectFp2Equal(fp2(1, 0), a_zero);
+}
+
+test "Fp2.norm multiplicative property" {
+    const a = fp2(12, 34);
+    const b = fp2(56, 78);
+    const product = a.mul(&b);
+    const norm_product = product.norm();
+    const product_norms = a.norm().mul(&b.norm());
+    try std.testing.expect(norm_product.equal(&product_norms));
+}
+
+test "Fp2.inv edge cases with large values" {
+    const a = fp2(FP_MOD - 100, FP_MOD - 200);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try expectFp2Equal(fp2(1, 0), product);
+}
+
+test "Fp2.add/sub near modulus boundaries" {
+    const a = fp2(FP_MOD - 5, FP_MOD - 10);
+    const b = fp2(10, 20);
+    const sum = a.add(&b);
+    const diff = a.sub(&b);
+
+    // Addition should wrap correctly
+    try std.testing.expect(sum.u0.value == 5);
+    try std.testing.expect(sum.u1.value == 10);
+
+    // Subtraction should handle underflow correctly
+    try std.testing.expect(diff.u0.value == FP_MOD - 15);
+    try std.testing.expect(diff.u1.value == FP_MOD - 30);
+}

--- a/src/crypto/bn254/Fp6.zig
+++ b/src/crypto/bn254/Fp6.zig
@@ -1,0 +1,393 @@
+const Fp2_mod = @import("Fp2.zig");
+const Fp2 = Fp2_mod.Fp2;
+const Fp = Fp2_mod.Fp;
+pub const FP_MOD = Fp2_mod.FP_MOD;
+
+pub const Fp6 = struct {
+    v0: Fp2,
+    v1: Fp2,
+    v2: Fp2,
+
+    pub const ZERO = Fp6{ .v0 = Fp2.ZERO, .v1 = Fp2.ZERO, .v2 = Fp2.ZERO };
+    pub const ONE = Fp6{ .v0 = Fp2.ONE, .v1 = Fp2.ZERO, .v2 = Fp2.ZERO };
+
+    pub const FROBENIUS_COEFF_V1 = Fp2.init_from_int(21575463638280843010398324269430826099269044274347216827212613867836435027261, 10307601595873709700152284273816112264069230130616436755625194854815875713954);
+    pub const FROBENIUS_COEFF_V2 = Fp2.init_from_int(2581911344467009335267311115468803099551665605076196740867805258568234346338, 19937756971775647987995932169929341994314640652964949448313374472400716661030);
+
+    pub fn init(val_v0: *const Fp2, val_v1: *const Fp2, val_v2: *const Fp2) Fp6 {
+        return Fp6{
+            .v0 = val_v0.*,
+            .v1 = val_v1.*,
+            .v2 = val_v2.*,
+        };
+    }
+
+    pub fn init_from_int(v0_real: u256, v0_imag: u256, v1_real: u256, v1_imag: u256, v2_real: u256, v2_imag: u256) Fp6 {
+        return Fp6{
+            .v0 = Fp2.init_from_int(v0_real, v0_imag),
+            .v1 = Fp2.init_from_int(v1_real, v1_imag),
+            .v2 = Fp2.init_from_int(v2_real, v2_imag),
+        };
+    }
+
+    pub fn add(self: *const Fp6, other: *const Fp6) Fp6 {
+        return Fp6{
+            .v0 = self.v0.add(&other.v0),
+            .v1 = self.v1.add(&other.v1),
+            .v2 = self.v2.add(&other.v2),
+        };
+    }
+
+    pub fn addAssign(self: *Fp6, other: *const Fp6) void {
+        self.* = self.add(other);
+    }
+
+    pub fn neg(self: *const Fp6) Fp6 {
+        return Fp6{
+            .v0 = self.v0.neg(),
+            .v1 = self.v1.neg(),
+            .v2 = self.v2.neg(),
+        };
+    }
+
+    pub fn negAssign(self: *Fp6) void {
+        self.* = self.neg();
+    }
+
+    pub fn sub(self: *const Fp6, other: *const Fp6) Fp6 {
+        return Fp6{
+            .v0 = self.v0.sub(&other.v0),
+            .v1 = self.v1.sub(&other.v1),
+            .v2 = self.v2.sub(&other.v2),
+        };
+    }
+
+    pub fn subAssign(self: *Fp6, other: *const Fp6) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn mul(self: *const Fp6, other: *const Fp6) Fp6 {
+        // ξ = 9 + u ∈ Fp2
+        const xi = Fp2.init_from_int(9, 1);
+
+        // s0 = a0 * b0, s1 = a1 * b1, s2 = a2 * b2
+        const s0 = self.v0.mul(&other.v0);
+        const s1 = self.v1.mul(&other.v1);
+        const s2 = self.v2.mul(&other.v2);
+
+        // t0 = (a1 + a2) * (b1 + b2)
+        // t1 = (a0 + a1) * (b0 + b1)
+        // t2 = (a0 + a2) * (b0 + b2)
+        const t0 = self.v1.add(&self.v2).mul(&other.v1.add(&other.v2));
+        const t1 = self.v0.add(&self.v1).mul(&other.v0.add(&other.v1));
+        const t2 = self.v0.add(&self.v2).mul(&other.v0.add(&other.v2));
+
+        // tmp0 = t0 - s1 - s2
+        // tmp1 = t1 - s0 - s1
+        // tmp2 = t2 - s0 - s2
+        const tmp0 = t0.sub(&s1).sub(&s2);
+        const tmp1 = t1.sub(&s0).sub(&s1);
+        const tmp2 = t2.sub(&s0).sub(&s2);
+
+        // c0 = s0 + ξ * tmp0
+        // c1 = tmp1 + ξ * s2
+        // c2 = tmp2 + s1
+        const c0 = s0.add(&xi.mul(&tmp0));
+        const c1 = tmp1.add(&xi.mul(&s2));
+        const c2 = tmp2.add(&s1);
+
+        return Fp6{
+            .v0 = c0,
+            .v1 = c1,
+            .v2 = c2,
+        };
+    }
+
+    pub fn mulAssign(self: *Fp6, other: *const Fp6) void {
+        self.* = self.mul(other);
+    }
+
+    //we use double and add to multiply by a small integer
+    pub fn mulBySmallInt(self: *const Fp6, other: u64) Fp6 {
+        var result = ZERO;
+        var base = self.*;
+        var exp = other;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.addAssign(&base);
+        }
+        return result;
+    }
+
+    pub fn mulBySmallIntAssign(self: *Fp6, other: u64) void {
+        self.* = self.mulBySmallInt(other);
+    }
+
+    // TODO: optimize this
+    pub fn square(self: *const Fp6) Fp6 {
+        return self.mul(self);
+    }
+
+    pub fn squareAssign(self: *Fp6) void {
+        self.* = self.square();
+    }
+
+    pub fn pow(self: *const Fp6, exponent: u256) Fp6 {
+        var result = ONE;
+        var base = self.*;
+        var exp = exponent;
+        while (exp > 0) {
+            if (exp & 1 == 1) {
+                result.mulAssign(&base);
+            }
+            base.mulAssign(&base);
+            exp >>= 1;
+        }
+        return result;
+    }
+
+    pub fn powAssign(self: *Fp6, exponent: u256) void {
+        self.* = self.pow(exponent);
+    }
+
+    pub fn norm(self: *const Fp6) Fp2 {
+        const xi = Fp2.init_from_int(9, 1);
+
+        // c0 = v0^2 - ξ * (v1 * v2)
+        const c0 = self.v0.mul(&self.v0).sub(&xi.mul(&self.v1.mul(&self.v2)));
+
+        // c1 = ξ * v2^2 - v0 * v1
+        const c1 = xi.mul(&self.v2.mul(&self.v2)).sub(&self.v0.mul(&self.v1));
+
+        // c2 = v1^2 - v0 * v2
+        const c2 = self.v1.mul(&self.v1).sub(&self.v0.mul(&self.v2));
+
+        // norm_result = v0 * c0 + ξ * (v2 * c1 + v1 * c2)
+        return self.v0.mul(&c0).add(&xi.mul(&self.v2.mul(&c1).add(&self.v1.mul(&c2))));
+    }
+
+    pub fn scalarMul(self: *const Fp6, scalar: *const Fp) Fp6 {
+        return Fp6{
+            .v0 = self.v0.scalarMul(scalar),
+            .v1 = self.v1.scalarMul(scalar),
+            .v2 = self.v2.scalarMul(scalar),
+        };
+    }
+
+    pub fn scalarMulAssign(self: *Fp6, scalar: *const Fp) void {
+        self.* = self.scalarMul(scalar);
+    }
+
+    pub fn inv(self: *const Fp6) Fp6 {
+        const xi = Fp2.init_from_int(9, 1);
+        const three = Fp.init(3);
+
+        // Calculate squares and basic products
+        const v0_sq = self.v0.mul(&self.v0);
+        const v1_sq = self.v1.mul(&self.v1);
+        const v2_sq = self.v2.mul(&self.v2);
+        const v2_xi = self.v2.mul(&xi);
+        const v1_v0 = self.v1.mul(&self.v0);
+
+        // Calculate norm factor components
+        const D1 = v2_sq.mul(&v2_xi).mul(&xi);
+        const D2 = v1_v0.mul(&v2_xi).scalarMul(&three);
+        const D3 = v1_sq.mul(&self.v1).mul(&xi);
+        const D4 = v0_sq.mul(&self.v0);
+
+        const norm_factor = D1.sub(&D2).add(&D3).add(&D4);
+        const norm_factor_inv = norm_factor.inv();
+
+        // Calculate result components
+        const result_v0 = v0_sq.sub(&v2_xi.mul(&self.v1));
+        const result_v1 = v2_sq.mul(&xi).sub(&v1_v0);
+        const result_v2 = v1_sq.sub(&self.v0.mul(&self.v2));
+
+        return Fp6{
+            .v0 = result_v0.mul(&norm_factor_inv),
+            .v1 = result_v1.mul(&norm_factor_inv),
+            .v2 = result_v2.mul(&norm_factor_inv),
+        };
+    }
+
+    pub fn invAssign(self: *Fp6) void {
+        self.* = self.inv();
+    }
+
+    pub fn equal(self: *const Fp6, other: *const Fp6) bool {
+        return self.v0.equal(&other.v0) and self.v1.equal(&other.v1) and self.v2.equal(&other.v2);
+    }
+
+    pub fn frobeniusMap(self: *const Fp6) Fp6 {
+        return Fp6{
+            .v0 = self.v0.frobeniusMap(),
+            .v1 = self.v1.frobeniusMap().mul(&FROBENIUS_COEFF_V1),
+            .v2 = self.v2.frobeniusMap().mul(&FROBENIUS_COEFF_V2),
+        };
+    }
+
+    pub fn frobeniusMapAssign(self: *Fp6) void {
+        self.v0.frobeniusMapAssign();
+        self.v1.frobeniusMapAssign();
+        self.v2.frobeniusMapAssign();
+    }
+
+    pub fn print(self: *const Fp6) void {
+        std.debug.print("Fp6(\n", .{});
+        std.debug.print("  v0: (0x{x}+ u * 0x{x}),\n", .{ self.v0.u0.value, self.v0.u1.value });
+        std.debug.print("  v1: (0x{x}+ u * 0x{x}),\n", .{ self.v1.u0.value, self.v1.u1.value });
+        std.debug.print("  v2: (0x{x}+ u * 0x{x})\n", .{ self.v2.u0.value, self.v2.u1.value });
+        std.debug.print(")\n", .{});
+    }
+};
+
+const std = @import("std");
+
+// Helper function to check Fp6 equality
+fn expectFp6Equal(expected: Fp6, actual: Fp6) !void {
+    try std.testing.expect(expected.equal(&actual));
+}
+
+test "Fp6.equal basic equality" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    try std.testing.expect(a.equal(&b));
+}
+
+test "Fp6.add basic addition" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const result = a.add(&b);
+    const expected = Fp6.init_from_int(8, 10, 12, 14, 16, 18);
+    try expectFp6Equal(expected, result);
+}
+
+test "Fp6.mul distributive property over addition" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const c = Fp6.init_from_int(13, 14, 15, 16, 17, 18);
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try expectFp6Equal(left, right);
+}
+
+test "Fp6.mul associative property" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const c = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b.mul(&c));
+    try expectFp6Equal(left, right);
+}
+
+test "Fp6.mul with zero" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
+    const result = a.mul(&zero);
+    try expectFp6Equal(zero, result);
+}
+
+test "Fp6.mul with one" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    const result = a.mul(&one);
+    try expectFp6Equal(a, result);
+}
+
+test "Fp6.pow to power of zero" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const result = a.pow(0);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    try expectFp6Equal(one, result);
+}
+
+test "Fp6.pow to power of one" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const result = a.pow(1);
+    try expectFp6Equal(a, result);
+}
+
+test "Fp6.pow basic squaring" {
+    const a = Fp6.init_from_int(1, 1, 1, 1, 1, 1);
+    const result = a.pow(2);
+    const manual_square = a.mul(&a);
+    try expectFp6Equal(manual_square, result);
+}
+
+test "Fp6.norm multiplicative property" {
+    const a = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
+    const b = Fp6.init_from_int(8, 9, 10, 11, 12, 13);
+    const product = a.mul(&b);
+    const norm_product = product.norm();
+    const product_norms = a.norm().mul(&b.norm());
+    try std.testing.expect(norm_product.equal(&product_norms));
+}
+
+test "Fp6.neg verification" {
+    const a = Fp6.init_from_int(10, 20, 30, 40, 50, 60);
+    const neg_a = a.neg();
+    const sum = a.add(&neg_a);
+    const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
+    try expectFp6Equal(zero, sum);
+}
+
+// FERMAT'S LITTLE THEOREM TEST
+test "Fp6.mul fermat's little theorem" {
+    const test_elements = [_]Fp6{
+        Fp6.init_from_int(0, 0, 0, 0, 0, 0), // zero
+        Fp6.init_from_int(1, 0, 0, 0, 0, 0), // one
+        Fp6.init_from_int(2, 3, 0, 0, 0, 0), // simple element
+        Fp6.init_from_int(1, 1, 1, 1, 1, 1), // all ones
+        Fp6.init_from_int(5, 7, 11, 13, 17, 19), // mixed values
+    };
+
+    for (test_elements) |a| {
+        // Test a^(p^6)==a using pow
+        var pow_result = a.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+
+        try expectFp6Equal(pow_result, a);
+    }
+}
+
+test "Fp6.inv basic inverse" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    try expectFp6Equal(one, product);
+}
+
+test "Fp6.inv double inverse" {
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try expectFp6Equal(a, a_double_inv);
+}
+
+test "Fp6.frobeniusMap" {
+    const pts = [_]Fp6{
+        Fp6.init_from_int(3, 5, 7, 11, 13, 17),
+        Fp6.init_from_int(123, 456, 789, 1011, 1213, 1415),
+        Fp6.init_from_int(999, 888, 777, 666, 555, 444),
+        Fp6.init_from_int(31415, 92653, 58979, 32384, 62643, 38327),
+        Fp6.init_from_int(17, 23, 31, 47, 53, 61),
+        Fp6.init_from_int(0, 1, 2, 3, 4, 5),
+        Fp6.init_from_int(1, 0, 0, 1, 1, 1),
+        Fp6.init_from_int(2023, 2024, 2025, 2026, 2027, 2028),
+        Fp6.init_from_int(123456, 654321, 111111, 222222, 333333, 444444),
+        Fp6.init_from_int(7, 6, 5, 4, 3, 2),
+    };
+
+    for (pts) |pt| {
+        const frob_pow = pt.pow(FP_MOD);
+        const frob_map = pt.frobeniusMap();
+        try expectFp6Equal(frob_pow, frob_map);
+    }
+}

--- a/src/crypto/bn254/Fr.zig
+++ b/src/crypto/bn254/Fr.zig
@@ -1,0 +1,345 @@
+const std = @import("std");
+
+pub const FR_MOD = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+
+pub const Fr = struct {
+    value: u256,
+
+    pub const ZERO = Fr{ .value = 0 };
+    pub const ONE = Fr{ .value = 1 };
+
+    pub fn init(value: u256) Fr {
+        return Fr{
+            .value = value % FR_MOD,
+        };
+    }
+
+    pub fn add(self: *const Fr, other: *const Fr) Fr {
+        const sum = self.value + other.value;
+        return Fr{
+            .value = if (sum >= FR_MOD) sum - FR_MOD else sum,
+        };
+    }
+
+    pub fn addAssign(self: *Fr, other: *const Fr) void {
+        self.* = self.add(other);
+    }
+
+    pub fn neg(self: *const Fr) Fr {
+        return Fr{
+            .value = if (self.value == 0) 0 else FR_MOD - self.value,
+        };
+    }
+
+    pub fn negAssign(self: *Fr) void {
+        self.* = self.neg();
+    }
+
+    pub fn sub(self: *const Fr, other: *const Fr) Fr {
+        return self.add(&other.neg());
+    }
+
+    pub fn subAssign(self: *Fr, other: *const Fr) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn mul(self: *const Fr, other: *const Fr) Fr {
+        const product = @as(u512, self.value) * @as(u512, other.value);
+        return Fr{
+            .value = @intCast(product % FR_MOD),
+        };
+    }
+
+    pub fn mulAssign(self: *Fr, other: *const Fr) void {
+        self.* = self.mul(other);
+    }
+
+    pub fn pow(self: *const Fr, exponent: u256) Fr {
+        var result = ONE;
+        var base = self.*;
+        var exp = exponent;
+        while (exp > 0) {
+            if (exp & 1 == 1) {
+                result.mulAssign(&base);
+            }
+            base.mulAssign(&base);
+            exp >>= 1;
+        }
+        return result;
+    }
+
+    pub fn powAssign(self: *Fr, exponent: u256) void {
+        self.* = self.pow(exponent);
+    }
+
+    // Fermat's little theorem: a^(p-1) = 1 (mod p)
+    // disgustingly slow, temporary solution
+    pub fn inv(self: *const Fr) Fr {
+        return self.pow(FR_MOD - 2);
+    }
+
+    pub fn invAssign(self: *Fr) void {
+        self.* = self.inv();
+    }
+
+    pub fn equal(self: *const Fr, other: *const Fr) bool {
+        return self.value == other.value;
+    }
+};
+
+test "Fr.add basic addition" {
+    const a = Fr{ .value = 10 };
+    const b = Fr{ .value = 20 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fr.add with modular reduction" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const b = Fr{ .value = 5 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 4);
+}
+
+test "Fr.add with zero" {
+    const a = Fr{ .value = 100 };
+    const b = Fr{ .value = 0 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 100);
+}
+
+test "Fr.add resulting in modulus" {
+    const a = Fr{ .value = FR_MOD - 10 };
+    const b = Fr{ .value = 10 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fr.neg basic negation" {
+    const a = Fr{ .value = 100 };
+    const result = a.neg();
+    try std.testing.expect(result.value == FR_MOD - 100);
+}
+
+test "Fr.neg of zero" {
+    const a = Fr{ .value = 0 };
+    const result = a.neg();
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fr.neg of maximum value" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const result = a.neg();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.sub basic subtraction" {
+    const a = Fr{ .value = 50 };
+    const b = Fr{ .value = 20 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fr.sub with underflow" {
+    const a = Fr{ .value = 10 };
+    const b = Fr{ .value = 20 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == FR_MOD - 10);
+}
+
+test "Fr.sub with zero" {
+    const a = Fr{ .value = 100 };
+    const b = Fr{ .value = 0 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == 100);
+}
+
+test "Fr.sub from zero" {
+    const a = Fr{ .value = 0 };
+    const b = Fr{ .value = 25 };
+    const result = a.sub(&b);
+    try std.testing.expect(result.value == FR_MOD - 25);
+}
+
+test "Fr.mul basic multiplication" {
+    const a = Fr{ .value = 6 };
+    const b = Fr{ .value = 5 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 30);
+}
+
+test "Fr.mul with zero" {
+    const a = Fr{ .value = 100 };
+    const b = Fr{ .value = 0 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fr.mul with one" {
+    const a = Fr{ .value = 123 };
+    const b = Fr{ .value = 1 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 123);
+}
+
+test "Fr.mul with modular reduction" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const b = Fr{ .value = 2 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == FR_MOD - 2);
+}
+
+test "Fr.mul large values" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const b = Fr{ .value = FR_MOD - 5 };
+    const result = a.mul(&b);
+    // This will test the modular reduction behavior with large numbers
+    try std.testing.expect(result.value == 5);
+}
+
+test "Fr.pow basic power" {
+    const a = Fr{ .value = 2 };
+    const result = a.pow(3);
+    try std.testing.expect(result.value == 8);
+}
+
+test "Fr.pow to power of zero" {
+    const a = Fr{ .value = 123 };
+    const result = a.pow(0);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.pow to power of one" {
+    const a = Fr{ .value = 456 };
+    const result = a.pow(1);
+    try std.testing.expect(result.value == 456);
+}
+
+test "Fr.pow with base zero" {
+    const a = Fr{ .value = 0 };
+    const result = a.pow(5);
+    try std.testing.expect(result.value == 0);
+}
+
+test "Fr.pow with base one" {
+    const a = Fr{ .value = 1 };
+    const result = a.pow(100);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.pow large exponent" {
+    const a = Fr{ .value = 3 };
+    const result = a.pow(10);
+    try std.testing.expect(result.value == 59049);
+}
+
+test "Fr.pow with modular reduction" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const result = a.pow(2);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.inv basic inverse" {
+    const a = Fr{ .value = 2 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fr.inv of one" {
+    const a = Fr{ .value = 1 };
+    const result = a.inv();
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.inv double inverse" {
+    const a = Fr{ .value = 17 };
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try std.testing.expect(a_double_inv.value == a.value);
+}
+
+test "Fr.inv with known value" {
+    const a = Fr{ .value = 3 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fr.inv large value" {
+    const a = Fr{ .value = 12345678 };
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    try std.testing.expect(product.value == 1);
+}
+
+test "Fr.equal basic equality" {
+    const a = Fr{ .value = 123 };
+    const b = Fr{ .value = 123 };
+    try std.testing.expect(a.equal(&b));
+}
+
+test "Fr.equal different values" {
+    const a = Fr{ .value = 123 };
+    const b = Fr{ .value = 456 };
+    try std.testing.expect(!a.equal(&b));
+}
+
+test "Fr.init basic initialization" {
+    const a = Fr.init(123);
+    try std.testing.expect(a.value == 123);
+}
+
+test "Fr.init with modular reduction" {
+    const a = Fr.init(FR_MOD + 5);
+    try std.testing.expect(a.value == 5);
+}
+
+test "Fr.mul near modulus boundary" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const b = Fr{ .value = FR_MOD - 1 };
+    const result = a.mul(&b);
+    try std.testing.expect(result.value == 1);
+}
+
+test "Fr.mul distributive property" {
+    const a = Fr{ .value = 123 };
+    const b = Fr{ .value = 456 };
+    const c = Fr{ .value = 789 };
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try std.testing.expect(left.equal(&right));
+}
+
+test "Fr.mul associative property" {
+    const a = Fr{ .value = 123 };
+    const b = Fr{ .value = 456 };
+    const c = Fr{ .value = 789 };
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b).mul(&c);
+    try std.testing.expect(left.equal(&right));
+}
+
+test "Fr.add modular wraparound edge case" {
+    const a = Fr{ .value = FR_MOD - 1 };
+    const b = Fr{ .value = FR_MOD - 1 };
+    const result = a.add(&b);
+    try std.testing.expect(result.value == FR_MOD - 2);
+}
+
+test "Fr.pow edge case with large exponent" {
+    const a = Fr{ .value = 2 };
+    const result = a.pow(256);
+    // 2^256 mod FR_MOD should be computed correctly
+    try std.testing.expect(result.value < FR_MOD);
+}
+
+test "Fr.inv mathematical property a * a^-1 = 1" {
+    const values = [_]u256{ 2, 3, 7, 11, 13, 17, 65537, FR_MOD - 1 };
+    for (values) |val| {
+        const a = Fr{ .value = val };
+        const a_inv = a.inv();
+        const product = a.mul(&a_inv);
+        try std.testing.expect(product.value == 1);
+    }
+}

--- a/src/crypto/bn254/benchmarks.zig
+++ b/src/crypto/bn254/benchmarks.zig
@@ -1,0 +1,1702 @@
+const std = @import("std");
+const Fp = @import("Fp.zig").Fp;
+const Fp2 = @import("Fp2.zig").Fp2;
+const Fp6 = @import("Fp6.zig").Fp6;
+const Fp12 = @import("Fp12.zig").Fp12;
+const Fr = @import("Fr.zig").Fr;
+const G1 = @import("g1.zig").G1;
+const G2 = @import("g2.zig").G2;
+const pairing_mod = @import("pairing.zig");
+
+// Constants
+const FP_MOD = @import("Fp.zig").FP_MOD;
+const FR_MOD = @import("Fr.zig").FR_MOD;
+
+// Time formatting function to use appropriate scale
+fn formatTime(ns: u64) struct { value: f64, unit: []const u8 } {
+    if (ns < 1000) {
+        return .{ .value = @as(f64, @floatFromInt(ns)), .unit = "ns" };
+    } else if (ns < 1000_000) {
+        return .{ .value = @as(f64, @floatFromInt(ns)) / 1000.0, .unit = "μs" };
+    } else if (ns < 1000_000_000) {
+        return .{ .value = @as(f64, @floatFromInt(ns)) / 1000_000.0, .unit = "ms" };
+    } else {
+        return .{ .value = @as(f64, @floatFromInt(ns)) / 1000_000_000.0, .unit = "s" };
+    }
+}
+
+// Random element generators - using simple PRNG approach
+var random_state: u64 = 12345;
+
+fn nextRandom() u256 {
+    random_state = random_state *% 1103515245 +% 12345;
+    const high = @as(u256, random_state) << 192;
+    random_state = random_state *% 1103515245 +% 12345;
+    const mid_high = @as(u256, random_state) << 128;
+    random_state = random_state *% 1103515245 +% 12345;
+    const mid_low = @as(u256, random_state) << 64;
+    random_state = random_state *% 1103515245 +% 12345;
+    const low = @as(u256, random_state);
+    return high | mid_high | mid_low | low;
+}
+
+fn randomFp() Fp {
+    return Fp.init(nextRandom());
+}
+
+fn randomFp2() Fp2 {
+    return Fp2.init_from_int(nextRandom(), nextRandom());
+}
+
+fn randomFp6() Fp6 {
+    return Fp6.init_from_int(nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom());
+}
+
+fn randomFp12() Fp12 {
+    return Fp12.init_from_int(nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom(), nextRandom());
+}
+
+fn randomFr() Fr {
+    return Fr.init(nextRandom());
+}
+
+fn randomG1() G1 {
+    const scalar = randomFr();
+    return G1.GENERATOR.mul(&scalar);
+}
+
+fn randomG2() G2 {
+    const scalar = randomFr();
+    return G2.GENERATOR.mul(&scalar);
+}
+
+// =============================================================================
+// BASE FIELD OPERATIONS (Fp)
+// =============================================================================
+
+test "benchmark Fp.add" {
+    const n = 50000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp();
+        inputs_b[i] = randomFp();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp.sub" {
+    const n = 50000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp();
+        inputs_b[i] = randomFp();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].sub(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp.sub n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp.mul" {
+    const n = 50000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp();
+        inputs_b[i] = randomFp();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].mul(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp.pow" {
+    const n = 5000;
+
+    var inputs = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs);
+    var exponents = try std.testing.allocator.alloc(u256, n);
+    defer std.testing.allocator.free(exponents);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp();
+        exponents[i] = nextRandom();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].pow(exponents[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp.pow n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp.inv" {
+    const n = 5000;
+
+    var inputs = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp();
+        if (inputs[i].value == 0) inputs[i] = Fp.ONE;
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].inv();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp.inv n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// QUADRATIC EXTENSION FIELD OPERATIONS (Fp2)
+// =============================================================================
+
+test "benchmark Fp2.add" {
+    const n = 10000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp2();
+        inputs_b[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.sub" {
+    const n = 10000;
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp2();
+        inputs_b[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].sub(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.sub n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.mul" {
+    const n = 5000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp2();
+        inputs_b[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].mul(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.pow" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+    var exponents = try std.testing.allocator.alloc(u256, n);
+    defer std.testing.allocator.free(exponents);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+        exponents[i] = nextRandom();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].pow(exponents[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.pow n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.inv" {
+    const n = 500;
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+        if (inputs[i].u0.value == 0 and inputs[i].u1.value == 0) {
+            inputs[i] = Fp2.ONE;
+        }
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].inv();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.inv n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.neg" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.norm" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].norm();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.norm n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.conj" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].conj();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.conj n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.scalarMul" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+    var scalars = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(scalars);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+        scalars[i] = randomFp();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].scalarMul(&scalars[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.scalarMul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp2.frobeniusMap" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].frobeniusMap();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp2.frobeniusMap n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// SEXTIC EXTENSION FIELD OPERATIONS (Fp6)
+// =============================================================================
+
+test "benchmark Fp6.add" {
+    const n = 1000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp6();
+        inputs_b[i] = randomFp6();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.sub" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp6();
+        inputs_b[i] = randomFp6();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].sub(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.sub n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.mul" {
+    const n = 1000;
+
+    var inputs_a = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp6();
+        inputs_b[i] = randomFp6();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].mul(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.pow" {
+    const n = 500;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs);
+    var exponents = try std.testing.allocator.alloc(u256, n);
+    defer std.testing.allocator.free(exponents);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp6();
+        exponents[i] = nextRandom();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].pow(exponents[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.pow n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.inv" {
+    const n = 500;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp6();
+        // Ensure non-zero
+        if (inputs[i].v0.u0.value == 0 and inputs[i].v0.u1.value == 0 and
+            inputs[i].v1.u0.value == 0 and inputs[i].v1.u1.value == 0 and
+            inputs[i].v2.u0.value == 0 and inputs[i].v2.u1.value == 0)
+        {
+            inputs[i] = Fp6.ONE;
+        }
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].inv();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.inv n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.neg" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp6();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.norm" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp6();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].norm();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.norm n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp6.scalarMul" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp6, n);
+    defer std.testing.allocator.free(inputs);
+    var scalars = try std.testing.allocator.alloc(Fp, n);
+    defer std.testing.allocator.free(scalars);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp6();
+        scalars[i] = randomFp();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].scalarMul(&scalars[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp6.scalarMul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// DODECIC EXTENSION FIELD OPERATIONS (Fp12)
+// =============================================================================
+
+test "benchmark Fp12.add" {
+    const n = 500;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp12();
+        inputs_b[i] = randomFp12();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp12.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp12.sub" {
+    const sample_sizes = [_]usize{ 5, 50, 500 };
+
+    for (sample_sizes) |n| {
+        // Random number generation
+        // Using deterministic PRNG
+
+        var inputs_a = try std.testing.allocator.alloc(Fp12, n);
+        defer std.testing.allocator.free(inputs_a);
+        var inputs_b = try std.testing.allocator.alloc(Fp12, n);
+        defer std.testing.allocator.free(inputs_b);
+
+        for (0..n) |i| {
+            inputs_a[i] = randomFp12();
+            inputs_b[i] = randomFp12();
+        }
+
+        const start = std.time.nanoTimestamp();
+        for (0..n) |i| {
+            const result = inputs_a[i].sub(&inputs_b[i]);
+            std.mem.doNotOptimizeAway(result);
+        }
+        const end = std.time.nanoTimestamp();
+
+        const duration_ns = @as(u64, @intCast(end - start));
+        const avg_ns = duration_ns / n;
+        // ops_per_sec calculation removed
+
+        const time = formatTime(avg_ns);
+        std.debug.print("Fp12.sub n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+    }
+}
+
+test "benchmark Fp12.mul" {
+    const n = 250;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFp12();
+        inputs_b[i] = randomFp12();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].mul(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp12.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp12.pow" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs);
+    var exponents = try std.testing.allocator.alloc(u256, n);
+    defer std.testing.allocator.free(exponents);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp12();
+        exponents[i] = nextRandom();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].pow(exponents[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp12.pow n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp12.inv" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp12();
+        // Ensure non-zero (simplified check)
+        if (inputs[i].w0.v0.u0.value == 0 and inputs[i].w0.v0.u1.value == 0 and
+            inputs[i].w0.v1.u0.value == 0 and inputs[i].w0.v1.u1.value == 0 and
+            inputs[i].w0.v2.u0.value == 0 and inputs[i].w0.v2.u1.value == 0 and
+            inputs[i].w1.v0.u0.value == 0 and inputs[i].w1.v0.u1.value == 0 and
+            inputs[i].w1.v1.u0.value == 0 and inputs[i].w1.v1.u1.value == 0 and
+            inputs[i].w1.v2.u0.value == 0 and inputs[i].w1.v2.u1.value == 0)
+        {
+            inputs[i] = Fp12.ONE;
+        }
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].inv();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp12.inv n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fp12.neg" {
+    const n = 500;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp12();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fp12.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// SCALAR FIELD OPERATIONS (Fr)
+// =============================================================================
+
+test "benchmark Fr.add" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFr();
+        inputs_b[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fr.sub" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFr();
+        inputs_b[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].sub(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.sub n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fr.mul" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomFr();
+        inputs_b[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].mul(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fr.pow" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs);
+    var exponents = try std.testing.allocator.alloc(u256, n);
+    defer std.testing.allocator.free(exponents);
+
+    for (0..n) |i| {
+        inputs[i] = randomFr();
+        exponents[i] = nextRandom();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].pow(exponents[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.pow n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fr.inv" {
+    const n = 1000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFr();
+        // Ensure non-zero
+        if (inputs[i].value == 0) inputs[i] = Fr.ONE;
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].inv();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.inv n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark Fr.neg" {
+    const n = 10000;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("Fr.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// GROUP OPERATIONS (G1)
+// =============================================================================
+
+test "benchmark G1.add" {
+    const n = 200;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomG1();
+        inputs_b[i] = randomG1();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G1.double" {
+    const n = 200;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG1();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].double();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.double n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G1.mul" {
+    const n = 250;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs);
+    var scalars = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(scalars);
+
+    for (0..n) |i| {
+        inputs[i] = randomG1();
+        scalars[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].mul(&scalars[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G1.neg" {
+    const n = 500;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG1();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G1.toAffine" {
+    const n = 200;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG1();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].toAffine();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.toAffine n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G1.isOnCurve" {
+    const n = 300;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG1();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].isOnCurve();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G1.isOnCurve n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// GROUP OPERATIONS (G2)
+// =============================================================================
+
+test "benchmark G2.add" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs_a = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs_a);
+    var inputs_b = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs_b);
+
+    for (0..n) |i| {
+        inputs_a[i] = randomG2();
+        inputs_b[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs_a[i].add(&inputs_b[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.add n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G2.double" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].double();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.double n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G2.mul" {
+    const n = 50;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs);
+    var scalars = try std.testing.allocator.alloc(Fr, n);
+    defer std.testing.allocator.free(scalars);
+
+    for (0..n) |i| {
+        inputs[i] = randomG2();
+        scalars[i] = randomFr();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].mul(&scalars[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.mul n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G2.neg" {
+    const n = 200;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].neg();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.neg n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G2.toAffine" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].toAffine();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.toAffine n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark G2.isOnCurve" {
+    const n = 100;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = inputs[i].isOnCurve();
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("G2.isOnCurve n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// PAIRING OPERATIONS
+// =============================================================================
+
+test "benchmark pairing.pairing" {
+    const n = 5;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var g1_inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(g1_inputs);
+    var g2_inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(g2_inputs);
+
+    for (0..n) |i| {
+        g1_inputs[i] = randomG1();
+        g2_inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = pairing_mod.pairing(&g1_inputs[i], &g2_inputs[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("pairing.pairing n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark pairing.miller_loop" {
+    const n = 25;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var g1_inputs = try std.testing.allocator.alloc(G1, n);
+    defer std.testing.allocator.free(g1_inputs);
+    var g2_inputs = try std.testing.allocator.alloc(G2, n);
+    defer std.testing.allocator.free(g2_inputs);
+
+    for (0..n) |i| {
+        g1_inputs[i] = randomG1();
+        g2_inputs[i] = randomG2();
+    }
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        const result = pairing_mod.miller_loop(&g1_inputs[i], &g2_inputs[i]);
+        std.mem.doNotOptimizeAway(result);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("pairing.miller_loop n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+test "benchmark pairing.final_exponentiation" {
+    const n = 10;
+
+    // Random number generation
+    // Using deterministic PRNG
+
+    var inputs = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(inputs);
+
+    for (0..n) |i| {
+        inputs[i] = randomFp12();
+    }
+
+    var results = try std.testing.allocator.alloc(Fp12, n);
+    defer std.testing.allocator.free(results);
+
+    const start = std.time.nanoTimestamp();
+    for (0..n) |i| {
+        results[i] = pairing_mod.final_exponentiation(&inputs[i]);
+        std.mem.doNotOptimizeAway(results[i]);
+    }
+    const end = std.time.nanoTimestamp();
+
+    const duration_ns = @as(u64, @intCast(end - start));
+    const avg_ns = duration_ns / n;
+    // ops_per_sec calculation removed
+
+    const time = formatTime(avg_ns);
+    std.debug.print("pairing.final_exponentiation n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+}
+
+// =============================================================================
+// SPECIAL CASES AND EDGE CASE BENCHMARKS
+// =============================================================================
+
+test "benchmark Fp.mul with identity elements" {
+    const sample_sizes = [_]usize{ 100, 1000, 10000 };
+
+    for (sample_sizes) |n| {
+        // Random number generation
+        // Using deterministic PRNG
+
+        var inputs = try std.testing.allocator.alloc(Fp, n);
+        defer std.testing.allocator.free(inputs);
+
+        for (0..n) |i| {
+            inputs[i] = randomFp();
+        }
+
+        const start = std.time.nanoTimestamp();
+        for (0..n) |i| {
+            const result = inputs[i].mul(&Fp.ONE);
+            std.mem.doNotOptimizeAway(result);
+        }
+        const end = std.time.nanoTimestamp();
+
+        const duration_ns = @as(u64, @intCast(end - start));
+        const avg_ns = duration_ns / n;
+        // ops_per_sec calculation removed
+
+        const time = formatTime(avg_ns);
+        std.debug.print("Fp.mul_identity n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+    }
+}
+
+test "benchmark Fp.mul near modulus boundary" {
+    const sample_sizes = [_]usize{ 10, 100, 1000 };
+
+    for (sample_sizes) |n| {
+        var inputs_a = try std.testing.allocator.alloc(Fp, n);
+        defer std.testing.allocator.free(inputs_a);
+        var inputs_b = try std.testing.allocator.alloc(Fp, n);
+        defer std.testing.allocator.free(inputs_b);
+
+        for (0..n) |i| {
+            inputs_a[i] = Fp.init(FP_MOD - 1 - @as(u256, @intCast(i % 100)));
+            inputs_b[i] = Fp.init(FP_MOD - 1 - @as(u256, @intCast((i + 50) % 100)));
+        }
+
+        const start = std.time.nanoTimestamp();
+        for (0..n) |i| {
+            const result = inputs_a[i].mul(&inputs_b[i]);
+            std.mem.doNotOptimizeAway(result);
+        }
+        const end = std.time.nanoTimestamp();
+
+        const duration_ns = @as(u64, @intCast(end - start));
+        const avg_ns = duration_ns / n;
+        // ops_per_sec calculation removed
+
+        const time = formatTime(avg_ns);
+        std.debug.print("Fp.mul_boundary n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+    }
+}
+
+test "benchmark G1.add with infinity" {
+    const sample_sizes = [_]usize{ 5, 50, 500 };
+
+    for (sample_sizes) |n| {
+        // Random number generation
+        // Using deterministic PRNG
+
+        var inputs = try std.testing.allocator.alloc(G1, n);
+        defer std.testing.allocator.free(inputs);
+
+        for (0..n) |i| {
+            inputs[i] = randomG1();
+        }
+
+        const start = std.time.nanoTimestamp();
+        for (0..n) |i| {
+            const result = inputs[i].add(&G1.INFINITY);
+            std.mem.doNotOptimizeAway(result);
+        }
+        const end = std.time.nanoTimestamp();
+
+        const duration_ns = @as(u64, @intCast(end - start));
+        const avg_ns = duration_ns / n;
+        // ops_per_sec calculation removed
+
+        const time = formatTime(avg_ns);
+        std.debug.print("G1.add_infinity n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+    }
+}
+
+test "benchmark Fp12.mul with sparse elements" {
+    const sample_sizes = [_]usize{ 5, 50, 500 };
+
+    for (sample_sizes) |n| {
+        // Random number generation
+        // Using deterministic PRNG
+
+        var inputs_a = try std.testing.allocator.alloc(Fp12, n);
+        defer std.testing.allocator.free(inputs_a);
+        var inputs_b = try std.testing.allocator.alloc(Fp12, n);
+        defer std.testing.allocator.free(inputs_b);
+
+        for (0..n) |i| {
+            // Create sparse Fp12 elements (most components are zero)
+            inputs_a[i] = Fp12.init_from_int(nextRandom(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            inputs_b[i] = Fp12.init_from_int(0, 0, 0, 0, 0, 0, nextRandom(), 0, 0, 0, 0, 0);
+        }
+
+        const start = std.time.nanoTimestamp();
+        for (0..n) |i| {
+            const result = inputs_a[i].mul(&inputs_b[i]);
+            std.mem.doNotOptimizeAway(result);
+        }
+        const end = std.time.nanoTimestamp();
+
+        const duration_ns = @as(u64, @intCast(end - start));
+        const avg_ns = duration_ns / n;
+        // ops_per_sec calculation removed
+
+        const time = formatTime(avg_ns);
+        std.debug.print("Fp12.mul_sparse n={}: {d:.2} {s}/op\n", .{ n, time.value, time.unit });
+    }
+}

--- a/src/crypto/bn254/g1.zig
+++ b/src/crypto/bn254/g1.zig
@@ -1,0 +1,379 @@
+const Fp_mod = @import("Fp.zig");
+const Fr_mod = @import("Fr.zig");
+const std = @import("std");
+
+const Fp = Fp_mod.Fp;
+const Fr = Fr_mod.Fr;
+
+//G1 is the group of points on the elliptic curve y^2 = x^3 + 3
+// We use the Jacobian projective coordinates to represent the points
+pub const G1 = struct {
+    x: Fp,
+    y: Fp,
+    z: Fp,
+
+    pub const INFINITY = G1{ .x = Fp.ZERO, .y = Fp.ONE, .z = Fp.ZERO };
+    pub const GENERATOR = G1{ .x = Fp.init(1), .y = Fp.init(2), .z = Fp.init(1) };
+
+    pub fn isInfinity(self: *const G1) bool {
+        return self.z.value == 0;
+    }
+
+    // Unchecked constructor
+    pub fn initUnchecked(x: *const Fp, y: *const Fp, z: *const Fp) G1 {
+        return G1{ .x = x.*, .y = y.*, .z = z.* };
+    }
+
+    // Checked constructor - validates point is on curve
+    pub fn init(x: *const Fp, y: *const Fp, z: *const Fp) !G1 {
+        const point = G1{ .x = x.*, .y = y.*, .z = z.* };
+        if (!point.isOnCurve()) {
+            return error.InvalidPoint;
+        }
+        return point;
+    }
+
+    pub fn toAffine(self: *const G1) G1 {
+        if (self.isInfinity()) {
+            return INFINITY;
+        }
+        const z_inv = self.z.inv();
+        const z_inv_sq = z_inv.mul(&z_inv);
+        const z_inv_cubed = z_inv_sq.mul(&z_inv);
+
+        return G1{
+            .x = self.x.mul(&z_inv_sq),
+            .y = self.y.mul(&z_inv_cubed),
+            .z = Fp.ONE,
+        };
+    }
+
+    pub fn isOnCurve(self: *const G1) bool {
+        if (self.isInfinity()) return true;
+
+        // BN254 Jacobian equation: Y² = X³ + 3Z⁶
+        const y_squared = self.y.mul(&self.y);
+        const x_cubed = self.x.mul(&self.x).mul(&self.x);
+        const z_squared = self.z.mul(&self.z);
+        const z_sixth = z_squared.mul(&z_squared).mul(&z_squared);
+        const three = Fp.init(3);
+        const rhs = x_cubed.add(&three.mul(&z_sixth));
+
+        return y_squared.equal(&rhs);
+    }
+
+    pub fn neg(self: *const G1) G1 {
+        return G1{
+            .x = self.x,
+            .y = self.y.neg(),
+            .z = self.z,
+        };
+    }
+
+    pub fn negAssign(self: *G1) void {
+        self.* = self.neg();
+    }
+
+    pub fn equal(self: *const G1, other: *const G1) bool {
+        const selfInf = self.isInfinity();
+        const otherInf = other.isInfinity();
+
+        if (selfInf and otherInf) {
+            return true;
+        }
+        if (selfInf != otherInf) {
+            return false;
+        }
+
+        // Both not infinity: cross-multiply to compare
+        // For X coordinates: X1/Z1² = X2/Z2² => X1 * Z2² = X2 * Z1²
+        const Z1_sq = self.z.mul(&self.z);
+        const Z2_sq = other.z.mul(&other.z);
+        const X1_Z2_sq = self.x.mul(&Z2_sq);
+        const X2_Z1_sq = other.x.mul(&Z1_sq);
+
+        // For Y coordinates: Y1/Z1³ = Y2/Z2³ => Y1 * Z2³ = Y2 * Z1³
+        const Z1_cubed = Z1_sq.mul(&self.z);
+        const Z2_cubed = Z2_sq.mul(&other.z);
+        const Y1_Z2_cubed = self.y.mul(&Z2_cubed);
+        const Y2_Z1_cubed = other.y.mul(&Z1_cubed);
+
+        return X1_Z2_sq.equal(&X2_Z1_sq) and Y1_Z2_cubed.equal(&Y2_Z1_cubed);
+    }
+
+    pub fn sub(self: *const G1, other: *const G1) G1 {
+        return self.add(other.neg());
+    }
+
+    pub fn subAssign(self: *G1, other: *const G1) void {
+        self.* = self.sub(other);
+    }
+
+    pub fn double(self: *const G1) G1 {
+        // Compute intermediate values
+        const X_squared = self.x.mul(&self.x); // X²
+        const Y_squared = self.y.mul(&self.y); // Y²
+        const Y_fourth = Y_squared.mul(&Y_squared); // Y⁴
+
+        // S = 4XY²
+        const S = self.x.mul(&Y_squared).mul(&Fp.init(4));
+
+        // M = 3X²
+        const M = X_squared.mul(&Fp.init(3));
+
+        // X' = M² - 2S
+        const M_squared = M.mul(&M);
+        const two_S = S.mul(&Fp.init(2));
+        const x_result = M_squared.sub(&two_S);
+
+        // Y' = M(S - X') - 8Y⁴
+        const S_minus_X = S.sub(&x_result);
+
+        //const eight_Y_fourth = Y_fourth.mul(&Fp.init(8));
+        const eight_Y_fourth = Y_fourth.mulBySmallInt(8);
+
+        const y_result = M.mul(&S_minus_X).sub(&eight_Y_fourth);
+
+        // Z' = 2YZ
+        const z_result = self.y.mul(&self.z).mul(&Fp.init(2));
+
+        return G1{ .x = x_result, .y = y_result, .z = z_result };
+    }
+
+    pub fn doubleAssign(self: *G1) void {
+        self.* = self.double();
+    }
+
+    pub fn add(self: *const G1, other: *const G1) G1 {
+        if (self.isInfinity()) {
+            return other.*;
+        }
+        if (other.isInfinity()) {
+            return self.*;
+        }
+
+        // Compute U1 = X1 * Z2² and U2 = X2 * Z1²
+        const Z1_sq = self.z.mul(&self.z);
+        const Z2_sq = other.z.mul(&other.z);
+        const U1 = self.x.mul(&Z2_sq);
+        const U2 = other.x.mul(&Z1_sq);
+
+        // Compute S1 = Y1 * Z2³ and S2 = Y2 * Z1³
+        const Z1_cubed = Z1_sq.mul(&self.z);
+        const Z2_cubed = Z2_sq.mul(&other.z);
+        const S1 = self.y.mul(&Z2_cubed);
+        const S2 = other.y.mul(&Z1_cubed);
+
+        // Check if points are equal or negatives
+        if (U1.equal(&U2)) {
+            if (S1.equal(&S2)) {
+                return self.double();
+            }
+            return INFINITY;
+        }
+
+        // Compute H = U2 - U1 and R = S2 - S1
+        const H = U2.sub(&U1);
+        const R = S2.sub(&S1);
+
+        // Compute H², H³, and intermediate values
+        const H_sq = H.mul(&H);
+        const H_cubed = H_sq.mul(&H);
+        const U1_H_sq = U1.mul(&H_sq);
+
+        // X3 = R² - H³ - 2*U1*H²
+        const R_sq = R.mul(&R);
+        const two_U1_H_sq = U1_H_sq.mul(&Fp.init(2));
+        const result_x = R_sq.sub(&H_cubed).sub(&two_U1_H_sq);
+
+        // Y3 = R*(U1*H² - X3) - S1*H³
+        const result_y = R.mul(&U1_H_sq.sub(&result_x)).sub(&S1.mul(&H_cubed));
+
+        // Z3 = Z1 * Z2 * H
+        const result_z = self.z.mul(&other.z).mul(&H);
+
+        return G1{ .x = result_x, .y = result_y, .z = result_z };
+    }
+
+    pub fn addAssign(self: *G1, other: *const G1) void {
+        self.* = self.add(other);
+    }
+
+    pub fn mul(self: *const G1, scalar: *const Fr) G1 {
+        return self.mul_by_int(scalar.value);
+    }
+
+    pub fn mul_by_int(self: *const G1, scalar: u256) G1 {
+        if (self.isInfinity()) {
+            return INFINITY;
+        }
+        var result = INFINITY;
+        var base = self.*;
+        var exp = scalar;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.doubleAssign();
+        }
+        return result;
+    }
+
+    pub fn mulAssign(self: *G1, scalar: *const Fr) void {
+        self.* = self.mul(scalar);
+    }
+};
+
+// TESTS
+// expected output came from arkworks-rs
+
+test "g1.add opposite" {
+    const Gen = G1.GENERATOR;
+    const minusG = Gen.neg();
+    const G_plus_minusG = Gen.add(&minusG);
+    try std.testing.expect(G_plus_minusG.isInfinity());
+}
+
+test "g1.add" {
+    const Gen = G1.GENERATOR;
+    const Gen2 = G1{
+        .x = Fp.init(21888242871839275222246405745257275088696311157297823662689037894645226208560),
+        .y = Fp.init(21888242871839275222246405745257275088696311157297823662689037894645226208572),
+        .z = Fp.init(4),
+    };
+    const expected_result = G1{
+        .x = Fp.init(119872),
+        .y = Fp.init(21888242871839275222246405745257275088696311157297823662689037894645159203143),
+        .z = Fp.init(312),
+    };
+    try std.testing.expect(Gen.add(&Gen2).equal(&expected_result));
+}
+
+test "g1.double" {
+    const Gen = G1.GENERATOR;
+    const doubleG = Gen.double();
+    const expected_result = G1{
+        .x = Fp.init(21888242871839275222246405745257275088696311157297823662689037894645226208560),
+        .y = Fp.init(21888242871839275222246405745257275088696311157297823662689037894645226208572),
+        .z = Fp.init(4),
+    };
+
+    try std.testing.expect(doubleG.equal(&expected_result));
+}
+
+test "g1.mul" {
+    const Gen = G1.GENERATOR;
+    const minus_G = Gen.mul(&Fr.init(1).neg());
+    const G_plus_minus_G = Gen.add(&minus_G);
+    try std.testing.expect(G_plus_minus_G.isInfinity());
+}
+
+test "g1.isOnCurve generator" {
+    const gen = G1.GENERATOR;
+    try std.testing.expect(gen.isOnCurve());
+}
+
+test "g1.isOnCurve identity" {
+    const identity = G1.INFINITY;
+    try std.testing.expect(identity.isOnCurve());
+}
+
+test "g1.isOnCurve random point" {
+    const k = 7; // example scalar
+    const random_point = G1.GENERATOR.mul(&Fr.init(k));
+    try std.testing.expect(random_point.isOnCurve());
+}
+
+test "g1.equal generator to itself" {
+    const gen = G1.GENERATOR;
+    try std.testing.expect(gen.equal(&gen));
+}
+
+test "g1.equal different representations same point" {
+    const gen = G1.GENERATOR;
+    const scaled_gen = G1{
+        .x = gen.x.mul(&Fp.init(4)), // scale by 2²
+        .y = gen.y.mul(&Fp.init(8)), // scale by 2³
+        .z = gen.z.mul(&Fp.init(2)), // scale by 2
+    };
+    try std.testing.expect(gen.equal(&scaled_gen));
+}
+
+test "g1.toAffine random point" {
+    const k = 13; // example scalar
+    const random_point = G1.GENERATOR.mul(&Fr.init(k));
+    const affine = random_point.toAffine();
+
+    const expected_result = G1{
+        .x = Fp.init(2672242651313367459976336264061690128665099451055893690004467838496751824703),
+        .y = Fp.init(18247534626997477790812670345925575171672701304065784723769023620148097699216),
+        .z = Fp.ONE, // affine points have z = 1
+    };
+
+    try std.testing.expect(affine.equal(&expected_result));
+    try std.testing.expect(affine.isOnCurve());
+}
+
+test "g1.add generator to identity" {
+    const gen = G1.GENERATOR;
+    const identity = G1.INFINITY;
+    const result = gen.add(&identity);
+    try std.testing.expect(result.equal(&gen));
+}
+
+test "g1.add random points" {
+    const k1 = 3; // example scalar
+    const k2 = 5; // example scalar
+    const point1 = G1.GENERATOR.mul(&Fr.init(k1));
+    const point2 = G1.GENERATOR.mul(&Fr.init(k2));
+    const result = point1.add(&point2);
+
+    const expected_result = G1{
+        .x = Fp.init(41677742803929195922238593),
+        .y = Fp.init(269065159484683478575364835230449703617),
+        .z = Fp.init(712815062608),
+    };
+
+    try std.testing.expect(result.equal(&expected_result));
+    try std.testing.expect(result.isOnCurve());
+}
+
+test "g1.add commutativity" {
+    const k1 = 11; // example scalar
+    const k2 = 17; // example scalar
+    const point1 = G1.GENERATOR.mul(&Fr.init(k1));
+    const point2 = G1.GENERATOR.mul(&Fr.init(k2));
+
+    const result1 = point1.add(&point2);
+    const result2 = point2.add(&point1);
+    try std.testing.expect(result1.equal(&result2));
+}
+
+test "g1.double identity" {
+    const identity = G1.INFINITY;
+    const result = identity.double();
+    try std.testing.expect(result.isInfinity());
+}
+
+test "g1.double random point" {
+    const k = 9; // example scalar
+    const random_point = G1.GENERATOR.mul(&Fr.init(k));
+    const doubled = random_point.double();
+
+    const expected_result = G1{
+        .x = Fp.init(16214338358589738794944521397038398142658042174982207107873684518498175669939),
+        .y = Fp.init(11686337248854933627526225912767414320106940505209835321155346996117578735613),
+        .z = Fp.init(2952297635626254264598100546197407825999396807330657291329469442697244479715),
+    };
+
+    try std.testing.expect(doubled.equal(&expected_result));
+    try std.testing.expect(doubled.isOnCurve());
+}
+
+test "g1.chain operations" {
+    const gen = G1.GENERATOR;
+    const doubled = gen.double();
+    const quadrupled = doubled.double();
+    const gen_times_four = gen.add(&gen).add(&gen).add(&gen);
+    try std.testing.expect(quadrupled.equal(&gen_times_four));
+}

--- a/src/crypto/bn254/g2.zig
+++ b/src/crypto/bn254/g2.zig
@@ -1,0 +1,390 @@
+const Fp2_mod = @import("Fp2.zig");
+const Fr_mod = @import("Fr.zig");
+const std = @import("std");
+const Fp6_mod = @import("Fp6.zig");
+const Fp12_mod = @import("Fp12.zig");
+
+const Fp2 = Fp2_mod.Fp2;
+const FP_MOD = Fp2_mod.FP_MOD;
+const Fp = Fp2_mod.Fp;
+const Fr = Fr_mod.Fr;
+const Fp12 = Fp12_mod.Fp12;
+const Fp6 = Fp6_mod.Fp6;
+
+//G1 is the group of points on the elliptic curve y^2 = x^3 + 3
+// We use the Jacobian projective coordinates to represent the points
+pub const G2 = struct {
+    x: Fp2,
+    y: Fp2,
+    z: Fp2,
+
+    pub const INFINITY = G2{ .x = Fp2.ZERO, .y = Fp2.ONE, .z = Fp2.ZERO };
+    pub const GENERATOR = G2{ .x = Fp2.init_from_int(10857046999023057135944570762232829481370756359578518086990519993285655852781, 11559732032986387107991004021392285783925812861821192530917403151452391805634), .y = Fp2.init_from_int(8495653923123431417604973247489272438418190587263600148770280649306958101930, 4082367875863433681332203403145435568316851327593401208105741076214120093531), .z = Fp2.init_from_int(1, 0) };
+
+    pub const FROBENIUS_X_COEFF = Fp2.init_from_int(21575463638280843010398324269430826099269044274347216827212613867836435027261, 10307601595873709700152284273816112264069230130616436755625194854815875713954);
+    pub const FROBENIUS_Y_COEFF = Fp2.init_from_int(2821565182194536844548159561693502659359617185244120367078079554186484126554, 3505843767911556378687030309984248845540243509899259641013678093033130930403);
+
+    pub fn isInfinity(self: *const G2) bool {
+        return self.z.u0.value == 0 and self.z.u1.value == 0;
+    }
+
+    // Unchecked constructor
+    pub fn initUnchecked(x: *const Fp2, y: *const Fp2, z: *const Fp2) G2 {
+        return G2{ .x = x.*, .y = y.*, .z = z.* };
+    }
+
+    // Checked constructor - validates point is on curve
+    pub fn init(x: *const Fp2, y: *const Fp2, z: *const Fp2) !G2 {
+        const point = G2{ .x = x.*, .y = y.*, .z = z.* };
+        if (!point.isOnCurve()) {
+            return error.InvalidPoint;
+        }
+        return point;
+    }
+
+    pub fn toAffine(self: *const G2) G2 {
+        if (self.isInfinity()) {
+            return INFINITY;
+        }
+        const z_inv = self.z.inv();
+        const z_inv_sq = z_inv.mul(&z_inv);
+        const z_inv_cubed = z_inv_sq.mul(&z_inv);
+
+        return G2{
+            .x = self.x.mul(&z_inv_sq),
+            .y = self.y.mul(&z_inv_cubed),
+            .z = Fp2.ONE,
+        };
+    }
+
+    pub fn isOnCurve(self: *const G2) bool {
+        if (self.isInfinity()) return true;
+        const xi = Fp2.init_from_int(9, 1);
+        const z_factor = Fp2.init_from_int(3, 0).mul(&xi.inv());
+
+        // BN254 Jacobian equation: Y² = X³ + (3/xi)Z⁶
+        const y_squared = self.y.mul(&self.y);
+        const x_cubed = self.x.mul(&self.x).mul(&self.x);
+        const z_squared = self.z.mul(&self.z);
+        const z_sixth = z_squared.mul(&z_squared).mul(&z_squared);
+        const rhs = x_cubed.add(&z_sixth.mul(&z_factor));
+
+        return y_squared.equal(&rhs);
+    }
+
+    pub fn isInSubgroup(self: *const G2) bool {
+        _ = self;
+        @panic("TODO: implement isInSubgroup");
+    }
+
+    pub fn neg(self: *const G2) G2 {
+        return G2{
+            .x = self.x,
+            .y = self.y.neg(),
+            .z = self.z,
+        };
+    }
+
+    pub fn negAssign(self: *G2) void {
+        self.* = self.neg();
+    }
+
+    pub fn equal(self: *const G2, other: *const G2) bool {
+        const selfInf = self.isInfinity();
+        const otherInf = other.isInfinity();
+
+        if (selfInf and otherInf) {
+            return true;
+        }
+        if (selfInf != otherInf) {
+            return false;
+        }
+
+        // Both not infinity: cross-multiply to compare
+        // For X coordinates: X1/Z1² = X2/Z2² => X1 * Z2² = X2 * Z1²
+        const Z1_sq = self.z.mul(&self.z);
+        const Z2_sq = other.z.mul(&other.z);
+        const X1_Z2_sq = self.x.mul(&Z2_sq);
+        const X2_Z1_sq = other.x.mul(&Z1_sq);
+
+        // For Y coordinates: Y1/Z1³ = Y2/Z2³ => Y1 * Z2³ = Y2 * Z1³
+        const Z1_cubed = Z1_sq.mul(&self.z);
+        const Z2_cubed = Z2_sq.mul(&other.z);
+        const Y1_Z2_cubed = self.y.mul(&Z2_cubed);
+        const Y2_Z1_cubed = other.y.mul(&Z1_cubed);
+
+        return X1_Z2_sq.equal(&X2_Z1_sq) and Y1_Z2_cubed.equal(&Y2_Z1_cubed);
+    }
+
+    pub fn double(self: *const G2) G2 {
+        // Compute intermediate values
+        const X_squared = self.x.mul(&self.x); // X²
+        const Y_squared = self.y.mul(&self.y); // Y²
+        const Y_fourth = Y_squared.mul(&Y_squared); // Y⁴
+
+        // S = 4XY²
+        const S = self.x.mul(&Y_squared).scalarMul(&Fp.init(4));
+
+        // M = 3X²
+        const M = X_squared.scalarMul(&Fp.init(3));
+
+        // X' = M² - 2S
+        const M_squared = M.mul(&M);
+        const two_S = S.scalarMul(&Fp.init(2));
+        const x_result = M_squared.sub(&two_S);
+
+        // Y' = M(S - X') - 8Y⁴
+        const S_minus_X = S.sub(&x_result);
+        const eight_Y_fourth = Y_fourth.scalarMul(&Fp.init(8));
+        const y_result = M.mul(&S_minus_X).sub(&eight_Y_fourth);
+
+        // Z' = 2YZ
+        const z_result = self.y.mul(&self.z).scalarMul(&Fp.init(2));
+
+        return G2{ .x = x_result, .y = y_result, .z = z_result };
+    }
+
+    pub fn doubleAssign(self: *G2) void {
+        self.* = self.double();
+    }
+
+    pub fn add(self: *const G2, other: *const G2) G2 {
+        if (self.isInfinity()) {
+            return other.*;
+        }
+        if (other.isInfinity()) {
+            return self.*;
+        }
+
+        // Compute U1 = X1 * Z2² and U2 = X2 * Z1²
+        const Z1_sq = self.z.mul(&self.z);
+        const Z2_sq = other.z.mul(&other.z);
+        const U1 = self.x.mul(&Z2_sq);
+        const U2 = other.x.mul(&Z1_sq);
+
+        // Compute S1 = Y1 * Z2³ and S2 = Y2 * Z1³
+        const Z1_cubed = Z1_sq.mul(&self.z);
+        const Z2_cubed = Z2_sq.mul(&other.z);
+        const S1 = self.y.mul(&Z2_cubed);
+        const S2 = other.y.mul(&Z1_cubed);
+
+        // Check if points are equal or negatives
+        if (U1.equal(&U2)) {
+            if (S1.equal(&S2)) {
+                return self.double();
+            }
+            return INFINITY;
+        }
+
+        // Compute H = U2 - U1 and R = S2 - S1
+        const H = U2.sub(&U1);
+        const R = S2.sub(&S1);
+
+        // Compute H², H³, and intermediate values
+        const H_sq = H.mul(&H);
+        const H_cubed = H_sq.mul(&H);
+        const U1_H_sq = U1.mul(&H_sq);
+
+        // X3 = R² - H³ - 2*U1*H²
+        const R_sq = R.mul(&R);
+        const two_U1_H_sq = U1_H_sq.scalarMul(&Fp.init(2));
+        const result_x = R_sq.sub(&H_cubed).sub(&two_U1_H_sq);
+
+        // Y3 = R*(U1*H² - X3) - S1*H³
+        const result_y = R.mul(&U1_H_sq.sub(&result_x)).sub(&S1.mul(&H_cubed));
+
+        // Z3 = Z1 * Z2 * H
+        const result_z = self.z.mul(&other.z).mul(&H);
+
+        return G2{ .x = result_x, .y = result_y, .z = result_z };
+    }
+
+    pub fn addAssign(self: *G2, other: *const G2) void {
+        self.* = self.add(other);
+    }
+
+    pub fn mul(self: *const G2, scalar: *const Fr) G2 {
+        return self.mul_by_int(scalar.value);
+    }
+
+    pub fn mul_by_int(self: *const G2, scalar: u256) G2 {
+        if (self.isInfinity()) {
+            return INFINITY;
+        }
+        var result = INFINITY;
+        var base = self.*;
+        var exp = scalar;
+        while (exp > 0) : (exp >>= 1) {
+            if (exp & 1 == 1) {
+                result.addAssign(&base);
+            }
+            base.doubleAssign();
+        }
+        return result;
+    }
+
+    pub fn frobenius(self: *const G2) G2 {
+        return G2{
+            .x = self.x.frobeniusMap().mul(&FROBENIUS_X_COEFF),
+            .y = self.y.frobeniusMap().mul(&FROBENIUS_Y_COEFF),
+            .z = self.z.frobeniusMap(),
+        };
+    }
+};
+
+// TESTS
+// expected output came from arkworks-rs
+
+test "g2.add opposite" {
+    const Gen = G2.GENERATOR;
+    const minusG = Gen.neg();
+    const G_plus_minusG = Gen.add(&minusG);
+    try std.testing.expect(G_plus_minusG.isInfinity());
+}
+
+test "g2.add" {
+    const Gen = G2.GENERATOR;
+    const Gen2 = G2{
+        .x = Fp2.init_from_int(8068064665578754444291054647125927633989259848632494988160623383584150338969, 10201766053784902393624440516579763048402213644202139977240562962104124808534),
+        .y = Fp2.init_from_int(18350387758438165722514006433324734852126505429007818091896560652419680779208, 2361120538552305763462588552289584032113666280040005078430227626567900900889),
+        .z = Fp2.init_from_int(16991307846246862835209946494978544876836381174527200297540561298613916203860, 8164735751726867362664406806290871136633702655186802416211482152428240187062),
+    };
+    const expected_result = G2{
+        .x = Fp2.init_from_int(16964963043016842499038600092728359482547221737098759962437502895503860098956, 9802038328124067467167916831831108021770181501290579378159059786039834492047),
+        .y = Fp2.init_from_int(16820779252272725671048206721551654470547449467959363398932701258504709733061, 18729480042507864736551419171906659760696723842014658768251241386616345560593),
+        .z = Fp2.init_from_int(394855990771205946776485094759919347105338213653118418588150452214006819405, 8586553845205426076950860668862984318775103285308506851115128319666650804540),
+    };
+    try std.testing.expect(Gen.add(&Gen2).equal(&expected_result));
+}
+
+test "g2.double expected" {
+    const Gen = G2.GENERATOR;
+    const doubleG = Gen.double();
+    const expected_result = G2{
+        .x = Fp2.init_from_int(8068064665578754444291054647125927633989259848632494988160623383584150338969, 10201766053784902393624440516579763048402213644202139977240562962104124808534),
+        .y = Fp2.init_from_int(18350387758438165722514006433324734852126505429007818091896560652419680779208, 2361120538552305763462588552289584032113666280040005078430227626567900900889),
+        .z = Fp2.init_from_int(16991307846246862835209946494978544876836381174527200297540561298613916203860, 8164735751726867362664406806290871136633702655186802416211482152428240187062),
+    };
+
+    try std.testing.expect(doubleG.equal(&expected_result));
+}
+
+test "g2.mul" {
+    const Gen = G2.GENERATOR;
+    const minus_G = Gen.mul(&Fr.init(1).neg());
+    const G_plus_minus_G = Gen.add(&minus_G);
+    try std.testing.expect(G_plus_minus_G.isInfinity());
+}
+
+test "g2.isOnCurve generator" {
+    const gen = G2.GENERATOR;
+    try std.testing.expect(gen.isOnCurve());
+}
+
+test "g2.isOnCurve identity" {
+    const identity = G2.INFINITY;
+    try std.testing.expect(identity.isOnCurve());
+}
+
+test "g2.isOnCurve random point" {
+    const k = 7; // example scalar
+    const random_point = G2.GENERATOR.mul(&Fr.init(k));
+    try std.testing.expect(random_point.isOnCurve());
+}
+
+test "g2.equal generator to itself" {
+    const gen = G2.GENERATOR;
+    try std.testing.expect(gen.equal(&gen));
+}
+
+test "g2.toAffine random point" {
+    const k = 13; // example scalar
+    const random_point = G2.GENERATOR.mul(&Fr.init(k));
+    const affine = random_point.toAffine();
+
+    const expected_result = G2{
+        .x = Fp2.init_from_int(16137324789686743234629608741537369181251990815455155257427276976918350071287, 280672898440571232725436467950720547829638241593507531241322547969961007057),
+        .y = Fp2.init_from_int(12136420650226457477690750437223209427924916790606163705631661913973995426040, 17641806683785498955878869918183868440783188556637975525088932771694068429840),
+        .z = Fp2.ONE, // affine points have z = 1
+    };
+
+    try std.testing.expect(affine.equal(&expected_result));
+    try std.testing.expect(affine.isOnCurve());
+}
+
+test "g2.add generator to identity" {
+    const gen = G2.GENERATOR;
+    const identity = G2.INFINITY;
+    const result = gen.add(&identity);
+    try std.testing.expect(result.equal(&gen));
+}
+
+test "g2.add random points" {
+    const k1 = 3; // example scalar
+    const k2 = 5; // example scalar
+    const point1 = G2.GENERATOR.mul(&Fr.init(k1));
+    const point2 = G2.GENERATOR.mul(&Fr.init(k2));
+    const result = point1.add(&point2);
+
+    const expected_result = G2{
+        .x = Fp2.init_from_int(12338822787986259899292241915605503554934128188921556766068436962878160930396, 7873988026505017611181106612809016613872895048560600031197901192282892195467),
+        .y = Fp2.init_from_int(15022180381621582952906644413383285972184526146125412741587595613615896914712, 19921033716458048718332470098885436883122273955056609736463017767128109247250),
+        .z = Fp2.init_from_int(1774573728518825553032624160373027001804770585936131378855038206560263646397, 16540582363439390354595677887183297241579373102577794439755118116102427771932),
+    };
+
+    try std.testing.expect(result.equal(&expected_result));
+    try std.testing.expect(result.isOnCurve());
+}
+
+test "g2.add commutativity" {
+    const k1 = 11; // example scalar
+    const k2 = 17; // example scalar
+    const point1 = G2.GENERATOR.mul(&Fr.init(k1));
+    const point2 = G2.GENERATOR.mul(&Fr.init(k2));
+
+    const result1 = point1.add(&point2);
+    const result2 = point2.add(&point1);
+    try std.testing.expect(result1.equal(&result2));
+}
+
+test "g2.double identity" {
+    const identity = G2.INFINITY;
+    const result = identity.double();
+    try std.testing.expect(result.isInfinity());
+}
+
+test "g2.double random point" {
+    const k = 9; // example scalar
+    const random_point = G2.GENERATOR.mul(&Fr.init(k));
+    const doubled = random_point.double();
+
+    const expected_result = G2{
+        .x = Fp2.init_from_int(9010315763217961467479503725255056756346217638634836905524514729866798122782, 12713521549126352466862126562479899179793375378918102927559864838005817848258),
+        .y = Fp2.init_from_int(2938963071173997916611155186588796442091168500216583928241941802670927160507, 4637911005980597202814535267161061392968887007349473417306059045353733452774),
+        .z = Fp2.init_from_int(21027050538969145131013453157421638377169363093479560088903524997919820324535, 16346656561829046745170627665889413954208741171200634938000383914340115265265),
+    };
+
+    try std.testing.expect(doubled.equal(&expected_result));
+    try std.testing.expect(doubled.isOnCurve());
+}
+
+test "g2.chain operations" {
+    const gen = G2.GENERATOR;
+    const doubled = gen.double();
+    const quadrupled = doubled.double();
+    const gen_times_four = gen.add(&gen).add(&gen).add(&gen);
+    try std.testing.expect(quadrupled.equal(&gen_times_four));
+}
+
+// check that the frobenius map is correct
+test "g2.frobenius" {
+    const scalars = [_]u64{
+        1, 3, 5, 7, 11, 19, 123, 999, 10007, 123456, 987654321, 3141592653, 9007199254740991, 18446744073709551557,
+    };
+    for (scalars) |k| {
+        const point = G2.GENERATOR.mul(&Fr.init(k));
+        const frob_point = point.frobenius();
+        const p_point = point.mul(&Fr.init(FP_MOD));
+        try std.testing.expect(p_point.equal(&frob_point));
+    }
+}

--- a/src/crypto/bn254/pairing.zig
+++ b/src/crypto/bn254/pairing.zig
@@ -1,0 +1,314 @@
+const g1_mod = @import("g1.zig");
+const g2_mod = @import("g2.zig");
+const fr_mod = @import("Fr.zig");
+const Fp_mod = @import("Fp.zig");
+const Fp2_mod = @import("Fp2.zig");
+const Fp6_mod = @import("Fp6.zig");
+const Fp12_mod = @import("Fp12.zig");
+const std = @import("std");
+
+const Fp = Fp_mod.Fp;
+const Fp2 = Fp2_mod.Fp2;
+const Fp6 = Fp6_mod.Fp6;
+const Fp12 = Fp12_mod.Fp12;
+const G1 = g1_mod.G1;
+const G2 = g2_mod.G2;
+const Fr = fr_mod.Fr;
+
+const FR_MOD = fr_mod.FR_MOD;
+
+const miller_loop_constant_signed = &[_]i2{ 0, 0, 0, 1, 0, 1, 0, -1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, 0, -1, 0, 0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 1, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0, 1, 0, -1, 0, 0, 0, -1, 0, -1, 0, 0, 0, 1, 0, 1, 1 };
+//slightly better
+const miller_loop_constant_signed2 = &[_]i2{ 0, 0, 0, 1, 0, 1, 0, -1, 0, 0, 1, -1, 0, 0, 1, 0, 0, 1, 1, 0, -1, 0, 0, 1, 0, -1, 0, 0, 0, 0, 1, 1, 1, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 1, 0, 0, -1, 0, 0, 0, 1, 1, 0, -1, 0, 0, 1, 0, 1, 1 };
+
+const miller_loop_constant = 29793968203157093288;
+const miller_loop_iterations = 64;
+const final_exponentiation_constant = 552484233613224096312617126783173147097382103762957654188882734314196910839907541213974502761540629817009608548654680343627701153829446747810907373256841551006201639677726139946029199968412598804882391702273019083653272047566316584365559776493027495458238373902875937659943504873220554161550525926302303331747463515644711876653177129578303191095900909191624817826566688241804408081892785725967931714097716709526092261278071952560171111444072049229123565057483750161460024353346284167282452756217662335528813519139808291170539072125381230815729071544861602750936964829313608137325426383735122175229541155376346436093930287402089517426973178917569713384748081827255472576937471496195752727188261435633271238710131736096299798168852925540549342330775279877006784354801422249722573783561685179618816480037695005515426162362431072245638324744480;
+const final_exponentiation_constant_hard_part = 10486551571378427818905133077457505975217533156541166536005452068033223782873764572151541189142778783267711471998854717549389605644966361077867290379973073897271417449614939788000730910148473503528371060814157528868116901618729649;
+
+pub const point_line = struct {
+    point: G2,
+    line: Fp12,
+};
+
+pub fn pairing(g1: *const G1, g2: *const G2) Fp12 {
+    const f = miller_loop(g1, g2);
+    return final_exponentiation(&f);
+}
+
+pub fn miller_loop(p: *const G1, q: *const G2) Fp12 {
+    var result = Fp12.ONE;
+    if (p.isInfinity() or q.isInfinity()) {
+        return result;
+    }
+    const p_affine = p.toAffine();
+    const q_affine = q.toAffine();
+    var t = q_affine;
+    for (1..miller_loop_iterations + 1) |j| {
+        const i = miller_loop_iterations - j;
+        const signed_bit = miller_loop_constant_signed2[i];
+        const double_point_line = point_double_line_evaluation(&p_affine, &t);
+        t = double_point_line.point;
+        const double_line: Fp12 = double_point_line.line;
+        result = result.square().mul(&double_line);
+
+        if (signed_bit == 1) {
+            const add_point_line = point_add_line_evaluation(&p_affine, &q_affine, &t);
+            t = add_point_line.point;
+            const add_line: Fp12 = add_point_line.line;
+            result.mulAssign(&add_line);
+        } else if (signed_bit == -1) {
+            const add_point_line = point_add_line_evaluation(&p_affine, &q_affine.neg(), &t);
+            t = add_point_line.point;
+            const add_line: Fp12 = add_point_line.line;
+            result.mulAssign(&add_line);
+        }
+    }
+
+    const q1 = q_affine.frobenius();
+    const q1_point_line = point_add_line_evaluation(&p_affine, &q1, &t);
+    t = q1_point_line.point;
+    const q1_line: Fp12 = q1_point_line.line;
+    result.mulAssign(&q1_line);
+
+    const q2 = q1.frobenius().neg();
+    const q2_point_line = point_add_line_evaluation(&p_affine, &q2, &t);
+    //t = q2_point_line.point;
+    const q2_line: Fp12 = q2_point_line.line;
+    result.mulAssign(&q2_line);
+    return result;
+}
+
+pub fn final_exponentiation(f: *const Fp12) Fp12 {
+    const easy_part = final_exponentiation_easy_part(f);
+    return final_exponentiation_hard_part(&easy_part);
+}
+
+pub fn final_exponentiation_easy_part(f: *const Fp12) Fp12 {
+    var result = f.*;
+    for (0..6) |_| {
+        result.frobeniusMapAssign();
+    }
+    result.mulAssign(&f.inv());
+    result.mulAssign(&result.frobeniusMap().frobeniusMap());
+    return result;
+}
+
+pub fn final_exponentiation_hard_part(f: *const Fp12) Fp12 {
+    var result = Fp12.ONE;
+    var base = f.*;
+    var exp: u780 = final_exponentiation_constant_hard_part;
+    while (exp > 0) {
+        if (exp & 1 == 1) {
+            result.mulAssign(&base);
+        }
+        base.mulAssign(&base);
+        exp >>= 1;
+    }
+    return result;
+}
+
+// p needs to be in affine form
+pub fn point_double_line_evaluation(p: *const G1, q: *const G2) point_line {
+    var t0 = q.x.mul(&q.x);
+    const t1 = q.y.mul(&q.y);
+    const t2 = t1.mul(&t1);
+    var t3 = t1.add(&q.x);
+    t3.mulAssign(&t3);
+    t3.subAssign(&t0.add(&t2));
+    t3.addAssign(&t3);
+
+    const t4 = t0.scalarMul(&Fp.init(3));
+    var t6 = q.x.add(&t4);
+    const t5 = t4.mul(&t4);
+
+    const result_x = t5.sub(&t3.scalarMul(&Fp.init(2)));
+    const result_y = t3.sub(&result_x)
+        .mul(&t4)
+        .sub(&t2.scalarMul(&Fp.init(8)));
+
+    const result_z = q.y.add(&q.z).square()
+        .sub(&t1)
+        .sub(&q.z.square());
+
+    t3 = t4.mul(&q.z.square()).mulBySmallInt(2).neg();
+
+    t3.scalarMulAssign(&p.x);
+    t6 = t6.square()
+        .sub(&t0)
+        .sub(&t5)
+        .sub(&t1.mulBySmallInt(4));
+
+    t0 = result_z.mul(&q.z.square()).mulBySmallInt(2);
+    t0.scalarMulAssign(&p.y);
+
+    const a0 = Fp6{
+        .v0 = t0,
+        .v1 = Fp2.ZERO,
+        .v2 = Fp2.ZERO,
+    };
+
+    const a1 = Fp6{
+        .v0 = t3,
+        .v1 = t6,
+        .v2 = Fp2.ZERO,
+    };
+
+    const line = Fp12{
+        .w0 = a0,
+        .w1 = a1,
+    };
+
+    const point = G2{
+        .x = result_x,
+        .y = result_y,
+        .z = result_z,
+    };
+
+    return point_line{ .point = point, .line = line };
+}
+
+pub fn point_add_line_evaluation(p: *const G1, q: *const G2, r: *const G2) point_line {
+    const q_affine = q.toAffine();
+
+    var t0 = q_affine.x.mul(&r.z.square());
+    var t1 = q_affine.y.add(&r.z).square();
+    t1.subAssign(&q_affine.y.square());
+    t1.subAssign(&r.z.square());
+    t1.mulAssign(&r.z.square());
+
+    const t2 = t0.sub(&r.x);
+    const t3 = t2.square();
+    const t4 = t3.mulBySmallInt(4);
+    const t5 = t4.mul(&t2);
+    var t6 = t1.sub(&r.y.mulBySmallInt(2));
+    var t9 = t6.mul(&q_affine.x);
+    const t7 = r.x.mul(&t4);
+
+    const result_x = t6.square().sub(&t5).sub(&t7.mulBySmallInt(2));
+    const result_z = r.z.add(&t2).square()
+        .sub(&r.z.square())
+        .sub(&t3);
+
+    var t10 = q.y.add(&result_z);
+    const t8 = t7.sub(&result_x).mul(&t6);
+    t0 = r.y.mul(&t5).mulBySmallInt(2);
+    const result_y = t8.sub(&t0);
+
+    t10 = t10.square()
+        .sub(&q_affine.y.square())
+        .sub(&result_z.square());
+
+    t9 = t9.mulBySmallInt(2).sub(&t10);
+
+    t10 = result_z.scalarMul(&p.y.mulBySmallInt(2));
+    t6.negAssign();
+    t1 = t6.scalarMul(&p.x.mulBySmallInt(2));
+
+    const a0 = Fp6{
+        .v0 = t10,
+        .v1 = Fp2.ZERO,
+        .v2 = Fp2.ZERO,
+    };
+
+    const a1 = Fp6{
+        .v0 = t1,
+        .v1 = t9,
+        .v2 = Fp2.ZERO,
+    };
+
+    const line = Fp12{
+        .w0 = a0,
+        .w1 = a1,
+    };
+
+    const point = G2{
+        .x = result_x,
+        .y = result_y,
+        .z = result_z,
+    };
+
+    return point_line{ .point = point, .line = line };
+}
+
+test "final_exponentiation" {
+    const test_values = [_]Fp12{
+        Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+        Fp12.init_from_int(123, 456, 789, 1011, 1213, 1415, 1617, 1819, 2021, 2223, 2425, 2627),
+        Fp12.init_from_int(999, 888, 777, 666, 555, 444, 333, 222, 111, 100, 99, 88),
+        Fp12.init_from_int(17, 23, 31, 47, 53, 61, 67, 71, 73, 79, 83, 89),
+        Fp12.init_from_int(2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033, 2034),
+        Fp12.init_from_int(7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6),
+        Fp12.init_from_int(13, 37, 73, 97, 137, 173, 197, 233, 277, 313, 337, 373),
+    };
+
+    for (test_values) |f| {
+        const f_pow_r = f.pow(FR_MOD);
+        const result = final_exponentiation(&f_pow_r);
+        try std.testing.expect(result.equal(&Fp12.ONE));
+    }
+}
+
+test "point_double_line_evaluation" {
+    const p = G1.GENERATOR.mul_by_int(2987697);
+    const q = G2.GENERATOR.mul_by_int(759765972);
+    const q_times_2 = q.add(&q);
+    const result = point_double_line_evaluation(&p, &q);
+    try std.testing.expect(result.point.equal(&q_times_2));
+}
+
+test "point_add_line_evaluation" {
+    const p = G1.GENERATOR.mul_by_int(1234567890);
+    const q = G2.GENERATOR.mul_by_int(28769675);
+    const q_times_2 = q.add(&q);
+    // const q_times_3 = q_times_2.add(&q);
+    const result = point_add_line_evaluation(&p, &q.neg(), &q_times_2);
+    try std.testing.expect(result.point.equal(&q));
+}
+
+test "pairing bilinearity and infinity" {
+    const test_cases = [_]struct { p1: u256, p2: u256, q1: u256, q2: u256, scalar: u256 }{
+        .{ .p1 = 123, .p2 = 456, .q1 = 321, .q2 = 654, .scalar = 3 },
+        .{ .p1 = 789, .p2 = 1011, .q1 = 987, .q2 = 1213, .scalar = 5 },
+        .{ .p1 = 1337, .p2 = 2023, .q1 = 1729, .q2 = 2024, .scalar = 7 },
+    };
+    var i: u256 = 0;
+    for (test_cases) |test_case| {
+        i += 1;
+        const p1 = G1.GENERATOR.mul_by_int(test_case.p1);
+        const p2 = G1.GENERATOR.mul_by_int(test_case.p2);
+        const q1 = G2.GENERATOR.mul_by_int(test_case.q1);
+        const q2 = G2.GENERATOR.mul_by_int(test_case.q2);
+
+        // Test bilinearity in first argument: e(P1 + P2, Q) = e(P1, Q) * e(P2, Q)
+        const p1_plus_p2 = p1.add(&p2);
+        const left_side_1 = pairing(&p1_plus_p2, &q1);
+        const e_p1_q1 = pairing(&p1, &q1);
+        const e_p2_q1 = pairing(&p2, &q1);
+        const right_side_1 = e_p1_q1.mul(&e_p2_q1);
+        try std.testing.expect(left_side_1.equal(&right_side_1));
+
+        // Test bilinearity in second argument: e(P, Q1 + Q2) = e(P, Q1) * e(P, Q2)
+        const q1_plus_q2 = q1.add(&q2);
+        const left_side_2 = pairing(&p1, &q1_plus_q2);
+        const e_p1_q2 = pairing(&p1, &q2);
+        const right_side_2 = e_p1_q1.mul(&e_p1_q2);
+        try std.testing.expect(left_side_2.equal(&right_side_2));
+
+        // Test scalar multiplication
+        const scalar_times_p1 = p1.mul_by_int(test_case.scalar);
+        const left_side_3 = pairing(&scalar_times_p1, &q1);
+        const right_side_3 = e_p1_q1.pow(test_case.scalar);
+        try std.testing.expect(left_side_3.equal(&right_side_3));
+    }
+
+    //Test infinity properties
+    const result_inf_gen = pairing(&G1.INFINITY, &G2.GENERATOR);
+    try std.testing.expect(result_inf_gen.equal(&Fp12.ONE));
+
+    const result_gen_inf = pairing(&G1.GENERATOR, &G2.INFINITY);
+    try std.testing.expect(result_gen_inf.equal(&Fp12.ONE));
+
+    const result_both_inf = pairing(&G1.INFINITY, &G2.INFINITY);
+    try std.testing.expect(result_both_inf.equal(&Fp12.ONE));
+}

--- a/src/crypto/root.zig
+++ b/src/crypto/root.zig
@@ -47,3 +47,6 @@ pub const Keccak256_Accel = @import("keccak256_accel.zig");
 
 // KZG commitments for EIP-4844
 pub const c_kzg = @import("c_kzg");
+
+// BN254 for precompiles
+pub const bn254 = @import("bn254.zig");


### PR DESCRIPTION
## Summary
This PR adds a complete BN254 elliptic curve implementation to support Ethereum's three required elliptic curve precompiles: ECADD (0x06), ECMUL (0x07), and ECPAIRING (0x08).
Changes

## Add complete BN254 curve mathematical foundation:

- Field Arithmetic: Fp (base field), Fp2/Fp6/Fp12 (extension fields), Fr (scalar field)
- Elliptic Curve Groups: G1 (points on y² = x³ + 3), G2 (points on twist curve over Fp2)
- Pairing Operations: Miller loop, final exponentiation, optimal ate pairing

## Implementation Details

- Tower field extensions constructed as Fp → Fp2 → Fp6 → Fp12 using irreducible binomials
- G1 points use Jacobian projective coordinates to avoid expensive inversions
- G2 points operate on sextic twist curve to reduce computational overhead
- Pairing implementation uses optimal ate pairing
- Code is currently standalone - integration with EVM precompile dispatcher is future work

## Testing

- Unit tests for all field arithmetic operations (addition, multiplication, inversion, etc.)
- Elliptic curve tests using expected values from Arkworks
- Pairing operation tests using known relations

## Future Work

- Connect BN254 implementation to EVM precompile dispatcher
- Implement actual ECADD, ECMUL, and ECPAIRING precompile handlers
- Refactor to keep all constants in a single file
- Optimize performance:
    - Montgomery form
    - use NAF for EC scalar multiplication
    - use GLS/GLV for scalar multiplication
    - use base p for faster evaluation of the hard part of the final exponentiation

Closes #1 

🤖 Mostly generated with Claude Sonnet 4