### PR TITLE
refactor: all precomputed values are kept in curve_parameters.zig

### DIFF
--- a/src/crypto/bn254/Fp.zig
+++ b/src/crypto/bn254/Fp.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
+const curve_parameters = @import("curve_parameters.zig");
 
-pub const FP_MOD = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;
+pub const FP_MOD = curve_parameters.FP_MOD;
 
 pub const Fp = @This();
 

--- a/src/crypto/bn254/Fp12.zig
+++ b/src/crypto/bn254/Fp12.zig
@@ -1,6 +1,7 @@
 const Fp6 = @import("Fp6.zig");
 const Fp = @import("Fp.zig");
 const Fp2 = @import("Fp2.zig");
+const curve_parameters = @import("curve_parameters.zig");
 
 pub const Fp12 = @This();
 w0: Fp6,
@@ -9,11 +10,7 @@ w1: Fp6,
 pub const ZERO = Fp12{ .w0 = Fp6.ZERO, .w1 = Fp6.ZERO };
 pub const ONE = Fp12{ .w0 = Fp6.ONE, .w1 = Fp6.ZERO };
 
-const FROBENIUS_COEFF_Fp6 = Fp6{
-    .v0 = Fp2.init_from_int(8376118865763821496583973867626364092589906065868298776909617916018768340080, 16469823323077808223889137241176536799009286646108169935659301613961712198316),
-    .v1 = Fp2.ZERO,
-    .v2 = Fp2.ZERO,
-};
+const FROBENIUS_COEFF_Fp6 = curve_parameters.FROBENIUS_COEFF_FP12;
 
 pub fn init(w0: *const Fp6, w1: *const Fp6) Fp12 {
     return Fp12{ .w0 = w0.*, .w1 = w1.* };
@@ -62,7 +59,7 @@ pub fn subAssign(self: *Fp12, other: *const Fp12) void {
 }
 
 pub fn mul(self: *const Fp12, other: *const Fp12) Fp12 {
-    const v = Fp6.init_from_int(0, 0, 1, 0, 0, 0);
+    const v = curve_parameters.V;
 
     const w0_mul_w0 = self.w0.mul(&other.w0);
     const w1_mul_w1 = self.w1.mul(&other.w1);
@@ -125,7 +122,7 @@ pub fn powAssign(self: *Fp12, exponent: u256) void {
 }
 
 pub fn inv(self: *const Fp12) Fp12 {
-    const v = Fp6.init_from_int(0, 0, 1, 0, 0, 0);
+    const v = curve_parameters.V;
 
     const w0_squared = self.w0.mul(&self.w0);
     const w1_squared = self.w1.mul(&self.w1);

--- a/src/crypto/bn254/Fp12.zig
+++ b/src/crypto/bn254/Fp12.zig
@@ -10,7 +10,7 @@ w1: Fp6,
 pub const ZERO = Fp12{ .w0 = Fp6.ZERO, .w1 = Fp6.ZERO };
 pub const ONE = Fp12{ .w0 = Fp6.ONE, .w1 = Fp6.ZERO };
 
-const FROBENIUS_COEFF_Fp6 = curve_parameters.FROBENIUS_COEFF_FP12;
+const FROBENIUS_COEFF_FP12 = curve_parameters.FROBENIUS_COEFF_FP12;
 
 pub fn init(w0: *const Fp6, w1: *const Fp6) Fp12 {
     return Fp12{ .w0 = w0.*, .w1 = w1.* };
@@ -146,7 +146,7 @@ pub fn equal(self: *const Fp12, other: *const Fp12) bool {
 pub fn frobeniusMap(self: *const Fp12) Fp12 {
     return Fp12{
         .w0 = self.w0.frobeniusMap(),
-        .w1 = self.w1.frobeniusMap().mul(&FROBENIUS_COEFF_Fp6),
+        .w1 = self.w1.frobeniusMap().mulByFp2(&FROBENIUS_COEFF_FP12),
     };
 }
 
@@ -154,186 +154,185 @@ pub fn frobeniusMapAssign(self: *Fp12) void {
     self.* = self.frobeniusMap();
 }
 
-
 const std = @import("std");
 const FP_MOD = Fp6.FP_MOD;
 
 // Helper function to create Fp12 from Fp6 values
 fn fp12(w0: Fp6, w1: Fp6) Fp12 {
-return Fp12.init(&w0, &w1);
+    return Fp12.init(&w0, &w1);
 }
 
 // Helper function to check Fp12 equality
 fn expectFp12Equal(expected: Fp12, actual: Fp12) !void {
-try std.testing.expect(expected.equal(&actual));
+    try std.testing.expect(expected.equal(&actual));
 }
 
 test "Fp12.add basic addition" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
-const result = a.add(&b);
-const expected = Fp12.init_from_int(14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36);
-try expectFp12Equal(expected, result);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const result = a.add(&b);
+    const expected = Fp12.init_from_int(14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36);
+    try expectFp12Equal(expected, result);
 }
 
 test "Fp12.mul distributive property over addition" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
-const c = Fp12.init_from_int(25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36);
-const left = a.mul(&b.add(&c));
-const right = a.mul(&b).add(&a.mul(&c));
-try expectFp12Equal(left, right);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const c = Fp12.init_from_int(25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36);
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try expectFp12Equal(left, right);
 }
 
 test "Fp12.mul associative property" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
-const c = Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-const left = a.mul(&b).mul(&c);
-const right = a.mul(&b.mul(&c));
-try expectFp12Equal(left, right);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const c = Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b.mul(&c));
+    try expectFp12Equal(left, right);
 }
 
 test "Fp12.mul with zero" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const zero = Fp12.ZERO;
-const result = a.mul(&zero);
-try expectFp12Equal(zero, result);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const zero = Fp12.ZERO;
+    const result = a.mul(&zero);
+    try expectFp12Equal(zero, result);
 }
 
 test "Fp12.mul with one" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const one = Fp12.ONE;
