### PR TITLE
🎉 feat: implement CALLCODE opcode with EIP-150/2929 gas and host path Add callcode variant to Host.CallParam

### DIFF
--- a/src/evm/execution/system.zig
+++ b/src/evm/execution/system.zig
@@ -964,15 +964,123 @@ pub fn op_call(context: *anyopaque) ExecutionError.Error!void {
 }
 
 pub fn op_callcode(context: *anyopaque) ExecutionError.Error!void {
-    const ctx = @as(*Frame, @ptrCast(@alignCast(context)));
-    _ = ctx;
+    const frame = @as(*Frame, @ptrCast(@alignCast(context)));
 
-    // TODO: Implementation requires:
-    // - vm instance for callcode operations
-    // - frame.contract.address access
-    // - frame.is_static checks
-    // - frame.return_data operations
-    // - handle_call_result integration
+    // Pop parameters from stack (same layout as CALL)
+    const gas = try frame.stack.pop();
+    const to = try frame.stack.pop();
+    const value = try frame.stack.pop();
+    const args_offset = try frame.stack.pop();
+    const args_size = try frame.stack.pop();
+    const ret_offset = try frame.stack.pop();
+    const ret_size = try frame.stack.pop();
+
+    // CALLCODE obeys static context for value transfers
+    if (frame.is_static() and value != 0) {
+        return ExecutionError.Error.WriteProtection;
+    }
+
+    // Depth limit
+    if (validate_call_depth(frame)) {
+        try frame.stack.append(0);
+        return;
+    }
+
+    const to_address = from_u256(to);
+
+    // Compute memory expansion costs safely first
+    const args_end = if (args_size == 0) 0 else blk: {
+        if (args_offset > std.math.maxInt(u64) or args_size > std.math.maxInt(u64))
+            return ExecutionError.Error.InvalidOffset;
+        const offset = @as(u64, @intCast(args_offset));
+        const size = @as(u64, @intCast(args_size));
+        if (offset > std.math.maxInt(u64) - size)
+            return ExecutionError.Error.GasUintOverflow;
+        break :blk offset + size;
+    };
+
+    const ret_end = if (ret_size == 0) 0 else blk: {
+        if (ret_offset > std.math.maxInt(u64) or ret_size > std.math.maxInt(u64))
+            return ExecutionError.Error.InvalidOffset;
+        const offset = @as(u64, @intCast(ret_offset));
+        const size = @as(u64, @intCast(ret_size));
+        if (offset > std.math.maxInt(u64) - size)
+            return ExecutionError.Error.GasUintOverflow;
+        break :blk offset + size;
+    };
+
+    const max_memory_size = @max(args_end, ret_end);
+    const memory_expansion_cost = if (max_memory_size > 0) frame.memory.get_expansion_cost(max_memory_size) else 0;
+
+    // Base gas cost for CALLCODE is same as CALL (700 at Tangerine)
+    var total_gas_cost: u64 = GasConstants.CALL_BASE_COST + memory_expansion_cost;
+
+    // EIP-2929 cold/warm account access cost
+    if (frame.is_at_least(.BERLIN)) {
+        const access_cost = try frame.access_address(to_address);
+        if (access_cost > GasConstants.WarmStorageReadCost) {
+            total_gas_cost += GasConstants.ColdAccountAccessCost - GasConstants.WarmStorageReadCost;
+        }
+    }
+
+    // Value transfer cost applies (CALLVALUE), but CALLCODE cannot create new accounts
+    if (value != 0) {
+        total_gas_cost += GasConstants.CallValueTransferGas;
+    }
+
+    // Charge operation costs before memory actions
+    try frame.consume_gas(total_gas_cost);
+
+    // Expand memory and get slices
+    const args = try get_call_args(frame, args_offset, args_size);
+    try ensure_return_memory(frame, ret_offset, ret_size);
+
+    // Calculate gas to forward with 63/64 rule and stipend for value
+    const gas_limit = calculate_call_gas_amount(frame, gas, value, total_gas_cost);
+    // Deduct forwarded gas from caller; stipend is not deducted
+    const gas_to_deduct = if (value != 0) gas_limit - GasConstants.CallStipend else gas_limit;
+    try frame.consume_gas(gas_to_deduct);
+
+    // Snapshot state for potential revert
+    const snapshot = frame.journal.create_snapshot();
+
+    // Execute via host using callcode variant; host must run code at `to` in current storage
+    const call_params = CallParams{ .callcode = .{
+        .caller = frame.contract_address,
+        .to = to_address,
+        .value = value,
+        .input = args,
+        .gas = gas_limit,
+    } };
+
+    const call_result = frame.host.call(call_params) catch {
+        frame.journal.revert_to_snapshot(snapshot);
+        try frame.stack.append(0);
+        return;
+    };
+
+    // Commit or revert snapshot based on success
+    if (!call_result.success) {
+        frame.journal.revert_to_snapshot(snapshot);
+    }
+
+    // Return unused gas to caller
+    frame.gas_remaining += call_result.gas_left;
+
+    // Write return data
+    if (call_result.output) |output| {
+        if (ret_size > 0) {
+            const ret_offset_usize = @as(usize, @intCast(ret_offset));
+            const ret_size_usize = @as(usize, @intCast(ret_size));
+            const copy_size = @min(output.len, ret_size_usize);
+            if (copy_size > 0) {
+                try frame.memory.set_data_bounded(ret_offset_usize, output, 0, copy_size);
+            }
+        }
+    }
+
+    // Push success flag
+    try frame.stack.append(if (call_result.success) 1 else 0);
 }
 
 pub fn op_delegatecall(context: *anyopaque) ExecutionError.Error!void {

--- a/src/evm/host.zig
+++ b/src/evm/host.zig
@@ -13,6 +13,15 @@ pub const CallParams = union(enum) {
         input: []const u8,
         gas: u64,
     },
+    /// CALLCODE operation: execute external code with current storage/context
+    /// Executes code at `to`, but uses caller's storage and address context
+    callcode: struct {
+        caller: Address,
+        to: Address,
+        value: u256,
+        input: []const u8,
+        gas: u64,
+    },
     /// DELEGATECALL operation (preserves caller context)
     delegatecall: struct {
         caller: Address,  // Original caller, not current contract


### PR DESCRIPTION
Add callcode variant to Host.CallParams\n- Implement op_callcode mirroring CALL semantics without new-account cost\n- Apply 63/64 gas forwarding, cold/warm access cost, value transfer cost, stipend handling\n- Wire memory expansion and return data handling\n\n🤖 Generated with Claude Code (https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>