### PR TITLE
🎉 feat: implement EIP-2200/EIP-3529 SSTORE original value tracking and gas/refund logic

### DIFF
--- a/src/evm/evm.zig
+++ b/src/evm/evm.zig
@@ -226,7 +226,6 @@ pub fn deinit(self: *Evm) void {
 
     // Clean up self-destruct tracking
     self.self_destruct.deinit();
-
     // Clean up created contracts tracking
     self.created_contracts.deinit();
 
@@ -237,16 +236,7 @@ pub fn deinit(self: *Evm) void {
         self.frame_stack = null;
     }
 
-    // Clean up created_contracts - always initialized in init()
-    self.created_contracts.deinit();
-
-    // Clean up self_destruct if it was initialized
-    // Since self_destruct is initially undefined and only initialized in call(),
-    // we need to check if it has a valid allocator (non-null pointer)
-    // The allocator field in the HashMap will be valid if init() was called
-    if (@intFromPtr(self.self_destruct.allocator.ptr) != 0) {
-        self.self_destruct.deinit();
-    }
+    // created_contracts is initialized in init(); single deinit above is sufficient
 }
 
 /// Reset the EVM for reuse without deallocating memory.

--- a/src/evm/frame.zig
+++ b/src/evm/frame.zig
@@ -298,6 +298,12 @@ pub const Frame = struct {
         try self.state.set_storage(self.contract_address, slot, value);
     }
 
+    /// Get the original storage value for this slot at transaction start if recorded
+    pub fn get_original_storage(self: *const Frame, slot: u256) u256 {
+        if (self.journal.get_original_storage(self.contract_address, slot)) |val| return val;
+        return self.state.get_storage(self.contract_address, slot) catch 0;
+    }
+
     pub fn get_transient_storage(self: *const Frame, slot: u256) u256 {
         return self.state.get_transient_storage(self.contract_address, slot) catch 0; // Return 0 on error (EVM behavior)
     }

--- a/src/evm/self_destruct.zig
+++ b/src/evm/self_destruct.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const primitives = @import("primitives");
 const Address = primitives.Address.Address;
+const CreatedContracts = @import("created_contracts.zig").CreatedContracts;
 
 /// Error type for SelfDestruct operations
 pub const StateError = error{OutOfMemory};


### PR DESCRIPTION
## Summary

This PR implements EIP-2200 (Istanbul) and EIP-3529 (London) SSTORE gas calculation with proper original value tracking for accurate gas costs and refunds.

### Key Changes:
- **Original value tracking**: `CallJournal` now persists the first-seen storage value per (address, key) in a transaction
- **Frame API**: Added `Frame.get_original_storage()` to retrieve original values
- **Gas calculation**: New `calculateSstoreCost()` function implements full EIP-2200/EIP-3529 logic with original/current/new value comparison
- **Cold/warm handling**: Properly applies EIP-2929 cold surcharge when accessing cold storage slots
- **Refund logic**: Correctly handles refunds for clearing storage and undoing clears

## Technical Details

### Storage Cost Rules (EIP-2200/3529):
1. **No-op** (new == current): Charges warm SLOAD cost
2. **First write** (original == current):
   - 0 → non-zero: 20,000 gas
   - non-zero → different: 2,900 gas (Berlin+) or 5,000 (Istanbul)
   - Clearing to zero earns refund: 4,800 (Berlin+) or 15,000 (Istanbul)
3. **Subsequent writes** (slot already dirty): 100 gas (Berlin+) or 800 (Istanbul)
   - Refund adjustments based on transitions relative to original value

### Files Changed:
- `call_frame_stack.zig`: Added original storage tracking to CallJournal
- `frame.zig`: Added `get_original_storage()` method
- `gas/storage_costs.zig`: Implemented `calculateSstoreCost()` with full EIP logic
- `execution/storage.zig`: Updated `op_sstore` to use new gas calculation
- `evm.zig`: Cleaned up duplicate deinit calls
- `self_destruct.zig`: Added missing import

## Test Plan
- [x] All existing tests pass
- [x] Storage gas calculations match EIP specifications
- [x] Original value tracking persists across nested calls
- [x] Refunds are properly accumulated and capped

🤖 Generated with [Claude Code](https://claude.ai/code)