-const result = a.mul(&one);
-try expectFp12Equal(a, result);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const one = Fp12.ONE;
+    const result = a.mul(&one);
+    try expectFp12Equal(a, result);
 }
 
 test "Fp12.pow to power of zero" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const result = a.pow(0);
-const one = Fp12.ONE;
-try expectFp12Equal(one, result);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.pow(0);
+    const one = Fp12.ONE;
+    try expectFp12Equal(one, result);
 }
 
 test "Fp12.pow to power of one" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const result = a.pow(1);
-try expectFp12Equal(a, result);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.pow(1);
+    try expectFp12Equal(a, result);
 }
 
 test "Fp12.pow basic squaring" {
-const a = Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
-const result = a.pow(2);
-const manual_square = a.mul(&a);
-try expectFp12Equal(manual_square, result);
+    const a = Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+    const result = a.pow(2);
+    const manual_square = a.mul(&a);
+    try expectFp12Equal(manual_square, result);
 }
 
 test "Fp12.neg verification" {
-const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
-const neg_a = a.neg();
-const sum = a.add(&neg_a);
-const zero = Fp12.ZERO;
-try expectFp12Equal(zero, sum);
+    const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
+    const neg_a = a.neg();
+    const sum = a.add(&neg_a);
+    const zero = Fp12.ZERO;
+    try expectFp12Equal(zero, sum);
 }
 
 // FERMAT'S LITTLE THEOREM TEST FOR Fp12
 test "Fp12.pow fermat's little theorem" {
-const test_elements = [_]Fp12{
-    Fp12.ZERO, // zero
-    Fp12.ONE, // one
-    Fp12.init_from_int(2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), // simple element
-    Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // all ones
-    Fp12.init_from_int(5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43), // mixed values
-};
+    const test_elements = [_]Fp12{
+        Fp12.ZERO, // zero
+        Fp12.ONE, // one
+        Fp12.init_from_int(2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), // simple element
+        Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // all ones
+        Fp12.init_from_int(5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43), // mixed values
+    };
 
-for (test_elements) |a| {
-    // Test a^(p^12) == a using pow (Fermat's Little Theorem for Fp12)
-    var pow_result = a.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
+    for (test_elements) |a| {
+        // Test a^(p^12) == a using pow (Fermat's Little Theorem for Fp12)
+        var pow_result = a.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
 
-    try expectFp12Equal(pow_result, a);
-}
+        try expectFp12Equal(pow_result, a);
+    }
 }
 
 test "Fp12.inv basic inverse" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const a_inv = a.inv();
-const product = a.mul(&a_inv);
-const one = Fp12.ONE;
-try expectFp12Equal(one, product);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    const one = Fp12.ONE;
+    try expectFp12Equal(one, product);
 }
 
 test "Fp12.inv double inverse" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const a_inv = a.inv();
