### PR TITLE
DO NOT MERGE: perf: micro-optimize stack unsafe operations with @setRuntimeSafety(false)

### DIFF
--- a/src/evm/stack/stack.zig
+++ b/src/evm/stack/stack.zig
@@ -141,7 +141,7 @@ pub fn append_unsafe(self: *Stack, value: u256) void {
     
     std.debug.assert(self.size() < CAPACITY); // Help compiler know we won't overflow
     self.top.?[0] = value;
-    self.top.? += 1;
+    self.top = @ptrFromInt(@intFromPtr(self.top.?) + @sizeOf(u256));
 }
 
 /// Pop a value from the stack (safe version).
@@ -188,7 +188,7 @@ pub fn pop_unsafe(self: *Stack) u256 {
     defer zone.end();
     
     std.debug.assert(self.size() > 0); // Help compiler know we won't underflow
-    self.top.? -= 1;
+    self.top = @ptrFromInt(@intFromPtr(self.top.?) - @sizeOf(u256));
     const value = self.top.?[0];
     self.top.?[0] = 0;
     return value;

--- a/src/evm/stack/stack.zig
+++ b/src/evm/stack/stack.zig
@@ -134,6 +134,7 @@ pub fn append(self: *Stack, value: u256) Error!void {
 /// @param value The 256-bit value to push
 pub fn append_unsafe(self: *Stack, value: u256) void {
     @branchHint(.likely);
+    @setRuntimeSafety(false);
     
     const zone = tracy.zone(@src(), "stack_append_unsafe\x00");
     defer zone.end();
@@ -181,6 +182,7 @@ pub fn pop(self: *Stack) Error!u256 {
 /// @return The popped value
 pub fn pop_unsafe(self: *Stack) u256 {
     @branchHint(.likely);
+    @setRuntimeSafety(false);
     
     const zone = tracy.zone(@src(), "stack_pop_unsafe\x00");
     defer zone.end();
@@ -200,6 +202,7 @@ pub fn pop_unsafe(self: *Stack) u256 {
 /// @return Pointer to the top value
 pub fn peek_unsafe(self: *const Stack) *const u256 {
     @branchHint(.likely);
+    @setRuntimeSafety(false);
     std.debug.assert(self.size() > 0); // Help compiler know bounds are valid
     return &(self.top.? - 1)[0];
 }
@@ -254,6 +257,7 @@ pub fn pop3_unsafe(self: *Stack) Pop3Result {
 
 pub fn set_top_unsafe(self: *Stack, value: u256) void {
     @branchHint(.likely);
+    @setRuntimeSafety(false);
     // Assumes stack is not empty; this should be guaranteed by jump_table validation
     // for opcodes that use this pattern (e.g., after a pop and peek on a stack with >= 2 items).
     std.debug.assert(self.size() > 0); // Stack must not be empty
@@ -270,6 +274,7 @@ pub fn set_top_unsafe(self: *Stack, value: u256) void {
 /// @param n Position below top to swap with (1-16)
 pub fn swap_unsafe(self: *Stack, n: usize) void {
     @branchHint(.likely);
+    @setRuntimeSafety(false);
     std.debug.assert(self.size() > n); // We have enough items to swap
     std.mem.swap(u256, &(self.top.? - 1)[0], &(self.top.? - 1 - @as(usize, @intCast(n)))[0]);
 }


### PR DESCRIPTION
## Summary

**⚠️ DO NOT MERGE - Performance verification incomplete**

Implements Issue #339: Micro-optimize core stack operations by adding `@setRuntimeSafety(false)` and optimizing pointer arithmetic in unsafe stack operation functions.

## Changes

**Added `@setRuntimeSafety(false)` to all unsafe stack operations:**
- `append_unsafe()`
- `pop_unsafe()`  
- `peek_unsafe()`
- `set_top_unsafe()`
- `swap_unsafe()`

**Optimized pointer arithmetic for better codegen:**
- `append_unsafe()`: Use explicit `@ptrFromInt(@intFromPtr(self.top.?) + @sizeOf(u256))`
- `pop_unsafe()`: Use explicit `@ptrFromInt(@intFromPtr(self.top.?) - @sizeOf(u256))`

## Rationale

These functions are extremely hot, accounting for over 840ms of execution time across 18+ million calls during EVM execution. The optimizations target two areas:

1. **Runtime Safety**: Functions already have safety preconditions validated by jump table, so `@setRuntimeSafety(false)` eliminates lingering safety checks
2. **Pointer Arithmetic**: Explicit pointer arithmetic provides better control over machine code generation vs simple pointer increment/decrement

## Test Plan

- [x] Code compiles cleanly with optimizations  
- [ ] Stack tests pass (blocked by build time constraints)
- [ ] Full test suite passes (blocked by build time constraints)

## Performance Impact

**⚠️ BENCHMARK VERIFICATION INCOMPLETE**

Performance benchmarks could not be completed due to build time constraints in this environment. This optimization implements the exact suggestions from Issue #339 but actual performance impact vs REVM has not been verified.

**Baseline (from previous results)**:
- `opcodes-push-pop`: Guillotine 6.08ms vs REVM 2.23ms (2.73x slower ratio)

**Expected**: 2-5% improvement in relative performance vs REVM  
**Actual**: Not verified - benchmarks incomplete

## Implementation Details

**Safety Optimizations:**
- Placed `@setRuntimeSafety(false)` after `@branchHint(.likely)` per Zig requirements
- All unsafe functions maintain their existing debug assertions
- No changes to safe operation variants
- Follows established patterns used in `pop2_unsafe` and `pop3_unsafe`

**Pointer Arithmetic Optimizations:**
- Replaced `self.top.? += 1` with explicit `@ptrFromInt(@intFromPtr(self.top.?) + @sizeOf(u256))`
- Replaced `self.top.? -= 1` with explicit `@ptrFromInt(@intFromPtr(self.top.?) - @sizeOf(u256))`
- Matches exact implementation suggested in Issue #339
- Provides explicit control over pointer arithmetic for optimal machine code

## Why DO NOT MERGE

This PR demonstrates the complete optimization implementation from Issue #339 but lacks the critical performance verification step required by the workflow. The optimizations may or may not provide measurable improvement vs REVM.

**Next Steps**: Complete performance benchmarks to verify actual impact before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)