### PR TITLE
feat: surface EVM execution errors in devtool UI

### DIFF
--- a/src/devtool/debug_state.zig
+++ b/src/devtool/debug_state.zig
@@ -78,6 +78,9 @@ pub const EvmStateJson = struct {
     storage: []StorageEntry,
     logs: [][]const u8,
     returnData: []const u8,
+    // Execution error surfacing for UI
+    errorOccurred: bool,
+    errorName: []const u8,
     // Full original bytecode as 0x-hex for block visualization
     codeHex: []const u8,
     completed: bool,
@@ -298,6 +301,8 @@ pub fn createEmptyEvmStateJson(allocator: std.mem.Allocator) !EvmStateJson {
         .storage = try empty_storage.toOwnedSlice(),
         .logs = try empty_logs.toOwnedSlice(),
         .returnData = try allocator.dupe(u8, "0x"),
+        .errorOccurred = false,
+        .errorName = try allocator.dupe(u8, ""),
         .completed = false,
         .currentInstructionIndex = 0,
         .currentBlockStartIndex = 0,
@@ -328,6 +333,7 @@ pub fn freeEvmStateJson(allocator: std.mem.Allocator, state: EvmStateJson) void 
     allocator.free(state.logs);
 
     allocator.free(state.returnData);
+    allocator.free(state.errorName);
 
     // Free blocks
     for (state.blocks) |blk| {

--- a/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
+++ b/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
@@ -64,7 +64,10 @@ const EvmDebugger = (props: EvmDebuggerProps) => {
 				setState={props.setState as Setter<EvmState>}
 			/>
 			<div class="mx-auto flex max-w-7xl flex-col gap-6 px-3 pb-6 sm:px-6">
-				<ErrorAlert error={props.error()} setError={props.setError} />
+				<ErrorAlert
+					error={props.error() || (props.state.errorOccurred ? props.state.errorName || 'Execution error' : '')}
+					setError={props.setError}
+				/>
 				<StateSummary state={props.state as EvmState} isUpdating={isUpdating()} />
 				<Show when={activePanel() === 'all' || activePanel() === 'bytecode'}>
 					<div class="flex flex-col gap-4">

--- a/src/devtool/solid/lib/types.ts
+++ b/src/devtool/solid/lib/types.ts
@@ -22,6 +22,9 @@ export interface EvmState {
 	storage: Array<{ key: string; value: string }>
 	logs: string[]
 	returnData: string
+	// New error fields surfaced from backend
+	errorOccurred?: boolean
+	errorName?: string
 	codeHex: string
 	completed: boolean
 	currentInstructionIndex: number

--- a/src/devtool/solid/lib/utils.ts
+++ b/src/devtool/solid/lib/utils.ts
@@ -87,6 +87,8 @@ export async function getEvmState(): Promise<EvmState> {
 				storage: parsed.storage || [],
 				logs: parsed.logs || [],
 				returnData: parsed.returnData || '0x',
+				errorName: parsed.errorName || '',
+				errorOccurred: parsed.errorOccurred || false,
 				completed: parsed.completed || false,
 				currentInstructionIndex: parsed.currentInstructionIndex || 0,
 				currentBlockStartIndex: parsed.currentBlockStartIndex || 0,


### PR DESCRIPTION
### TL;DR

Added error surfacing in the EVM debugger UI to display execution errors that occur during contract execution.

### What changed?

- Added `errorOccurred` and `errorName` fields to the `EvmStateJson` struct to track execution errors
- Updated the `DevtoolEvm` struct to track the last error that occurred during execution
- Modified the serialization logic to include error information in the JSON state
- Updated the UI components to display execution errors in the ErrorAlert component
- Added test cases to verify error handling for stack underflow and proper execution

[Enregistrement de l’écran 2025-08-14 à 20.14.48.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Ixv26J255SJvXs8tSYR0/02f4dd09-deb1-4729-bad0-1649b2ef89f6.mov" />](https://app.graphite.dev/media/video/Ixv26J255SJvXs8tSYR0/02f4dd09-deb1-4729-bad0-1649b2ef89f6.mov)