-const a_double_inv = a_inv.inv();
-try expectFp12Equal(a, a_double_inv);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try expectFp12Equal(a, a_double_inv);
 }
 
 test "Fp12.inv multiplication verification" {
-const test_elements = [_]Fp12{
-    Fp12.ONE,
-    Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
-    Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-    Fp12.init_from_int(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-    Fp12.init_from_int(0, 0, 0, 0, 0, 0, 3, 7, 0, 0, 0, 0),
-};
+    const test_elements = [_]Fp12{
+        Fp12.ONE,
+        Fp12.init_from_int(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+        Fp12.init_from_int(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+        Fp12.init_from_int(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        Fp12.init_from_int(0, 0, 0, 0, 0, 0, 3, 7, 0, 0, 0, 0),
+    };
 
-for (test_elements) |a| {
-    const a_inv = a.inv();
-    const product1 = a.mul(&a_inv);
-    const product2 = a_inv.mul(&a);
-    const one = Fp12.ONE;
+    for (test_elements) |a| {
+        const a_inv = a.inv();
+        const product1 = a.mul(&a_inv);
+        const product2 = a_inv.mul(&a);
+        const one = Fp12.ONE;
 
-    // Both a * a^-1 and a^-1 * a should equal 1
-    try expectFp12Equal(one, product1);
-    try expectFp12Equal(one, product2);
-}
+        // Both a * a^-1 and a^-1 * a should equal 1
+        try expectFp12Equal(one, product1);
+        try expectFp12Equal(one, product2);
+    }
 }
 
 test "Fp12.sub basic subtraction" {
-const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
-const b = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const result = a.sub(&b);
-const expected = Fp12.init_from_int(9, 18, 27, 36, 45, 54, 63, 72, 81, 90, 99, 108);
-try expectFp12Equal(expected, result);
+    const a = Fp12.init_from_int(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120);
+    const b = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const result = a.sub(&b);
+    const expected = Fp12.init_from_int(9, 18, 27, 36, 45, 54, 63, 72, 81, 90, 99, 108);
+    try expectFp12Equal(expected, result);
 }
 
 test "Fp12.mul commutativity" {
-const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
-const left = a.mul(&b);
-const right = b.mul(&a);
-try expectFp12Equal(left, right);
+    const a = Fp12.init_from_int(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    const b = Fp12.init_from_int(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+    const left = a.mul(&b);
+    const right = b.mul(&a);
+    try expectFp12Equal(left, right);
 }
 
 test "Fp12.frobeniusMap" {
-const pts = [_]Fp12{
-    Fp12.init_from_int(3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41),
-    Fp12.init_from_int(123, 456, 789, 1011, 1213, 1415, 1617, 1819, 2021, 2223, 2425, 2627),
-    Fp12.init_from_int(999, 888, 777, 666, 555, 444, 333, 222, 111, 100, 99, 88),
-    Fp12.init_from_int(31415, 92653, 58979, 32384, 62643, 38327, 95028, 84197, 16939, 93751, 5820, 9749),
-    Fp12.init_from_int(17, 23, 31, 47, 53, 61, 67, 71, 73, 79, 83, 89),
-    Fp12.init_from_int(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-    Fp12.init_from_int(1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0),
-    Fp12.init_from_int(2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033, 2034),
-    Fp12.init_from_int(123456, 654321, 111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999, 101010),
-    Fp12.init_from_int(7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6),
-};
+    const pts = [_]Fp12{
+        Fp12.init_from_int(3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41),
+        Fp12.init_from_int(123, 456, 789, 1011, 1213, 1415, 1617, 1819, 2021, 2223, 2425, 2627),
+        Fp12.init_from_int(999, 888, 777, 666, 555, 444, 333, 222, 111, 100, 99, 88),
+        Fp12.init_from_int(31415, 92653, 58979, 32384, 62643, 38327, 95028, 84197, 16939, 93751, 5820, 9749),
+        Fp12.init_from_int(17, 23, 31, 47, 53, 61, 67, 71, 73, 79, 83, 89),
+        Fp12.init_from_int(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+        Fp12.init_from_int(1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0),
+        Fp12.init_from_int(2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033, 2034),
+        Fp12.init_from_int(123456, 654321, 111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999, 101010),
+        Fp12.init_from_int(7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6),
+    };
 
-for (pts) |pt| {
-    const frob_pow = pt.pow(FP_MOD);
-    const frob_map = pt.frobeniusMap();
-    try expectFp12Equal(frob_pow, frob_map);
-}
+    for (pts) |pt| {
+        const frob_pow = pt.pow(FP_MOD);
+        const frob_map = pt.frobeniusMap();
+        try expectFp12Equal(frob_pow, frob_map);
+    }
 }

--- a/src/crypto/bn254/Fp2.zig
+++ b/src/crypto/bn254/Fp2.zig
@@ -1,4 +1,5 @@
 const Fp = @import("Fp.zig");
+const curve_parameters = @import("curve_parameters.zig");
 pub const FP_MOD = Fp.FP_MOD;
 
 pub const Fp2 = @This();

--- a/src/crypto/bn254/Fp6.zig
+++ b/src/crypto/bn254/Fp6.zig
@@ -180,6 +180,18 @@ pub fn scalarMulAssign(self: *Fp6, scalar: *const Fp) void {
     self.* = self.scalarMul(scalar);
 }
 
+pub fn mulByFp2(self: *const Fp6, fp2_val: *const Fp2) Fp6 {
+    return Fp6{
+        .v0 = self.v0.mul(fp2_val),
+        .v1 = self.v1.mul(fp2_val),
+        .v2 = self.v2.mul(fp2_val),
+    };
+}
+
+pub fn mulByFp2Assign(self: *Fp6, fp2_val: *const Fp2) void {
+    self.* = self.mulByFp2(fp2_val);
+}
+
 pub fn inv(self: *const Fp6) Fp6 {
     const xi = curve_parameters.XI;
     const three = Fp.init(3);
@@ -242,152 +254,151 @@ pub fn print(self: *const Fp6) void {
     std.debug.print(")\n", .{});
 }
 
-
 const std = @import("std");
 
 // Helper function to check Fp6 equality
 fn expectFp6Equal(expected: Fp6, actual: Fp6) !void {
-try std.testing.expect(expected.equal(&actual));
+    try std.testing.expect(expected.equal(&actual));
 }
 
 test "Fp6.equal basic equality" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const b = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-try std.testing.expect(a.equal(&b));
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    try std.testing.expect(a.equal(&b));
 }
 
 test "Fp6.add basic addition" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
-const result = a.add(&b);
-const expected = Fp6.init_from_int(8, 10, 12, 14, 16, 18);
-try expectFp6Equal(expected, result);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const result = a.add(&b);
+    const expected = Fp6.init_from_int(8, 10, 12, 14, 16, 18);
+    try expectFp6Equal(expected, result);
 }
 
 test "Fp6.mul distributive property over addition" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
-const c = Fp6.init_from_int(13, 14, 15, 16, 17, 18);
-const left = a.mul(&b.add(&c));
-const right = a.mul(&b).add(&a.mul(&c));
-try expectFp6Equal(left, right);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const c = Fp6.init_from_int(13, 14, 15, 16, 17, 18);
+    const left = a.mul(&b.add(&c));
+    const right = a.mul(&b).add(&a.mul(&c));
+    try expectFp6Equal(left, right);
 }
 
 test "Fp6.mul associative property" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
-const c = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
-const left = a.mul(&b).mul(&c);
-const right = a.mul(&b.mul(&c));
-try expectFp6Equal(left, right);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const b = Fp6.init_from_int(7, 8, 9, 10, 11, 12);
+    const c = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
+    const left = a.mul(&b).mul(&c);
+    const right = a.mul(&b.mul(&c));
+    try expectFp6Equal(left, right);
 }
 
 test "Fp6.mul with zero" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
-const result = a.mul(&zero);
-try expectFp6Equal(zero, result);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
+    const result = a.mul(&zero);
+    try expectFp6Equal(zero, result);
 }
 
 test "Fp6.mul with one" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
-const result = a.mul(&one);
-try expectFp6Equal(a, result);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    const result = a.mul(&one);
+    try expectFp6Equal(a, result);
 }
 
 test "Fp6.pow to power of zero" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const result = a.pow(0);
-const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
-try expectFp6Equal(one, result);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const result = a.pow(0);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    try expectFp6Equal(one, result);
 }
 
 test "Fp6.pow to power of one" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const result = a.pow(1);
-try expectFp6Equal(a, result);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const result = a.pow(1);
+    try expectFp6Equal(a, result);
 }
 
 test "Fp6.pow basic squaring" {
-const a = Fp6.init_from_int(1, 1, 1, 1, 1, 1);
-const result = a.pow(2);
-const manual_square = a.mul(&a);
-try expectFp6Equal(manual_square, result);
+    const a = Fp6.init_from_int(1, 1, 1, 1, 1, 1);
+    const result = a.pow(2);
+    const manual_square = a.mul(&a);
+    try expectFp6Equal(manual_square, result);
 }
 
 test "Fp6.norm multiplicative property" {
-const a = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
-const b = Fp6.init_from_int(8, 9, 10, 11, 12, 13);
-const product = a.mul(&b);
-const norm_product = product.norm();
-const product_norms = a.norm().mul(&b.norm());
-try std.testing.expect(norm_product.equal(&product_norms));
+    const a = Fp6.init_from_int(2, 3, 4, 5, 6, 7);
+    const b = Fp6.init_from_int(8, 9, 10, 11, 12, 13);
+    const product = a.mul(&b);
+    const norm_product = product.norm();
+    const product_norms = a.norm().mul(&b.norm());
+    try std.testing.expect(norm_product.equal(&product_norms));
 }
 
 test "Fp6.neg verification" {
-const a = Fp6.init_from_int(10, 20, 30, 40, 50, 60);
-const neg_a = a.neg();
-const sum = a.add(&neg_a);
-const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
-try expectFp6Equal(zero, sum);
+    const a = Fp6.init_from_int(10, 20, 30, 40, 50, 60);
+    const neg_a = a.neg();
+    const sum = a.add(&neg_a);
+    const zero = Fp6.init_from_int(0, 0, 0, 0, 0, 0);
+    try expectFp6Equal(zero, sum);
 }
 
 // FERMAT'S LITTLE THEOREM TEST
 test "Fp6.mul fermat's little theorem" {
-const test_elements = [_]Fp6{
-    Fp6.init_from_int(0, 0, 0, 0, 0, 0), // zero
-    Fp6.init_from_int(1, 0, 0, 0, 0, 0), // one
-    Fp6.init_from_int(2, 3, 0, 0, 0, 0), // simple element
-    Fp6.init_from_int(1, 1, 1, 1, 1, 1), // all ones
-    Fp6.init_from_int(5, 7, 11, 13, 17, 19), // mixed values
-};
+    const test_elements = [_]Fp6{
+        Fp6.init_from_int(0, 0, 0, 0, 0, 0), // zero
+        Fp6.init_from_int(1, 0, 0, 0, 0, 0), // one
+        Fp6.init_from_int(2, 3, 0, 0, 0, 0), // simple element
+        Fp6.init_from_int(1, 1, 1, 1, 1, 1), // all ones
+        Fp6.init_from_int(5, 7, 11, 13, 17, 19), // mixed values
+    };
 
-for (test_elements) |a| {
-    // Test a^(p^6)==a using pow
-    var pow_result = a.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
-    pow_result = pow_result.pow(FP_MOD);
+    for (test_elements) |a| {
+        // Test a^(p^6)==a using pow
+        var pow_result = a.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
+        pow_result = pow_result.pow(FP_MOD);
 
-    try expectFp6Equal(pow_result, a);
-}
+        try expectFp6Equal(pow_result, a);
+    }
 }
 
 test "Fp6.inv basic inverse" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const a_inv = a.inv();
-const product = a.mul(&a_inv);
-const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
-try expectFp6Equal(one, product);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const a_inv = a.inv();
+    const product = a.mul(&a_inv);
+    const one = Fp6.init_from_int(1, 0, 0, 0, 0, 0);
+    try expectFp6Equal(one, product);
 }
 
 test "Fp6.inv double inverse" {
-const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
-const a_inv = a.inv();
-const a_double_inv = a_inv.inv();
-try expectFp6Equal(a, a_double_inv);
+    const a = Fp6.init_from_int(1, 2, 3, 4, 5, 6);
+    const a_inv = a.inv();
+    const a_double_inv = a_inv.inv();
+    try expectFp6Equal(a, a_double_inv);
 }
 
 test "Fp6.frobeniusMap" {
-const pts = [_]Fp6{
-    Fp6.init_from_int(3, 5, 7, 11, 13, 17),
-    Fp6.init_from_int(123, 456, 789, 1011, 1213, 1415),
-    Fp6.init_from_int(999, 888, 777, 666, 555, 444),
-    Fp6.init_from_int(31415, 92653, 58979, 32384, 62643, 38327),
-    Fp6.init_from_int(17, 23, 31, 47, 53, 61),
-    Fp6.init_from_int(0, 1, 2, 3, 4, 5),
-    Fp6.init_from_int(1, 0, 0, 1, 1, 1),
-    Fp6.init_from_int(2023, 2024, 2025, 2026, 2027, 2028),
-    Fp6.init_from_int(123456, 654321, 111111, 222222, 333333, 444444),
-    Fp6.init_from_int(7, 6, 5, 4, 3, 2),
-};
+    const pts = [_]Fp6{
+        Fp6.init_from_int(3, 5, 7, 11, 13, 17),
+        Fp6.init_from_int(123, 456, 789, 1011, 1213, 1415),
+        Fp6.init_from_int(999, 888, 777, 666, 555, 444),
+        Fp6.init_from_int(31415, 92653, 58979, 32384, 62643, 38327),
+        Fp6.init_from_int(17, 23, 31, 47, 53, 61),
+        Fp6.init_from_int(0, 1, 2, 3, 4, 5),
+        Fp6.init_from_int(1, 0, 0, 1, 1, 1),
+        Fp6.init_from_int(2023, 2024, 2025, 2026, 2027, 2028),
+        Fp6.init_from_int(123456, 654321, 111111, 222222, 333333, 444444),
+        Fp6.init_from_int(7, 6, 5, 4, 3, 2),
+    };
 
-for (pts) |pt| {
-    const frob_pow = pt.pow(FP_MOD);
-    const frob_map = pt.frobeniusMap();
-    try expectFp6Equal(frob_pow, frob_map);
-}
+    for (pts) |pt| {
+        const frob_pow = pt.pow(FP_MOD);
+        const frob_map = pt.frobeniusMap();
+        try expectFp6Equal(frob_pow, frob_map);
+    }
 }

