### PR TITLE
⚡ perf: optimize memory.ensure_context_capacity with inline fast path

### DIFF
--- a/src/evm/memory/memory.zig
+++ b/src/evm/memory/memory.zig
@@ -96,6 +96,7 @@ const slice_ops = @import("slice.zig");
 // Context operations
 pub const context_size = context_ops.context_size;
 pub const ensure_context_capacity = context_ops.ensure_context_capacity;
+pub const ensure_context_capacity_slow = context_ops.ensure_context_capacity_slow;
 pub const resize_context = context_ops.resize_context;
 pub const size = context_ops.size;
 pub const total_size = context_ops.total_size;


### PR DESCRIPTION
## Summary
- Optimized `ensure_context_capacity` function with an inline fast path that avoids function call overhead when memory is already sufficient
- Renamed original implementation to `ensure_context_capacity_slow` (noinline)
- Added new inline `ensure_context_capacity` that checks if buffer is already large enough before calling slow path

## Performance Impact
The fast path check `if (self.shared_buffer_ref.items.len >= required_total_len)` allows the function to return immediately with 0 when no memory expansion is needed, which is the common case. This avoids:
- Function call overhead to the noinline version
- Debug logging in the slow path
- Additional calculations in the slow path

## Test plan
- [x] All existing tests pass (`zig build && zig build test`)
- [x] No functional changes - only performance optimization

🤖 Generated with [Claude Code](https://claude.ai/code)