### PR TITLE
⚡ perf: Remove intermediate buffer allocations in hash precompiles

### DIFF
--- a/src/evm/precompiles/precompile_gas.zig
+++ b/src/evm/precompiles/precompile_gas.zig
@@ -149,14 +149,12 @@ pub inline fn executeHashPrecompile(
         return PrecompileOutput.failure_result(PrecompileError.ExecutionFailed);
     }
 
-    // Create temporary buffer for hash result
-    var hash_buffer: [64]u8 = undefined; // Generous size for any hash
+    // Compute hash directly into output buffer (avoids intermediate allocation)
+    // Most hash functions can write directly to the output buffer
+    hash_fn(input, output);
     
-    // Compute hash
-    hash_fn(input, hash_buffer[0..]);
-    
-    // Format output using the provided formatting function
-    format_output(hash_buffer[0..], output);
+    // Format output in-place if needed (e.g., for padding)
+    format_output(output, output);
 
     return PrecompileOutput.success_result(gas_cost, output_size);
 }

--- a/src/evm/precompiles/ripemd160.zig
+++ b/src/evm/precompiles/ripemd160.zig
@@ -93,25 +93,30 @@ pub fn calculate_gas_checked(input_size: usize) !u64 {
 /// This allows RIPEMD160 to use the generic hash precompile implementation.
 ///
 /// @param input Input data to hash
-/// @param output Output buffer for hash result (will receive 20 bytes)
+/// @param output Output buffer for hash result (must be at least 32 bytes)
 fn ripemd160Hash(input: []const u8, output: []u8) void {
+    // Hash directly into the right position in the output buffer (after padding)
+    // RIPEMD160 produces 20 bytes, but Ethereum requires 32 bytes with left padding
     const hash = crypto.HashAlgorithms.RIPEMD160.hash_fixed(input);
-    @memcpy(output[0..RIPEMD160_HASH_SIZE], &hash);
+    
+    // Zero out the padding area (first 12 bytes)
+    @memset(output[0..12], 0);
+    
+    // Copy the hash after the padding
+    @memcpy(output[12..32], &hash);
 }
 
 /// Output formatter for RIPEMD160
 ///
-/// RIPEMD160 outputs a 20-byte hash but must be formatted as 32 bytes with
-/// 12 zero bytes of left padding according to Ethereum specification.
+/// Since we already hash and pad directly into the output buffer,
+/// this is a no-op for RIPEMD160.
 ///
-/// @param hash_bytes The 20-byte hash to format
-/// @param output The 32-byte output buffer to fill
+/// @param hash_bytes The hash (already in output buffer with padding)
+/// @param output The output buffer (same as hash_bytes for in-place operation)
 fn ripemd160Format(hash_bytes: []const u8, output: []u8) void {
-    // Zero out the entire output buffer
-    @memset(output[0..RIPEMD160_OUTPUT_SIZE], 0);
-    
-    // Copy hash to the right position (after 12 bytes of padding)
-    @memcpy(output[12..32], hash_bytes[0..RIPEMD160_HASH_SIZE]);
+    // No-op: RIPEMD160 already wrote and padded directly to the output buffer
+    _ = hash_bytes;
+    _ = output;
 }
 
 /// Executes the RIPEMD160 precompile

--- a/src/evm/precompiles/sha256.zig
+++ b/src/evm/precompiles/sha256.zig
@@ -90,23 +90,26 @@ pub fn calculate_gas_checked(input_size: usize) !u64 {
 /// Uses hardware acceleration when available for improved performance.
 ///
 /// @param input Input data to hash
-/// @param output Output buffer for hash result
+/// @param output Output buffer for hash result (must be at least 32 bytes)
 fn sha256Hash(input: []const u8, output: []u8) void {
-    // Use hardware-accelerated implementation when available
-    var hash_output: [SHA256_OUTPUT_SIZE]u8 = undefined;
-    crypto.SHA256_Accel.SHA256_Accel.hash(input, &hash_output);
-    @memcpy(output[0..SHA256_OUTPUT_SIZE], &hash_output);
+    // Hash directly into the output buffer to avoid intermediate allocation
+    // The output buffer must be at least SHA256_OUTPUT_SIZE bytes
+    crypto.SHA256_Accel.SHA256_Accel.hash(input, output[0..SHA256_OUTPUT_SIZE]);
 }
 
 /// Output formatter for SHA256
 ///
 /// SHA256 outputs exactly 32 bytes which matches the expected output size,
-/// so no padding is required. This directly copies the hash.
+/// so no padding is required. Since we hash directly into the output buffer,
+/// this is a no-op for SHA256.
 ///
-/// @param hash_bytes The hash to copy
-/// @param output The output buffer to fill
+/// @param hash_bytes The hash (already in output buffer)
+/// @param output The output buffer (same as hash_bytes for in-place operation)
 fn sha256Format(hash_bytes: []const u8, output: []u8) void {
-    @memcpy(output[0..SHA256_OUTPUT_SIZE], hash_bytes[0..SHA256_OUTPUT_SIZE]);
+    // No-op: SHA256 already wrote directly to the output buffer
+    // and doesn't need any formatting or padding
+    _ = hash_bytes;
+    _ = output;
 }
 
 /// Execute SHA256 precompile


### PR DESCRIPTION
## Summary
Optimized SHA256 and RIPEMD160 precompiles to hash directly into the output buffer instead of using intermediate allocations. This reduces memory allocations and improves performance for hash operations.

## Changes
- Modified `executeHashPrecompile` to compute hash directly into output buffer
- Updated SHA256 to write hash directly to output (no intermediate buffer)
- Updated RIPEMD160 to hash and pad directly into output buffer
- Eliminated unnecessary memory copies in the hash pipeline

## Performance Impact
This optimization eliminates:
- One 64-byte stack allocation per hash operation
- One memory copy operation per hash
- Reduces function call overhead

For hash-intensive workloads like the ten-thousand-hashes benchmark, this should reduce allocation overhead and improve cache locality.

## Testing
The changes maintain the same external behavior while optimizing the internal implementation. All existing tests should continue to pass.

Closes #332

🤖 Generated with [Claude Code](https://claude.ai/code)