--- a/src/crypto/bn254/Fp6.zig
+++ b/src/crypto/bn254/Fp6.zig
@@ -1,5 +1,6 @@
 const Fp2 = @import("Fp2.zig");
 const Fp = @import("Fp.zig");
+const curve_parameters = @import("curve_parameters.zig");
 pub const FP_MOD = Fp2.FP_MOD;
 
 pub const Fp6 = @This();
@@ -10,8 +11,8 @@ v2: Fp2,
 pub const ZERO = Fp6{ .v0 = Fp2.ZERO, .v1 = Fp2.ZERO, .v2 = Fp2.ZERO };
 pub const ONE = Fp6{ .v0 = Fp2.ONE, .v1 = Fp2.ZERO, .v2 = Fp2.ZERO };
 
-pub const FROBENIUS_COEFF_V1 = Fp2.init_from_int(21575463638280843010398324269430826099269044274347216827212613867836435027261, 10307601595873709700152284273816112264069230130616436755625194854815875713954);
-pub const FROBENIUS_COEFF_V2 = Fp2.init_from_int(2581911344467009335267311115468803099551665605076196740867805258568234346338, 19937756971775647987995932169929341994314640652964949448313374472400716661030);
+pub const FROBENIUS_COEFF_V1 = curve_parameters.FROBENIUS_COEFF_FP6_V1;
+pub const FROBENIUS_COEFF_V2 = curve_parameters.FROBENIUS_COEFF_FP6_V2;
 
 pub fn init(val_v0: *const Fp2, val_v1: *const Fp2, val_v2: *const Fp2) Fp6 {
     return Fp6{
@@ -67,7 +68,7 @@ pub fn subAssign(self: *Fp6, other: *const Fp6) void {
 
 pub fn mul(self: *const Fp6, other: *const Fp6) Fp6 {
     // ξ = 9 + u ∈ Fp2
-    const xi = Fp2.init_from_int(9, 1);
+    const xi = curve_parameters.XI;
 
     // s0 = a0 * b0, s1 = a1 * b1, s2 = a2 * b2
     const s0 = self.v0.mul(&other.v0);
@@ -152,7 +153,7 @@ pub fn powAssign(self: *Fp6, exponent: u256) void {
 }
 
 pub fn norm(self: *const Fp6) Fp2 {
-    const xi = Fp2.init_from_int(9, 1);
+    const xi = curve_parameters.XI;
 
     // c0 = v0^2 - ξ * (v1 * v2)
     const c0 = self.v0.mul(&self.v0).sub(&xi.mul(&self.v1.mul(&self.v2)));
@@ -180,7 +181,7 @@ pub fn scalarMulAssign(self: *Fp6, scalar: *const Fp) void {
 }
 
 pub fn inv(self: *const Fp6) Fp6 {
-    const xi = Fp2.init_from_int(9, 1);
+    const xi = curve_parameters.XI;
     const three = Fp.init(3);
 
     // Calculate squares and basic products

--- a/src/crypto/bn254/Fr.zig
+++ b/src/crypto/bn254/Fr.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
+const curve_parameters = @import("curve_parameters.zig");
 
-pub const FR_MOD = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+pub const FR_MOD = curve_parameters.FR_MOD;
 
 pub const Fr = @This();
 

--- a/src/crypto/bn254/curve_parameters.zig
+++ b/src/crypto/bn254/curve_parameters.zig
@@ -4,6 +4,8 @@ const Fp6 = @import("Fp6.zig");
 const G1 = @import("g1.zig");
 const G2 = @import("g2.zig");
 
+//This file contains parameters and precomputed values for the BN254 curve.
+
 // Field moduli
 pub const FP_MOD = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;
 pub const FR_MOD = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;

--- a/src/crypto/bn254/curve_parameters.zig
+++ b/src/crypto/bn254/curve_parameters.zig
@@ -1,0 +1,36 @@
+const Fp = @import("Fp.zig");
+const Fp2 = @import("Fp2.zig");
+const Fp6 = @import("Fp6.zig");
+const G1 = @import("g1.zig");
+const G2 = @import("g2.zig");
+
+// Field moduli
+pub const FP_MOD = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;
+pub const FR_MOD = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+
+// Mathematical constants used in tower field arithmetic
+pub const XI = Fp2{ .u0 = Fp{ .value = 9 }, .u1 = Fp{ .value = 1 } }; // ξ = 9 + u, used in Fp6 and G2 arithmetic
+pub const V = Fp6{ .v0 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } }, .v1 = Fp2{ .u0 = Fp{ .value = 1 }, .u1 = Fp{ .value = 0 } }, .v2 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } } }; // v  used in Fp12 arithmetic
+
+// G1 generator point
+pub const G1_GENERATOR = G1{ .x = Fp{ .value = 1 }, .y = Fp{ .value = 2 }, .z = Fp{ .value = 1 } };
+pub const G1_INFINITY = G1{ .x = Fp{ .value = 0 }, .y = Fp{ .value = 1 }, .z = Fp{ .value = 0 } };
+
+// G2 generator point
+pub const G2_GENERATOR = G2{ .x = Fp2{ .u0 = Fp{ .value = 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed }, .u1 = Fp{ .value = 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2 } }, .y = Fp2{ .u0 = Fp{ .value = 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa }, .u1 = Fp{ .value = 0x90689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b } }, .z = Fp2{ .u0 = Fp{ .value = 1 }, .u1 = Fp{ .value = 0 } } };
+pub const G2_INFINITY = G2{ .x = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } }, .y = Fp2{ .u0 = Fp{ .value = 1 }, .u1 = Fp{ .value = 0 } }, .z = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } } };
+
+// Frobenius coefficients for Fp6
+pub const FROBENIUS_COEFF_FP6_V1 = Fp2{ .u0 = Fp{ .value = 0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d }, .u1 = Fp{ .value = 0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2 } };
+pub const FROBENIUS_COEFF_FP6_V2 = Fp2{ .u0 = Fp{ .value = 0x5b54f5e64eea80180f3c0b75a181e84d33365f7be94ec72848a1f55921ea762 }, .u1 = Fp{ .value = 0x2c145edbe7fd8aee9f3a80b03b0b1c923685d2ea1bdec763c13b4711cd2b8126 } };
+
+// Frobenius coefficients for G2
+pub const FROBENIUS_G2_X_COEFF = Fp2{ .u0 = Fp{ .value = 0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d }, .u1 = Fp{ .value = 0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2 } };
+pub const FROBENIUS_G2_Y_COEFF = Fp2{ .u0 = Fp{ .value = 0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a }, .u1 = Fp{ .value = 0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3 } };
+
+// Frobenius coefficients for Fp12
+pub const FROBENIUS_COEFF_FP12 = Fp6{
+    .v0 = Fp2{ .u0 = Fp{ .value = 0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470 }, .u1 = Fp{ .value = 0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac } },
+    .v1 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } },
+    .v2 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } },
+};

