### PR TITLE
♻️ refactor: remove unused evm.return_data field

### DIFF
--- a/bench/run_revm_comparison.zig
+++ b/bench/run_revm_comparison.zig
@@ -54,7 +54,7 @@ fn compareSimpleContract(allocator: std.mem.Allocator) !void {
         defer memory_db.deinit();
         
         const db_interface = memory_db.to_database_interface();
-        var vm = try Vm.init(allocator, db_interface, null, null, null, null, 0, false, null);
+        var vm = try Vm.init(allocator, db_interface, null, null, null, 0, false, null);
         defer vm.deinit();
         
         try vm.state.set_balance(caller, 1000000);
@@ -141,7 +141,7 @@ fn compareArithmeticOps(allocator: std.mem.Allocator) !void {
             defer memory_db.deinit();
             
             const db_interface = memory_db.to_database_interface();
-            var vm = try Vm.init(allocator, db_interface, null, null, null, null, 0, false, null);
+            var vm = try Vm.init(allocator, db_interface, null, null, null, 0, false, null);
             defer vm.deinit();
             
             const caller = Address.from_u256(0x1000);
@@ -232,7 +232,7 @@ fn compareMemoryOps(allocator: std.mem.Allocator) !void {
             defer memory_db.deinit();
             
             const db_interface = memory_db.to_database_interface();
-            var vm = try Vm.init(allocator, db_interface, null, null, null, null, 0, false, null);
+            var vm = try Vm.init(allocator, db_interface, null, null, null, 0, false, null);
             defer vm.deinit();
             
             const caller = Address.from_u256(0x1000);

--- a/src/evm/evm.zig
+++ b/src/evm/evm.zig
@@ -48,8 +48,6 @@ chain_rules: ChainRules,
 context: Context,
 
 // Data fields (moderate access frequency)
-/// Return data from the most recent operation
-return_data: []u8 = &[_]u8{},
 /// Optional tracer for capturing execution traces
 tracer: ?std.io.AnyWriter = null,
 
@@ -73,7 +71,6 @@ comptime {
 ///
 /// @param allocator Memory allocator for VM operations
 /// @param database Database interface for state management
-/// @param return_data Return data buffer (optional, defaults to empty slice)
 /// @param table Opcode dispatch table (optional, defaults to JumpTable.DEFAULT)
 /// @param chain_rules Protocol rules (optional, defaults to ChainRules.DEFAULT)
 /// @param context Execution context (optional, defaults to Context.init())
@@ -91,13 +88,12 @@ comptime {
 ///
 /// Example using direct initialization:
 /// ```zig
-/// var evm = try Evm.init(allocator, database, null, null, null, null, 0, false, null);
+/// var evm = try Evm.init(allocator, database, null, null, null, 0, false, null);
 /// defer evm.deinit();
 /// ```
 pub fn init(
     allocator: std.mem.Allocator,
     database: @import("state/database_interface.zig").DatabaseInterface,
-    return_data: ?[]u8,
     table: ?JumpTable,
     chain_rules: ?ChainRules,
     context: ?Context,
@@ -117,7 +113,6 @@ pub fn init(
     Log.debug("Evm.init: EVM initialization complete", .{});
     return Evm{
         .allocator = allocator,
-        .return_data = return_data orelse &[_]u8{},
         .table = table orelse JumpTable.DEFAULT,
         .chain_rules = chain_rules orelse ChainRules.DEFAULT,
         .state = state,
@@ -146,7 +141,6 @@ pub fn reset(self: *Evm) void {
     // Reset execution state
     self.depth = 0;
     self.read_only = false;
-    self.return_data = &[_]u8{};
 }
 
 pub usingnamespace @import("evm/set_context.zig");

--- a/src/evm/evm/call_contract.zig
+++ b/src/evm/evm/call_contract.zig
@@ -138,11 +138,8 @@ pub inline fn call_contract(self: *Vm, caller: primitives.Address.Address, to: p
 
         // For REVERT, we return partial gas
         if (err == ExecutionError.Error.REVERT) {
-            const output = if (self.return_data.len > 0)
-                try self.allocator.dupe(u8, self.return_data)
-            else
-                null;
-            return CallResult{ .success = false, .gas_left = contract.gas, .output = output };
+            // REVERT returns partial gas but no output data in error case
+            return CallResult{ .success = false, .gas_left = contract.gas, .output = null };
         }
 
         // Other errors consume all gas

--- a/src/evm/evm/delegatecall_contract.zig
+++ b/src/evm/evm/delegatecall_contract.zig
@@ -92,11 +92,8 @@ pub fn delegatecall_contract(self: *Vm, current: primitives.Address.Address, cod
 
         // For REVERT, we return partial gas
         if (err == ExecutionError.Error.REVERT) {
-            const output = if (self.return_data.len > 0)
-                try self.allocator.dupe(u8, self.return_data)
-            else
-                null;
-            return CallResult{ .success = false, .gas_left = contract.gas, .output = output };
+            // REVERT returns partial gas but no output data in error case
+            return CallResult{ .success = false, .gas_left = contract.gas, .output = null };
         }
 
         // Other errors consume all gas


### PR DESCRIPTION
## Summary

- Removes the unused `return_data` field from the `Evm` struct
- Updates all related code to eliminate references to this field
- Simplifies the `Evm.init()` function signature

## Context

As identified in #368, the `return_data` field in the `Evm` struct is unused and creates confusion about where return data is actually stored. Return data is properly handled at the Frame level through `frame.return_data`, making the EVM-level field redundant.

## Changes

1. **Removed `return_data` field** from `Evm` struct (src/evm/evm.zig)
2. **Updated `Evm.init()`** to remove the `return_data` parameter
3. **Updated `EvmBuilder`** to remove the `withReturnData()` method
4. **Fixed error handling** in `call_contract.zig` and `delegatecall_contract.zig` for REVERT cases
5. **Updated benchmark code** to use the new `Evm.init()` signature

## Test Plan

- [x] `zig build` passes
- [x] `zig build test` passes  
- [x] `zig build bench` passes
- [x] All existing tests continue to work correctly

Fixes #368

🤖 Generated with [Claude Code](https://claude.ai/code)