### PR TITLE
feat: add evm.zig tests to build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1141,6 +1141,23 @@ pub fn build(b: *std.Build) void {
     const evm_package_test_step = b.step("test-evm-all", "Run all EVM tests via package");
     evm_package_test_step.dependOn(&run_evm_package_test.step);
 
+    // Add evm.zig tests
+    const evm_core_test = b.addTest(.{
+        .name = "evm-core-test",
+        .root_source_file = b.path("src/evm/evm.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    evm_core_test.root_module.addImport("evm", evm_mod);
+    evm_core_test.root_module.addImport("primitives", primitives_mod);
+    evm_core_test.root_module.addImport("crypto", crypto_mod);
+    evm_core_test.root_module.addImport("build_options", build_options_mod);
+    evm_core_test.addIncludePath(b.path("src/bn254_wrapper"));
+    const run_evm_core_test = b.addRunArtifact(evm_core_test);
+    const evm_core_test_step = b.step("test-evm-core", "Run evm.zig tests");
+    evm_core_test_step.dependOn(&run_evm_core_test.step);
+    evm_package_test_step.dependOn(&run_evm_core_test.step);
+
     // Add comprehensive opcodes tests package
     const opcodes_package_test = b.addTest(.{
         .name = "opcodes-package-test",
@@ -1888,6 +1905,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_config_test.step);
     test_step.dependOn(&run_differential_test.step);
     test_step.dependOn(&run_staticcall_test.step);
+    test_step.dependOn(&run_evm_core_test.step);
     // benchmark runner test removed - file no longer exists
 
     // Add inline ops test


### PR DESCRIPTION
### TL;DR

Added a new test step for the EVM core module.

Note: This test will error with compilation errors fixed in #530.

### What changed?

- Added a new test configuration `evm-core-test` that specifically tests the `src/evm/evm.zig` file
- Created a dedicated step `test-evm-core` to run these tests
- Integrated this test into the existing test infrastructure by:
  - Making the `test-evm-all` step depend on the new EVM core test
  - Adding the EVM core test to the main test step

### How to test?

Run the new test step with:
```
zig build test-evm-core
```

Or run it as part of all EVM tests:
```
zig build test-evm-all
```

Or include it in the full test suite:
```
zig build test
```

### Why make this change?

This change improves test coverage by adding specific tests for the core EVM module. Having a dedicated test step for the EVM core allows developers to test just this component without running the entire test suite, which improves development efficiency.