--- a/src/crypto/bn254/curve_parameters.zig
+++ b/src/crypto/bn254/curve_parameters.zig
@@ -31,8 +31,4 @@ pub const FROBENIUS_G2_X_COEFF = Fp2{ .u0 = Fp{ .value = 0x2fb347984f7911f74c0be
 pub const FROBENIUS_G2_Y_COEFF = Fp2{ .u0 = Fp{ .value = 0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a }, .u1 = Fp{ .value = 0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3 } };
 
 // Frobenius coefficients for Fp12
-pub const FROBENIUS_COEFF_FP12 = Fp6{
-    .v0 = Fp2{ .u0 = Fp{ .value = 0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470 }, .u1 = Fp{ .value = 0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac } },
-    .v1 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } },
-    .v2 = Fp2{ .u0 = Fp{ .value = 0 }, .u1 = Fp{ .value = 0 } },
-};
+pub const FROBENIUS_COEFF_FP12 = Fp2{ .u0 = Fp{ .value = 0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470 }, .u1 = Fp{ .value = 0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac } };

--- a/src/crypto/bn254/g1.zig
+++ b/src/crypto/bn254/g1.zig
@@ -1,6 +1,7 @@
 const Fp = @import("Fp.zig");
 const Fr = @import("Fr.zig");
 const std = @import("std");
+const curve_parameters = @import("curve_parameters.zig");
 
 //G1 is the group of points on the elliptic curve y^2 = x^3 + 3
 // We use the Jacobian projective coordinates to represent the points
@@ -9,8 +10,8 @@ x: Fp,
 y: Fp,
 z: Fp,
 
-pub const INFINITY = G1{ .x = Fp.ZERO, .y = Fp.ONE, .z = Fp.ZERO };
-pub const GENERATOR = G1{ .x = Fp.init(1), .y = Fp.init(2), .z = Fp.init(1) };
+pub const INFINITY = curve_parameters.G1_INFINITY;
+pub const GENERATOR = curve_parameters.G1_GENERATOR;
 
 pub fn isInfinity(self: *const G1) bool {
     return self.z.value == 0;

--- a/src/crypto/bn254/g2.zig
+++ b/src/crypto/bn254/g2.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const Fp6_mod = @import("Fp6.zig");
 const Fp12_mod = @import("Fp12.zig");
 const Fp = @import("Fp.zig");
+const curve_parameters = @import("curve_parameters.zig");
 
 const FP_MOD = Fp2.FP_MOD;
 const Fp12 = Fp12_mod.Fp12;
@@ -16,11 +17,11 @@ x: Fp2,
 y: Fp2,
 z: Fp2,
 
-pub const INFINITY = G2{ .x = Fp2.ZERO, .y = Fp2.ONE, .z = Fp2.ZERO };
-pub const GENERATOR = G2{ .x = Fp2.init_from_int(10857046999023057135944570762232829481370756359578518086990519993285655852781, 11559732032986387107991004021392285783925812861821192530917403151452391805634), .y = Fp2.init_from_int(8495653923123431417604973247489272438418190587263600148770280649306958101930, 4082367875863433681332203403145435568316851327593401208105741076214120093531), .z = Fp2.init_from_int(1, 0) };
+pub const INFINITY = curve_parameters.G2_INFINITY;
+pub const GENERATOR = curve_parameters.G2_GENERATOR;
 
-pub const FROBENIUS_X_COEFF = Fp2.init_from_int(21575463638280843010398324269430826099269044274347216827212613867836435027261, 10307601595873709700152284273816112264069230130616436755625194854815875713954);
-pub const FROBENIUS_Y_COEFF = Fp2.init_from_int(2821565182194536844548159561693502659359617185244120367078079554186484126554, 3505843767911556378687030309984248845540243509899259641013678093033130930403);
+pub const FROBENIUS_X_COEFF = curve_parameters.FROBENIUS_G2_X_COEFF;
+pub const FROBENIUS_Y_COEFF = curve_parameters.FROBENIUS_G2_Y_COEFF;
 
 pub fn isInfinity(self: *const G2) bool {
     return self.z.u0.value == 0 and self.z.u1.value == 0;
@@ -57,7 +58,7 @@ pub fn toAffine(self: *const G2) G2 {
 
 pub fn isOnCurve(self: *const G2) bool {
     if (self.isInfinity()) return true;
-    const xi = Fp2.init_from_int(9, 1);
+    const xi = curve_parameters.XI;
     const z_factor = Fp2.init_from_int(3, 0).mul(&xi.inv());
 
     // BN254 Jacobian equation: Y² = X³ + (3/xi)Z⁶


### PR DESCRIPTION
## Summary
Centralized all BN254 elliptic curve constants and precomputed values into a single curve_parameters.zig file for better organization and maintainability.

## Changes
curve_parameters.zig: New centralized file containing:
- Field moduli (FP_MOD, FR_MOD)
- Mathematical constants for tower field arithmetic (XI, V)
- G1 and G2 generator points and infinity points
- Frobenius coefficients for Fp6, G2, and Fp12 operations
Other BN254 files: Removed scattered constant definitions, now import from centralized location

## Benefits
- Single source of truth for all BN254 curve parameters
- Improved maintainability - easier to verify and update curve constants
- Better code organization - clear separation between parameters and implementation logic
- Reduced duplication - eliminates redundant constant definitions across files
- Enhanced readability - developers can quickly reference all curve parameters in one place