### PR TITLE
feat: implement execution tracing with pause/resume support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -856,6 +856,30 @@ pub fn build(b: *std.Build) void {
     const compiler_test_step = b.step("test-compiler", "Run Compiler tests");
     compiler_test_step.dependOn(&run_compiler_test.step);
 
+    // Tracing test suite
+    // Add tracer tests (includes DebuggingTracer, NoOpTracer, LoggingTracer, FileTracer)
+    const tracer_test = b.addTest(.{
+        .name = "tracer-test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/evm/tracer.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    tracer_test.root_module.addImport("primitives", primitives_mod);
+    tracer_test.root_module.addImport("crypto", crypto_mod);
+    tracer_test.root_module.addImport("evm", evm_mod);
+    tracer_test.root_module.addImport("build_options", build_options_mod);
+    const run_tracer_test = b.addRunArtifact(tracer_test);
+
+    // Add tracer individual test step
+    const test_tracer_step = b.step("test-tracer", "Run tracer tests");
+    test_tracer_step.dependOn(&run_tracer_test.step);
+
+    // Combined tracing test step that runs all tracing-related tests
+    const tracing_test_step = b.step("test-tracing", "Run all tracing-related tests");
+    tracing_test_step.dependOn(&run_tracer_test.step);
+
     const devtool_test = b.addTest(.{
         .name = "devtool-test",
         .root_module = b.createModule(.{

--- a/src/evm/frame.zig
+++ b/src/evm/frame.zig
@@ -164,12 +164,6 @@ pub fn Frame(comptime config: FrameConfig) type {
                 self.tracer.afterOp(pc, opcode, Self, self);
             }
         }
-        /// Helper function to call tracer onError if tracer is configured
-        pub inline fn traceOnError(self: *Self, pc: u32, err: anyerror) void {
-            if (comptime config.TracerType != null) {
-                self.tracer.onError(pc, err, Self, self);
-            }
-        }
         /// Create a deep copy of the frame.
         /// This is used by DebugPlan to create a sidecar frame for validation.
         pub fn copy(self: *const Self, allocator: std.mem.Allocator) Error!Self {

--- a/src/evm/frame_interpreter.zig
+++ b/src/evm/frame_interpreter.zig
@@ -36,9 +36,7 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             .maxBytecodeSize = config.max_bytecode_size,
         });
         pub const WordType = config.WordType;
-        pub const Error = Frame.Error
-            || error{ OutOfMemory, TruncatedPush, InvalidJumpDestination, MissingJumpDestMetadata, InitcodeTooLarge }
-            || (if (config.TracerType != null) error{ ExecutionPaused } else error{});
+        pub const Error = Frame.Error || error{ OutOfMemory, TruncatedPush, InvalidJumpDestination, MissingJumpDestMetadata, InitcodeTooLarge } || (if (config.TracerType != null) error{ExecutionPaused} else error{});
         pub const HandlerFn = plan_mod.HandlerFn;
 
         const Self = @This();
@@ -217,7 +215,7 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
                 // Provide trace handlers to planner (compile-time gated)
                 planner.setTraceHandlers(&trace_before_op_handler, &trace_after_op_handler);
             }
-            
+
             // Use getOrAnalyze with the actual hardfork from host
             const plan_ptr = try planner.getOrAnalyze(bytecode, handlers, host.get_hardfork());
 
@@ -2561,10 +2559,10 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
                 // If tracer supports pause/resume, handle pause here
                 if (comptime @hasField(@TypeOf(self.tracer), "paused")) {
                     if (@field(self.tracer, "paused")) {
-                        if (comptime @hasDecl(@TypeOf(self.tracer), "set_resume_idx")) {
+                        if (comptime @hasDecl(@TypeOf(self.tracer), "setResumeIdx")) {
                             // Resume at the opcode handler index (next index)
                             const resume_idx: u32 = @intCast(interpreter.instruction_idx + 1);
-                            self.tracer.set_resume_idx(resume_idx);
+                            self.tracer.setResumeIdx(resume_idx);
                         }
                         return Error.ExecutionPaused;
                     }

--- a/src/evm/frame_interpreter.zig
+++ b/src/evm/frame_interpreter.zig
@@ -29,13 +29,16 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             .WordType = config.WordType,
             .maxBytecodeSize = config.max_bytecode_size,
             .stack_size = config.stack_size,
+            .inject_tracing = (config.TracerType != null),
         });
         pub const Plan = plan_mod.Plan(.{
             .WordType = config.WordType,
             .maxBytecodeSize = config.max_bytecode_size,
         });
         pub const WordType = config.WordType;
-        pub const Error = Frame.Error || error{ OutOfMemory, TruncatedPush, InvalidJumpDestination, MissingJumpDestMetadata, InitcodeTooLarge };
+        pub const Error = Frame.Error
+            || error{ OutOfMemory, TruncatedPush, InvalidJumpDestination, MissingJumpDestMetadata, InitcodeTooLarge }
+            || (if (config.TracerType != null) error{ ExecutionPaused } else error{});
         pub const HandlerFn = plan_mod.HandlerFn;
 
         const Self = @This();
@@ -210,6 +213,11 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             errdefer frame.deinit(allocator);
             var planner = try Planner.init(allocator, 32); // Small cache for frame interpreter
 
+            if (comptime config.TracerType != null) {
+                // Provide trace handlers to planner (compile-time gated)
+                planner.setTraceHandlers(&trace_before_op_handler, &trace_after_op_handler);
+            }
+            
             // Use getOrAnalyze with the actual hardfork from host
             const plan_ptr = try planner.getOrAnalyze(bytecode, handlers, host.get_hardfork());
 
@@ -238,19 +246,29 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             };
         }
 
-        /// Get current PC by instruction index (O(1) if mapping present)
+        /// Get current PC by instruction index.
+        /// When tracing is enabled, also resolves PCs at adjacent trace indices; otherwise identical to pre-change behavior.
         pub fn getCurrentPc(self: *const Self) ?Plan.PcType {
-            if (self.idx_to_pc.len != 0) {
-                const pc = self.idx_to_pc[self.instruction_idx];
-                const invalid_pc: Plan.PcType = std.math.maxInt(Plan.PcType);
-                if (pc != invalid_pc) {
-                    return pc;
-                } else {
-                    return null;
-                }
-            } else {
-                return null;
+            if (self.idx_to_pc.len == 0) return null;
+            const invalid_pc: Plan.PcType = std.math.maxInt(Plan.PcType);
+            const idx = self.instruction_idx;
+            // Exact index fast path
+            if (idx < self.idx_to_pc.len) {
+                const pc0 = self.idx_to_pc[idx];
+                if (pc0 != invalid_pc) return pc0;
             }
+            // Neighbor probes only compiled when tracing is enabled
+            if (comptime config.TracerType != null) {
+                if (idx + 1 < self.idx_to_pc.len) {
+                    const pc1 = self.idx_to_pc[idx + 1];
+                    if (pc1 != invalid_pc) return pc1;
+                }
+                if (idx > 0 and idx - 1 < self.idx_to_pc.len) {
+                    const pc2 = self.idx_to_pc[idx - 1];
+                    if (pc2 != invalid_pc) return pc2;
+                }
+            }
+            return null;
         }
 
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
@@ -265,7 +283,8 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             self.plan.debugPrint();
 
             if (self.plan.instructionStream.len == 0) return;
-            return try self.plan.instructionStream[0].handler(&self.frame, self.plan);
+            const start_idx: Plan.InstructionIndexType = if (comptime config.TracerType != null) self.instruction_idx else 0;
+            return try self.plan.instructionStream[start_idx].handler(&self.frame, self.plan);
         }
 
         /// Pretty print the interpreter state for debugging.
@@ -2527,10 +2546,34 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             const plan_ptr = @as(*const Plan, @ptrCast(@alignCast(plan)));
             const interpreter = @as(*Self, @fieldParentPtr("frame", self));
 
-            // Call tracer before operation
-            self.tracer.beforeOp(Frame, self);
+            // Resolve current PC robustly
+            const pc_opt = interpreter.getCurrentPc();
+            const pc_u32: u32 = @intCast(pc_opt orelse 0);
+            // Compute opcode from bytecode
+            const opcode: u8 = if (pc_opt) |pcv| blk: {
+                const p: usize = @intCast(pcv);
+                break :blk if (p < self.bytecode.len) self.bytecode[p] else 0;
+            } else 0;
 
-            // Get the next handler - trace handlers don't have metadata
+            // Call tracer.beforeOp via Frame helpers
+            if (comptime config.TracerType != null) {
+                self.traceBeforeOp(pc_u32, opcode);
+                // If tracer supports pause/resume, handle pause here
+                if (comptime @hasField(@TypeOf(self.tracer), "paused")) {
+                    if (@field(self.tracer, "paused")) {
+                        if (comptime @hasDecl(@TypeOf(self.tracer), "set_resume_idx")) {
+                            // Resume at the opcode handler index (next index)
+                            const resume_idx: u32 = @intCast(interpreter.instruction_idx + 1);
+                            self.tracer.set_resume_idx(resume_idx);
+                        }
+                        return Error.ExecutionPaused;
+                    }
+                }
+            }
+
+            // Move to opcode handler and dispatch
+            interpreter.instruction_idx += 1;
+            if (interpreter.instruction_idx >= plan_ptr.instructionStream.len) return Error.STOP;
             const next_handler = plan_ptr.instructionStream[interpreter.instruction_idx].handler;
             return dispatchNext(next_handler, self, plan_ptr);
         }
@@ -2540,10 +2583,22 @@ pub fn FrameInterpreter(comptime config: frame_mod.FrameConfig) type {
             const plan_ptr = @as(*const Plan, @ptrCast(@alignCast(plan)));
             const interpreter = @as(*Self, @fieldParentPtr("frame", self));
 
-            // Call tracer after operation
-            self.tracer.afterOp(Frame, self);
+            // Resolve current PC robustly
+            const pc_opt = interpreter.getCurrentPc();
+            const pc_u32: u32 = @intCast(pc_opt orelse 0);
+            const opcode: u8 = if (pc_opt) |pcv| blk: {
+                const p: usize = @intCast(pcv);
+                break :blk if (p < self.bytecode.len) self.bytecode[p] else 0;
+            } else 0;
 
-            // Get the next handler - trace handlers don't have metadata
+            // Call tracer.afterOp via Frame helper
+            if (comptime config.TracerType != null) {
+                self.traceAfterOp(pc_u32, opcode);
+            }
+
+            // Advance to the next instruction (entry index of next opcode)
+            interpreter.instruction_idx += 1;
+            if (interpreter.instruction_idx >= plan_ptr.instructionStream.len) return Error.STOP;
             const next_handler = plan_ptr.instructionStream[interpreter.instruction_idx].handler;
             return dispatchNext(next_handler, self, plan_ptr);
         }

--- a/src/evm/plan.zig
+++ b/src/evm/plan.zig
@@ -236,7 +236,7 @@ pub fn Plan(comptime cfg: PlanConfig) type {
         }
 
         /// Get the next instruction handler and advance the instruction pointer.
-        /// Advances by 1 or 2 based on whether the opcode has metadata.
+        /// Advances idx first (by 1 or 2 based on metadata), then returns the handler at the new idx.
         pub fn getNextInstruction(
             self: *const Self,
             idx: *InstructionIndexType,
@@ -311,26 +311,16 @@ pub fn Plan(comptime cfg: PlanConfig) type {
                 else => false,
             };
 
-            // Get the current handler, then advance index
-            if (idx.* >= self.instructionStream.len) {
-                log.warn("getNextInstruction: idx {} >= instructionStream.len {}", .{ idx.*, self.instructionStream.len });
-                return &end_of_stream_handler;
-            }
-            const handler = self.instructionStream[idx.*].handler;
-
-            // Debug logging for null handler issue
-            const handler_addr = @intFromPtr(handler);
-            std.debug.print("getNextInstruction: idx={}, opcode_value=0x{x}, handler_addr=0x{x}\n", .{ idx.*, opcode_value, handler_addr });
-            if (handler_addr < 0x1000) {
-                std.debug.print("ERROR: handler from instructionStream[{}] has null/low address: 0x{x}\n", .{ idx.*, handler_addr });
-            }
-
             // Advance past current instruction and its metadata
             idx.* += 1;
             if (has_metadata) idx.* += 1;
 
-            // Return the current handler
-            return handler;
+            // Now return the next handler (or end-of-stream if at end)
+            if (idx.* >= self.instructionStream.len) {
+                log.warn("getNextInstruction: advanced idx {} beyond stream len {}", .{ idx.*, self.instructionStream.len });
+                return &end_of_stream_handler;
+            }
+            return self.instructionStream[idx.*].handler;
         }
 
         /// Get instruction index for a given PC value.
@@ -731,9 +721,9 @@ test "Plan getNextInstruction advances correctly" {
     try std.testing.expectEqual(@intFromPtr(&testHandler), @intFromPtr(handler2));
     try std.testing.expectEqual(@as(TestPlan.InstructionIndexType, 3), idx); // Skipped metadata
 
-    // Test advancing from MUL (no metadata)
+    // Test advancing from MUL (no metadata); next is end-of-stream
     const handler3 = plan.getNextInstruction(&idx, .MUL);
-    try std.testing.expectEqual(@intFromPtr(&testHandler), @intFromPtr(handler3));
+    try std.testing.expectEqual(@intFromPtr(&end_of_stream_handler), @intFromPtr(handler3));
     try std.testing.expectEqual(@as(TestPlan.InstructionIndexType, 4), idx);
 }
 

--- a/src/evm/planner.zig
+++ b/src/evm/planner.zig
@@ -87,6 +87,9 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
         
         // Special metadata for entry block
         start: JumpDestMetadata,
+        // Trace handlers (only when injection enabled at comptime)
+        trace_before: if (Cfg.inject_tracing) *const HandlerFn else void,
+        trace_after: if (Cfg.inject_tracing) *const HandlerFn else void,
 
         /// Create a planner with LRU cache for repeated bytecode analysis.
         /// This is the standard initialization method for production use.
@@ -103,7 +106,17 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
                 .cache_hits = 0,
                 .cache_misses = 0,
                 .start = .{ .gas = 0, .min_stack = 0, .max_stack = 0 },
+                .trace_before = if (Cfg.inject_tracing) blk: { break :blk undefined; } else {},
+                .trace_after = if (Cfg.inject_tracing) blk: { break :blk undefined; } else {},
             };
+        }
+
+        /// Configure trace handler pointers (no-op when injection disabled)
+        pub fn setTraceHandlers(self: *Self, trace_before: if (Cfg.inject_tracing) *const HandlerFn else void, trace_after: if (Cfg.inject_tracing) *const HandlerFn else void) void {
+            if (comptime Cfg.inject_tracing) {
+                self.trace_before = trace_before;
+                self.trace_after = trace_after;
+            }
         }
         
         
@@ -134,10 +147,12 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
         /// The hardfork parameter is included in the cache key to avoid incorrect
         /// plan reuse when hardfork rules change (e.g., new opcodes, gas costs).
         pub fn getOrAnalyze(self: *Self, bytecode: []const u8, handlers: [256]*const HandlerFn, hardfork: Hardfork) !*const PlanType {
-            // Include hardfork in cache key to avoid incorrect plan reuse
+            // Include hardfork and inject flag in cache key to avoid incorrect plan reuse
             var hasher = std.hash.Wyhash.init(0);
             hasher.update(bytecode);
             hasher.update(std.mem.asBytes(&hardfork));
+            const inject_flag: u8 = if (Cfg.inject_tracing) 1 else 0;
+            hasher.update(&[_]u8{inject_flag});
             const key = hasher.final();
             
             // Check cache
@@ -411,7 +426,7 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
             var pc_map = std.AutoHashMap(PcType, InstructionIndexType).init(allocator);
             errdefer pc_map.deinit();
             
-            // Build instruction stream with handlers and metadata
+            // Build instruction stream with handlers and metadata (with optional trace injection)
             i = 0;
             // Dense PC->instruction index table for fast JUMP/JUMPI
             var dense_pc_to_idx = try allocator.alloc(?PlanType.InstructionIndexType, N);
@@ -425,6 +440,11 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
                 const current_instruction_idx = @as(InstructionIndexType, @intCast(stream.items.len));
                 try pc_map.put(@as(PcType, @intCast(i)), current_instruction_idx);
                 dense_pc_to_idx[i] = current_instruction_idx;
+                
+                // Inject tracing before the instruction
+                if (comptime Cfg.inject_tracing) {
+                    try stream.append(allocator, .{ .handler = self.trace_before });
+                }
                 
                 // Handle PUSH opcodes
                 if (op >= @intFromEnum(Opcode.PUSH1) and op <= @intFromEnum(Opcode.PUSH32)) {
@@ -530,7 +550,11 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
                         try constants.append(allocator, value);
                         try stream.append(allocator, .{ .pointer_index = const_idx });
                     }
-                    
+                    // Append after-trace if injected
+                    if (comptime Cfg.inject_tracing) {
+                        try stream.append(allocator, .{ .handler = self.trace_after });
+                    }
+
                     // Skip the next instruction if we fused
                     if (fused and next_pc < N) {
                         i = next_pc + 1;
@@ -571,12 +595,19 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
                         // This shouldn't happen - every JUMPDEST should have metadata
                         return error.MissingJumpDestMetadata;
                     }
-                    
+                    // Append after-trace if injected
+                    if (comptime Cfg.inject_tracing) {
+                        try stream.append(allocator, .{ .handler = self.trace_after });
+                    }
+
                     i += 1;
                 } else if (op == @intFromEnum(Opcode.PC)) {
                     // PC opcode needs to store the current program counter value
                     try stream.append(allocator, .{ .handler = handlers[op] });
                     try stream.append(allocator, .{ .inline_value = @intCast(i) });
+                    if (comptime Cfg.inject_tracing) {
+                        try stream.append(allocator, .{ .handler = self.trace_after });
+                    }
                     i += 1;
                 } else {
                     if (N <= 64) {
@@ -588,6 +619,9 @@ pub fn Planner(comptime Cfg: PlannerConfig) type {
                         log.warn("Uninitialized handler for opcode {x} at PC {}", .{ op, i });
                     }
                     try stream.append(allocator, .{ .handler = handler_ptr });
+                    if (comptime Cfg.inject_tracing) {
+                        try stream.append(allocator, .{ .handler = self.trace_after });
+                    }
                     i += 1;
                 }
             }

--- a/src/evm/planner_config.zig
+++ b/src/evm/planner_config.zig
@@ -26,6 +26,8 @@ pub const PlannerConfig = struct {
     vector_length: ?comptime_int = std.simd.suggestVectorLength(u8),
     /// Match stack sizing philosophy with stack.zig / FrameConfig.
     stack_size: u12 = 1024,
+    /// Compile-time toggle: inject generic trace handlers around opcodes.
+    inject_tracing: bool = false,
 
     /// PcType: chosen program-counter type (u16 or u32) from maxBytecodeSize.
     pub fn PcType(comptime self: Self) type {

--- a/src/evm/stack_frame.zig
+++ b/src/evm/stack_frame.zig
@@ -396,12 +396,6 @@ pub fn StackFrame(comptime config: FrameConfig) type {
                 self.tracer.afterOp(pc_val, opcode, Self, self);
             }
         }
-        /// Helper function to call tracer onError if tracer is configured
-        pub inline fn traceOnError(self: *Self, pc_val: u32, err: anyerror) void {
-            if (comptime config.TracerType != null) {
-                self.tracer.onError(pc_val, err, Self, self);
-            }
-        }
         /// Create a deep copy of the frame.
         /// This is used by DebugPlan to create a sidecar frame for validation.
         pub fn copy(self: *const Self, allocator: std.mem.Allocator) Error!Self {

--- a/src/evm/tracer.zig
+++ b/src/evm/tracer.zig
@@ -1,12 +1,12 @@
 /// Configurable execution tracing system for EVM debugging and analysis
-/// 
+///
 /// Provides multiple tracer implementations with compile-time selection:
 /// - `NoOpTracer`: Zero runtime overhead (default for production)
 /// - `DebuggingTracer`: Step-by-step debugging with breakpoints
 /// - `LoggingTracer`: Structured logging to stdout
 /// - `FileTracer`: High-performance file output
 /// - Custom tracers can be implemented by following the interface
-/// 
+///
 /// Tracers are selected at compile time for zero-cost abstractions.
 /// Enable tracing by configuring the Frame with a specific TracerType.
 const std = @import("std");
@@ -29,7 +29,7 @@ pub const NoOpTracer = struct {
     pub fn init() NoOpTracer {
         return .{};
     }
-    
+
     pub fn beforeOp(self: *NoOpTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         _ = self;
         _ = pc;
@@ -37,7 +37,7 @@ pub const NoOpTracer = struct {
         _ = frame;
         // FrameType is used in the function signature, no need to discard
     }
-    
+
     pub fn afterOp(self: *NoOpTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         _ = self;
         _ = pc;
@@ -45,7 +45,7 @@ pub const NoOpTracer = struct {
         _ = frame;
         // FrameType is used in the function signature, no need to discard
     }
-    
+
     pub fn onError(self: *NoOpTracer, pc: u32, err: anyerror, comptime FrameType: type, frame: *const FrameType) void {
         _ = self;
         _ = pc;
@@ -62,35 +62,35 @@ pub const NoOpTracer = struct {
 /// DebuggingTracer provides comprehensive debugging capabilities for the Go CLI debugger
 /// Features:
 /// - Step-by-step execution control
-/// - Breakpoint support  
+/// - Breakpoint support
 /// - State capture at each instruction
 /// - Memory/stack/gas tracking
 /// - Error reporting
 pub const DebuggingTracer = struct {
     const Self = @This();
-    
+
     allocator: std.mem.Allocator,
-    
+
     // Control state
-    step_mode: bool = false,          // true = step through each instruction
-    paused: bool = false,             // true = execution is paused
-    breakpoints: std.AutoHashMap(u32, void),    // Set of PC values to break on
+    step_mode: bool = false, // true = step through each instruction
+    paused: bool = false, // true = execution is paused
+    breakpoints: std.AutoHashMap(u32, void), // Set of PC values to break on
     resume_idx: ?u32 = null, // Resume index for paused execution (instruction stream index)
-    
+
     // Execution history
     steps: std.ArrayList(ExecutionStep),
-    max_history: usize = 10000,       // Limit history to prevent memory issues
-    
+    max_history: usize = 10000, // Limit history to prevent memory issues
+
     // State snapshots for debugging
     state_snapshots: std.ArrayList(StateSnapshot),
-    
+
     // Statistics
     total_instructions: u64 = 0,
     total_gas_used: u64 = 0,
 
     // Execution control helpers (keep interpreter logic minimal)
     pub const ExecutionResult = enum { Completed, Paused };
-    
+
     pub const ExecutionStep = struct {
         step_number: u64,
         pc: u32,
@@ -99,24 +99,24 @@ pub const DebuggingTracer = struct {
         gas_before: i32,
         gas_after: i32,
         gas_cost: u32,
-        stack_before: []u256,    // Owned slice
-        stack_after: []u256,     // Owned slice
+        stack_before: []u256, // Owned slice
+        stack_after: []u256, // Owned slice
         memory_size_before: usize,
         memory_size_after: usize,
         depth: u32,
         error_occurred: bool,
         error_msg: ?[]const u8,
     };
-    
+
     pub const StateSnapshot = struct {
         pc: u32,
         gas_remaining: u64,
-        stack: []u256,           // Owned slice
+        stack: []u256, // Owned slice
         memory_size: usize,
         depth: u32,
         timestamp: i64,
     };
-    
+
     pub fn init() Self {
         // Use a global allocator for debugging tracer
         // This is acceptable for debugging scenarios
@@ -128,7 +128,7 @@ pub const DebuggingTracer = struct {
             .state_snapshots = std.ArrayList(StateSnapshot){},
         };
     }
-    
+
     pub fn deinit(self: *Self) void {
         // Free execution step memory
         for (self.steps.items) |*step| {
@@ -139,21 +139,21 @@ pub const DebuggingTracer = struct {
             }
         }
         self.steps.deinit(self.allocator);
-        
+
         // Free state snapshots
         for (self.state_snapshots.items) |*snapshot| {
             self.allocator.free(snapshot.stack);
         }
         self.state_snapshots.deinit(self.allocator);
-        
+
         self.breakpoints.deinit();
     }
 
     /// Run the interpreter until a pause (step/breakpoint) or STOP.
     /// Generic over the interpreter type to avoid coupling.
-    pub fn run_until_pause_or_stop(self: *Self, comptime InterpreterType: type, interpreter: *InterpreterType) !ExecutionResult {
+    pub fn runUntilPauseOrStop(self: *Self, comptime InterpreterType: type, interpreter: *InterpreterType) !ExecutionResult {
         // If we have a resume index, set the interpreter to that point
-        if (self.take_resume_idx()) |i| {
+        if (self.takeResumeIdx()) |i| {
             interpreter.instruction_idx = @intCast(i);
         }
         // Run interpreter; catch pause/stop conditions
@@ -172,78 +172,78 @@ pub const DebuggingTracer = struct {
         self.step_mode = true;
         self.paused = false;
         defer self.step_mode = false;
-        return try self.run_until_pause_or_stop(InterpreterType, interpreter);
+        return try self.runUntilPauseOrStop(InterpreterType, interpreter);
     }
 
     /// Set instruction index to resume from when paused
-    pub fn set_resume_idx(self: *Self, idx: u32) void {
+    pub fn setResumeIdx(self: *Self, idx: u32) void {
         self.resume_idx = idx;
     }
 
     /// Take and clear the pending resume index
-    pub fn take_resume_idx(self: *Self) ?u32 {
+    pub fn takeResumeIdx(self: *Self) ?u32 {
         const i = self.resume_idx;
         self.resume_idx = null;
         return i;
     }
-    
+
     /// Enable or disable step-by-step execution mode
     pub fn setStepMode(self: *Self, enabled: bool) void {
         self.step_mode = enabled;
     }
-    
+
     /// Check if execution should pause (breakpoint or step mode)
     pub fn shouldPause(self: *Self, pc: u32) bool {
         return self.step_mode or self.breakpoints.get(pc) != null;
     }
-    
+
     /// Pause execution
     pub fn pause(self: *Self) void {
         self.paused = true;
     }
-    
+
     /// Resume execution
     pub fn resumeExecution(self: *Self) void {
         self.paused = false;
     }
-    
+
     /// Add a breakpoint at the given PC
     pub fn addBreakpoint(self: *Self, pc: u32) !void {
         try self.breakpoints.put(pc, {});
     }
-    
+
     /// Remove a breakpoint at the given PC
     pub fn removeBreakpoint(self: *Self, pc: u32) bool {
         return self.breakpoints.remove(pc);
     }
-    
+
     /// Check if there's a breakpoint at the given PC
     pub fn hasBreakpoint(self: *Self, pc: u32) bool {
         return self.breakpoints.get(pc) != null;
     }
-    
+
     /// Clear all breakpoints
     pub fn clearBreakpoints(self: *Self) void {
         self.breakpoints.clearRetainingCapacity();
     }
-    
+
     /// Get the current execution step count
     pub fn getStepCount(self: *Self) u64 {
         return self.total_instructions;
     }
-    
+
     /// Get the most recent execution steps
     pub fn getRecentSteps(self: *Self, count: usize) []const ExecutionStep {
         const start = if (self.steps.items.len > count) self.steps.items.len - count else 0;
         return self.steps.items[start..];
     }
-    
+
     /// Get a specific execution step by index
     pub fn getStep(self: *Self, index: usize) ?*const ExecutionStep {
         if (index >= self.steps.items.len) return null;
         return &self.steps.items[index];
     }
-    
+
     /// Create a snapshot of the current state
     pub fn captureState(self: *Self, pc: u32, comptime FrameType: type, frame: *const FrameType) !void {
         // Get current stack contents
@@ -257,77 +257,77 @@ pub const DebuggingTracer = struct {
             .depth = if (@hasField(FrameType, "depth")) frame.depth else 0,
             .timestamp = std.time.milliTimestamp(),
         };
-        
+
         try self.state_snapshots.append(self.allocator, snapshot);
-        
+
         // Limit snapshots to prevent memory growth
         if (self.state_snapshots.items.len > self.max_history) {
             const old = self.state_snapshots.orderedRemove(0);
             self.allocator.free(old.stack);
         }
     }
-    
+
     /// Required tracer interface: called before each operation
     pub fn beforeOp(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         // Check if we should pause execution
         if (self.shouldPause(pc)) {
             self.paused = true;
         }
-        
+
         // While paused, we would need to implement a mechanism to wait
         // In the C API, this could be handled by returning a "paused" status
         // and requiring explicit resume calls
-        
+
         // Capture state before operation for step recording
         self.captureStateForStep(pc, opcode, FrameType, frame, true) catch |err| {
             std.log.warn("Failed to capture before state: {}", .{err});
         };
     }
-    
+
     /// Required tracer interface: called after each operation
     pub fn afterOp(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         // Update statistics
         self.total_instructions += 1;
-        
+
         // Capture state after operation to complete the step record
         self.captureStateForStep(pc, opcode, FrameType, frame, false) catch |err| {
             std.log.warn("Failed to capture after state: {}", .{err});
         };
-        
+
         // Create state snapshot if configured
         self.captureState(pc, FrameType, frame) catch |err| {
             std.log.warn("Failed to capture state snapshot: {}", .{err});
         };
     }
-    
+
     /// Required tracer interface: called when an error occurs
     pub fn onError(self: *Self, pc: u32, err: anyerror, comptime FrameType: type, frame: *const FrameType) void {
         _ = frame;
         _ = pc;
-        
+
         // Record error in current step if we have one
         if (self.steps.items.len > 0) {
             const current_step = &self.steps.items[self.steps.items.len - 1];
             current_step.error_occurred = true;
-            
+
             // Store error message
             const error_name = @errorName(err);
             current_step.error_msg = self.allocator.dupe(u8, error_name) catch null;
         }
-        
+
         // Always pause on error for debugging
         self.paused = true;
-        
+
         std.log.debug("DebuggingTracer: Error occurred in frame type {s}: {}", .{ @typeName(FrameType), err });
     }
-    
+
     /// Helper function to capture state for step recording
     fn captureStateForStep(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType, is_before: bool) !void {
         const gas = @max(frame.gas_remaining, 0);
-        
+
         // Create stack copy
         const stack_copy = try self.copyStack(FrameType, frame);
-        
+
         if (is_before) {
             // Start a new execution step
             const step = ExecutionStep{
@@ -337,7 +337,7 @@ pub const DebuggingTracer = struct {
                 .opcode_name = getOpcodeName(opcode),
                 .gas_before = @as(i32, @intCast(@min(gas, std.math.maxInt(i32)))),
                 .gas_after = @as(i32, @intCast(@min(gas, std.math.maxInt(i32)))), // Will be updated in afterOp
-                .gas_cost = 0,    // Will be calculated in afterOp
+                .gas_cost = 0, // Will be calculated in afterOp
                 .stack_before = stack_copy,
                 .stack_after = &[_]u256{}, // Will be updated in afterOp
                 .memory_size_before = if (@hasField(FrameType, "memory")) frame.memory.size() else 0,
@@ -346,9 +346,9 @@ pub const DebuggingTracer = struct {
                 .error_occurred = false,
                 .error_msg = null,
             };
-            
+
             try self.steps.append(self.allocator, step);
-            
+
             // Limit history size
             if (self.steps.items.len > self.max_history) {
                 const old = self.steps.orderedRemove(0);
@@ -384,7 +384,7 @@ pub const DebuggingTracer = struct {
         }
         return out;
     }
-    
+
     /// Reset all debugging state
     pub fn reset(self: *Self) void {
         // Clear execution history
@@ -396,21 +396,21 @@ pub const DebuggingTracer = struct {
             }
         }
         self.steps.clearRetainingCapacity();
-        
+
         // Clear state snapshots
         for (self.state_snapshots.items) |*snapshot| {
             self.allocator.free(snapshot.stack);
         }
         self.state_snapshots.clearRetainingCapacity();
-        
+
         // Reset statistics
         self.total_instructions = 0;
         self.total_gas_used = 0;
-        
+
         // Keep breakpoints but reset execution state
         self.paused = false;
     }
-    
+
     /// Get debugging statistics
     pub fn getStats(self: *Self) struct {
         total_instructions: u64,
@@ -438,9 +438,9 @@ pub const MemoryCaptureMode = enum { none, prefix, full };
 
 pub const TracerConfig = struct {
     capture_memory: MemoryCaptureMode = .none,
-    memory_prefix: usize = 0,                  // bytes to capture when mode is .prefix
-    compute_gas_cost: bool = false,            // compute per-step gas deltas
-    capture_each_op: bool = false,             // capture snapshot after each operation
+    memory_prefix: usize = 0, // bytes to capture when mode is .prefix
+    compute_gas_cost: bool = false, // compute per-step gas deltas
+    capture_each_op: bool = false, // capture snapshot after each operation
 };
 
 pub const DetailedStructLog = struct {
@@ -465,9 +465,9 @@ pub fn Tracer(comptime Writer: type) type {
         writer: Writer,
         cfg: TracerConfig = .{},
         prev_gas: ?u64 = null,
-        
+
         const Self = @This();
-        
+
         pub fn init(allocator: std.mem.Allocator, writer: Writer) Self {
             return .{
                 .allocator = allocator,
@@ -475,7 +475,7 @@ pub fn Tracer(comptime Writer: type) type {
                 .cfg = .{},
             };
         }
-        
+
         pub fn initWithConfig(allocator: std.mem.Allocator, writer: Writer, cfg: TracerConfig) Self {
             return .{
                 .allocator = allocator,
@@ -483,16 +483,16 @@ pub fn Tracer(comptime Writer: type) type {
                 .cfg = cfg,
             };
         }
-        
+
         pub fn snapshot(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !DetailedStructLog {
             // Capture stack
             const stack_size = frame_instance.stack.size();
             const stack_copy = try self.allocator.alloc(u256, stack_size);
             const stack_slice = frame_instance.stack.get_slice();
             @memcpy(stack_copy, stack_slice);
-            
+
             const op_name = getOpcodeName(opcode);
-            
+
             // Gas calculation
             const gas_now: u64 = @max(frame_instance.gas_remaining, 0);
             var gas_cost: u64 = 0;
@@ -502,7 +502,7 @@ pub fn Tracer(comptime Writer: type) type {
                 }
                 self.prev_gas = gas_now;
             }
-            
+
             // Depth (if frame provides it)
             const depth_val: u32 = blk: {
                 if (comptime @hasField(FrameType, "depth")) {
@@ -512,7 +512,7 @@ pub fn Tracer(comptime Writer: type) type {
                 }
                 break :blk 1;
             };
-            
+
             // Refund (if frame provides it)
             const refund_val: u64 = blk: {
                 if (comptime @hasField(FrameType, "gas_refund")) {
@@ -520,14 +520,14 @@ pub fn Tracer(comptime Writer: type) type {
                 }
                 break :blk 0;
             };
-            
+
             // Memory capture
             var mem_size: u32 = 0;
             const mem_copy = try self.captureMemory(FrameType, frame_instance, &mem_size);
-            
+
             // Error capture
             const err_str = getFrameError(FrameType, frame_instance);
-            
+
             return DetailedStructLog{
                 .pc = @as(u64, pc),
                 .op = op_name,
@@ -541,15 +541,15 @@ pub fn Tracer(comptime Writer: type) type {
                 .@"error" = err_str,
             };
         }
-        
+
         pub fn writeSnapshot(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !void {
             const log = try self.snapshot(pc, opcode, FrameType, frame_instance);
             defer self.allocator.free(log.stack);
             defer if (log.memory) |m| self.allocator.free(m);
-            
+
             try self.writeJson(&log);
         }
-        
+
         pub fn beforeOp(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
             _ = self;
             _ = pc;
@@ -557,7 +557,7 @@ pub fn Tracer(comptime Writer: type) type {
             _ = frame;
             // Generic tracer doesn't do anything on beforeOp by default
         }
-        
+
         pub fn afterOp(self: *Self, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
             // Optionally capture snapshot after each operation
             if (self.cfg.capture_each_op) {
@@ -566,7 +566,7 @@ pub fn Tracer(comptime Writer: type) type {
                 };
             }
         }
-        
+
         pub fn onError(self: *Self, pc: u32, err: anyerror, comptime FrameType: type, frame: *const FrameType) void {
             _ = self;
             _ = pc;
@@ -574,21 +574,21 @@ pub fn Tracer(comptime Writer: type) type {
             _ = frame;
             // Generic tracer doesn't do anything on error by default
         }
-        
+
         pub fn writeJson(self: *Self, log: *const DetailedStructLog) !void {
             try self.writer.print(
                 "{{\"pc\":{},\"op\":\"{s}\",\"gas\":{},\"gasCost\":{},\"depth\":{},\"stack\":[",
                 .{ log.pc, log.op, log.gas, log.gasCost, log.depth },
             );
-            
+
             // Write stack array
             for (log.stack, 0..) |val, i| {
                 if (i > 0) try self.writer.writeAll(",");
                 try self.writer.print("\"0x{x}\"", .{val});
             }
-            
+
             try self.writer.print("],\"memSize\":{},\"refund\":{}", .{ log.memSize, log.refund });
-            
+
             // Write memory if captured
             if (log.memory) |mem| {
                 try self.writer.writeAll(",\"memory\":\"0x");
@@ -597,15 +597,15 @@ pub fn Tracer(comptime Writer: type) type {
                 }
                 try self.writer.writeByte('"');
             }
-            
+
             // Write error if present
             if (log.@"error") |err| {
                 try self.writer.print(",\"error\":\"{s}\"", .{err});
             }
-            
+
             try self.writer.writeAll("}}\n");
         }
-        
+
         fn captureMemory(
             self: *Self,
             comptime FrameType: type,
@@ -613,27 +613,27 @@ pub fn Tracer(comptime Writer: type) type {
             mem_size: *u32,
         ) !?[]const u8 {
             _ = frame_instance;
-            
+
             // For now, we don't have memory in the frame
             mem_size.* = 0;
-            
+
             if (self.cfg.capture_memory == .none) return null;
-            
+
             // When memory is added to frame, implement this:
             // if (comptime @hasField(FrameType, "memory")) {
             //     const mem_len = frame_instance.memory.len;
             //     mem_size.* = @intCast(mem_len);
-            //     
+            //
             //     const to_copy = switch (self.cfg.capture_memory) {
             //         .full => mem_len,
             //         .prefix => @min(mem_len, self.cfg.memory_prefix),
             //         .none => 0,
             //     };
-            //     
+            //
             //     if (to_copy == 0) return null;
             //     return try self.allocator.dupe(u8, frame_instance.memory[0..to_copy]);
             // }
-            
+
             return null;
         }
     };
@@ -642,37 +642,37 @@ pub fn Tracer(comptime Writer: type) type {
 // Logging tracer that writes to stdout
 pub const LoggingTracer = struct {
     base: Tracer(std.fs.File.Writer),
-    
+
     pub fn init(allocator: std.mem.Allocator) LoggingTracer {
         const stdout = std.io.getStdOut().writer();
         return .{
             .base = Tracer(std.fs.File.Writer).init(allocator, stdout),
         };
     }
-    
+
     pub fn initWithConfig(allocator: std.mem.Allocator, cfg: TracerConfig) LoggingTracer {
         const stdout = std.io.getStdOut().writer();
         return .{
             .base = Tracer(std.fs.File.Writer).initWithConfig(allocator, stdout, cfg),
         };
     }
-    
+
     pub fn snapshot(self: *LoggingTracer, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !DetailedStructLog {
         return self.base.snapshot(pc, opcode, FrameType, frame_instance);
     }
-    
+
     pub fn writeSnapshot(self: *LoggingTracer, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !void {
         return self.base.writeSnapshot(pc, opcode, FrameType, frame_instance);
     }
-    
+
     pub fn beforeOp(self: *LoggingTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         self.base.beforeOp(pc, opcode, FrameType, frame);
     }
-    
+
     pub fn afterOp(self: *LoggingTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         self.base.afterOp(pc, opcode, FrameType, frame);
     }
-    
+
     pub fn onError(self: *LoggingTracer, pc: u32, err: anyerror, comptime FrameType: type, frame: *const FrameType) void {
         self.base.onError(pc, err, FrameType, frame);
     }
@@ -682,7 +682,7 @@ pub const LoggingTracer = struct {
 pub const FileTracer = struct {
     base: Tracer(std.fs.File.Writer),
     file: std.fs.File,
-    
+
     pub fn init(allocator: std.mem.Allocator, path: []const u8) !FileTracer {
         const file = try std.fs.cwd().createFile(path, .{});
         return .{
@@ -690,7 +690,7 @@ pub const FileTracer = struct {
             .file = file,
         };
     }
-    
+
     pub fn initWithConfig(allocator: std.mem.Allocator, path: []const u8, cfg: TracerConfig) !FileTracer {
         const file = try std.fs.cwd().createFile(path, .{});
         return .{
@@ -698,27 +698,27 @@ pub const FileTracer = struct {
             .file = file,
         };
     }
-    
+
     pub fn deinit(self: *FileTracer) void {
         self.file.close();
     }
-    
+
     pub fn snapshot(self: *FileTracer, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !DetailedStructLog {
         return self.base.snapshot(pc, opcode, FrameType, frame_instance);
     }
-    
+
     pub fn writeSnapshot(self: *FileTracer, pc: u32, opcode: u8, comptime FrameType: type, frame_instance: *const FrameType) !void {
         return self.base.writeSnapshot(pc, opcode, FrameType, frame_instance);
     }
-    
+
     pub fn beforeOp(self: *FileTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         self.base.beforeOp(pc, opcode, FrameType, frame);
     }
-    
+
     pub fn afterOp(self: *FileTracer, pc: u32, opcode: u8, comptime FrameType: type, frame: *const FrameType) void {
         self.base.afterOp(pc, opcode, FrameType, frame);
     }
-    
+
     pub fn onError(self: *FileTracer, pc: u32, err: anyerror, comptime FrameType: type, frame: *const FrameType) void {
         self.base.onError(pc, err, FrameType, frame);
     }
@@ -726,12 +726,12 @@ pub const FileTracer = struct {
 
 fn getFrameError(comptime FrameType: type, frame_instance: *const FrameType) ?[]const u8 {
     _ = frame_instance;
-    
+
     // TODO: When frame has error fields, access them like:
     // if (comptime @hasField(FrameType, "last_error_str")) {
     //     return frame_instance.last_error_str;
     // }
-    
+
     return null;
 }
 
@@ -847,16 +847,16 @@ fn getOpcodeName(opcode: u8) []const u8 {
 // Tests
 test "tracer captures basic frame state with writer" {
     const allocator = std.testing.allocator;
-    
+
     // Create a frame with some state
     const Frame = frame_mod.Frame(.{
         .stack_size = 10,
         .block_gas_limit = 1000,
     });
-    
+
     var test_frame = try Frame.init(allocator, &[_]u8{ 0x60, 0x05, 0x60, 0x03, 0x01 }, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     // Push some values onto the stack
     try test_frame.stack.push(3);
     try test_frame.stack.push(5);
@@ -864,15 +864,15 @@ test "tracer captures basic frame state with writer" {
     const gas_to_consume1 = @as(u64, @intCast(test_frame.gas_remaining - 950));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume1))) return error.OutOfGas;
     test_frame.gas_remaining -= @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume1));
-    
+
     // Create tracer with array list writer
     var output = std.ArrayList(u8).init(allocator);
     defer output.deinit();
-    
+
     var tracer = Tracer(std.ArrayList(u8).Writer).init(allocator, output.writer());
     const log = try tracer.snapshot(4, 0x01, Frame, &test_frame); // PC=4, opcode=ADD
     defer allocator.free(log.stack);
-    
+
     // Verify snapshot
     try std.testing.expectEqual(@as(u64, 4), log.pc);
     try std.testing.expectEqualStrings("ADD", log.op);
@@ -885,25 +885,25 @@ test "tracer captures basic frame state with writer" {
 
 test "tracer writes JSON to writer" {
     const allocator = std.testing.allocator;
-    
+
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{ 0x60, 0x05, 0x60, 0x03, 0x01 }, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     try test_frame.stack.push(3);
     try test_frame.stack.push(5);
     // PC is now managed by plan, not frame
     const gas_to_consume2 = @as(u64, @intCast(test_frame.gas_remaining - 950));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume2))) return error.OutOfGas;
     test_frame.gas_remaining -= @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume2));
-    
+
     // Create tracer with array list writer
     var output = std.ArrayList(u8).init(allocator);
     defer output.deinit();
-    
+
     var tracer = Tracer(std.ArrayList(u8).Writer).init(allocator, output.writer());
     try tracer.writeSnapshot(4, 0x01, Frame, &test_frame); // PC=4, opcode=ADD
-    
+
     const json = output.items;
     try std.testing.expect(std.mem.indexOf(u8, json, "\"pc\":4") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"op\":\"ADD\"") != null);
@@ -913,54 +913,54 @@ test "tracer writes JSON to writer" {
 
 test "logging tracer writes to stdout" {
     const allocator = std.testing.allocator;
-    
+
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{0x00}, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     var tracer = LoggingTracer.init(allocator);
     const log = try tracer.snapshot(0, 0x00, Frame, &test_frame); // PC=0, opcode=STOP
     defer allocator.free(log.stack);
-    
+
     try std.testing.expectEqual(@as(u64, 0), log.pc);
     try std.testing.expectEqualStrings("STOP", log.op);
 }
 
 test "file tracer writes to file" {
     const allocator = std.testing.allocator;
-    
+
     // Create temp dir and file
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
-    
+
     // Create file in the temp directory
     const file = try tmp_dir.dir.createFile("trace.json", .{});
     file.close();
-    
+
     // Get the full path
     const file_path = try tmp_dir.dir.realpathAlloc(allocator, "trace.json");
     defer allocator.free(file_path);
-    
+
     // Create frame
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{ 0x60, 0x42 }, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     // PC is now managed by plan, not frame
     const gas_to_consume3 = @as(u64, @intCast(test_frame.gas_remaining - 997));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume3))) return error.OutOfGas;
     test_frame.gas_remaining -= @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume3));
-    
+
     // Create file tracer and write
     var tracer = try FileTracer.init(allocator, file_path);
     defer tracer.deinit();
-    
+
     try tracer.writeSnapshot(0, 0x60, Frame, &test_frame); // PC=0, opcode=PUSH1
-    
+
     // Read file and verify
     const contents = try tmp_dir.dir.readFileAlloc(allocator, "trace.json", 1024);
     defer allocator.free(contents);
-    
+
     try std.testing.expect(std.mem.indexOf(u8, contents, "\"pc\":0") != null);
     try std.testing.expect(std.mem.indexOf(u8, contents, "\"op\":\"PUSH1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, contents, "\"gas\":997") != null);
@@ -968,20 +968,20 @@ test "file tracer writes to file" {
 
 test "tracer with gas cost computation" {
     const allocator = std.testing.allocator;
-    
+
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{ 0x60, 0x05, 0x01 }, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     var output = std.ArrayList(u8).init(allocator);
     defer output.deinit();
-    
+
     var tracer = Tracer(std.ArrayList(u8).Writer).initWithConfig(
         allocator,
         output.writer(),
         .{ .compute_gas_cost = true },
     );
-    
+
     // First snapshot - no previous gas, so cost should be 0
     const gas_to_consume4 = @as(u64, @intCast(test_frame.gas_remaining - 1000));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume4))) return error.OutOfGas;
@@ -989,7 +989,7 @@ test "tracer with gas cost computation" {
     const log1 = try tracer.snapshot(0, 0x60, Frame, &test_frame); // PUSH1
     defer allocator.free(log1.stack);
     try std.testing.expectEqual(@as(u64, 0), log1.gasCost);
-    
+
     // Second snapshot - gas decreased by 3
     const gas_to_consume5 = @as(u64, @intCast(test_frame.gas_remaining - 997));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume5))) return error.OutOfGas;
@@ -997,7 +997,7 @@ test "tracer with gas cost computation" {
     const log2 = try tracer.snapshot(1, 0x60, Frame, &test_frame); // PUSH1
     defer allocator.free(log2.stack);
     try std.testing.expectEqual(@as(u64, 3), log2.gasCost);
-    
+
     // Third snapshot - gas decreased by 21
     const gas_to_consume6 = @as(u64, @intCast(test_frame.gas_remaining - 976));
     if (test_frame.gas_remaining < @as(@TypeOf(test_frame.gas_remaining), @intCast(gas_to_consume6))) return error.OutOfGas;
@@ -1009,37 +1009,37 @@ test "tracer with gas cost computation" {
 
 test "tracer handles empty stack with JSON output" {
     const allocator = std.testing.allocator;
-    
+
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{0x00}, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     var output = std.ArrayList(u8).init(allocator);
     defer output.deinit();
-    
+
     var tracer = Tracer(std.ArrayList(u8).Writer).init(allocator, output.writer());
     try tracer.writeSnapshot(0, 0x00, Frame, &test_frame); // STOP
-    
+
     const json = output.items;
     try std.testing.expect(std.mem.indexOf(u8, json, "\"stack\":[]") != null);
 }
 
 test "tracer handles large stack values in JSON" {
     const allocator = std.testing.allocator;
-    
+
     const Frame = frame_mod.Frame(.{});
     var test_frame = try Frame.init(allocator, &[_]u8{0x00}, 1000, {}, createTestHost());
     defer test_frame.deinit(allocator);
-    
+
     try test_frame.stack.push(std.math.maxInt(u256));
     try test_frame.stack.push(0xdeadbeef);
-    
+
     var output = std.ArrayList(u8).init(allocator);
     defer output.deinit();
-    
+
     var tracer = Tracer(std.ArrayList(u8).Writer).init(allocator, output.writer());
     try tracer.writeSnapshot(0, 0x00, Frame, &test_frame); // STOP
-    
+
     const json = output.items;
     try std.testing.expect(std.mem.indexOf(u8, json, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "0xdeadbeef") != null);
@@ -1052,13 +1052,13 @@ test "tracer handles large stack values in JSON" {
 // Test that NoOpTracer has zero cost
 test "NoOpTracer has zero runtime cost" {
     var tracer = NoOpTracer.init();
-    
+
     const TestFrame = struct {
         gas: i32,
     };
-    
+
     const test_frame = TestFrame{ .gas = 1000 };
-    
+
     // These should compile to nothing
     tracer.beforeOp(0, 0x00, TestFrame, &test_frame);
     tracer.afterOp(0, 0x00, TestFrame, &test_frame);
@@ -1258,28 +1258,28 @@ fn createTestHost() Host {
 test "DebuggingTracer basic functionality" {
     var tracer = DebuggingTracer.init();
     defer tracer.deinit();
-    
+
     // Test breakpoint management
     try tracer.addBreakpoint(10);
     try tracer.addBreakpoint(20);
-    
+
     try std.testing.expect(tracer.hasBreakpoint(10));
     try std.testing.expect(tracer.hasBreakpoint(20));
     try std.testing.expect(!tracer.hasBreakpoint(15));
-    
+
     // Test step mode
     tracer.setStepMode(true);
     try std.testing.expect(tracer.shouldPause(5)); // Should pause in step mode
-    
+
     tracer.setStepMode(false);
     try std.testing.expect(tracer.shouldPause(10)); // Should pause on breakpoint
     try std.testing.expect(!tracer.shouldPause(5)); // Should not pause on regular instruction
-    
+
     // Test removal
     try std.testing.expect(tracer.removeBreakpoint(10));
     try std.testing.expect(!tracer.hasBreakpoint(10));
     try std.testing.expect(!tracer.removeBreakpoint(10)); // Already removed
-    
+
     // Test clear
     tracer.clearBreakpoints();
     try std.testing.expect(!tracer.hasBreakpoint(20));
@@ -1288,7 +1288,7 @@ test "DebuggingTracer basic functionality" {
 test "DebuggingTracer memory management" {
     var tracer = DebuggingTracer.init();
     defer tracer.deinit();
-    
+
     // This test verifies that the tracer properly manages memory
     // when used with a mock frame
     const MockStack = struct {
@@ -1305,22 +1305,22 @@ test "DebuggingTracer memory management" {
         fn init() @This() {
             return .{
                 .gas_remaining = 1000,
-                .bytecode = &[_]u8{0x60, 0x05}, // PUSH1 5
+                .bytecode = &[_]u8{ 0x60, 0x05 }, // PUSH1 5
                 .stack = .{},
             };
         }
     };
-    
+
     var mock_frame = MockFrame.init();
-    
+
     // Test beforeOp and afterOp
     tracer.beforeOp(0, 0x60, MockFrame, &mock_frame); // PC=0, PUSH1
     tracer.afterOp(0, 0x60, MockFrame, &mock_frame);
-    
+
     // Verify step was recorded
     try std.testing.expectEqual(@as(usize, 1), tracer.steps.items.len);
     try std.testing.expectEqual(@as(u64, 1), tracer.total_instructions);
-    
+
     const step = &tracer.steps.items[0];
     try std.testing.expectEqual(@as(u32, 0), step.pc);
     try std.testing.expectEqual(@as(u8, 0x60), step.opcode);
@@ -1383,7 +1383,7 @@ test "DebuggingTracer breakpoint: pause at STOP, then complete" {
     try tracer.addBreakpoint(5);
 
     // Run until breakpoint: should pause before executing STOP
-    var res = try tracer.run_until_pause_or_stop(Interpreter, &interpreter);
+    var res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
     try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
     try std.testing.expectEqual(@as(?Interpreter.Plan.PcType, 5), interpreter.getCurrentPc());
     // Ensure result is computed
@@ -1391,6 +1391,6 @@ test "DebuggingTracer breakpoint: pause at STOP, then complete" {
     try std.testing.expectEqual(@as(u256, 8), interpreter.frame.stack.peek_unsafe());
 
     // Resume: should execute STOP -> Completed
-    res = try tracer.run_until_pause_or_stop(Interpreter, &interpreter);
+    res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
     try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Completed, res);
 }

--- a/src/evm/tracer.zig
+++ b/src/evm/tracer.zig
@@ -75,6 +75,7 @@ pub const DebuggingTracer = struct {
     step_mode: bool = false,          // true = step through each instruction
     paused: bool = false,             // true = execution is paused
     breakpoints: std.AutoHashMap(u32, void),    // Set of PC values to break on
+    resume_idx: ?u32 = null, // Resume index for paused execution (instruction stream index)
     
     // Execution history
     steps: std.ArrayList(ExecutionStep),
@@ -86,6 +87,9 @@ pub const DebuggingTracer = struct {
     // Statistics
     total_instructions: u64 = 0,
     total_gas_used: u64 = 0,
+
+    // Execution control helpers (keep interpreter logic minimal)
+    pub const ExecutionResult = enum { Completed, Paused };
     
     pub const ExecutionStep = struct {
         step_number: u64,
@@ -143,6 +147,44 @@ pub const DebuggingTracer = struct {
         self.state_snapshots.deinit(self.allocator);
         
         self.breakpoints.deinit();
+    }
+
+    /// Run the interpreter until a pause (step/breakpoint) or STOP.
+    /// Generic over the interpreter type to avoid coupling.
+    pub fn run_until_pause_or_stop(self: *Self, comptime InterpreterType: type, interpreter: *InterpreterType) !ExecutionResult {
+        // If we have a resume index, set the interpreter to that point
+        if (self.take_resume_idx()) |i| {
+            interpreter.instruction_idx = @intCast(i);
+        }
+        // Run interpreter; catch pause/stop conditions
+        interpreter.interpret() catch |err| switch (err) {
+            error.ExecutionPaused => return .Paused,
+            error.STOP => return .Completed,
+            else => return err,
+        };
+        // If interpret returns cleanly, treat as Completed
+        return .Completed;
+    }
+
+    /// Execute exactly one instruction (step). Returns Paused at next before, or Completed at STOP.
+    pub fn stepSingle(self: *Self, comptime InterpreterType: type, interpreter: *InterpreterType) !ExecutionResult {
+        // Enable step mode and clear paused flag
+        self.step_mode = true;
+        self.paused = false;
+        defer self.step_mode = false;
+        return try self.run_until_pause_or_stop(InterpreterType, interpreter);
+    }
+
+    /// Set instruction index to resume from when paused
+    pub fn set_resume_idx(self: *Self, idx: u32) void {
+        self.resume_idx = idx;
+    }
+
+    /// Take and clear the pending resume index
+    pub fn take_resume_idx(self: *Self) ?u32 {
+        const i = self.resume_idx;
+        self.resume_idx = null;
+        return i;
     }
     
     /// Enable or disable step-by-step execution mode
@@ -205,12 +247,8 @@ pub const DebuggingTracer = struct {
     /// Create a snapshot of the current state
     pub fn captureState(self: *Self, pc: u32, comptime FrameType: type, frame: *const FrameType) !void {
         // Get current stack contents
-        const stack_copy = try self.allocator.alloc(u256, frame.next_stack_index);
-        for (0..frame.next_stack_index) |i| {
-            // Access stack items from bottom to top for consistent ordering
-            stack_copy[i] = frame.stack[i];
-        }
-        
+        const stack_copy = try self.copyStack(FrameType, frame);
+
         const snapshot = StateSnapshot{
             .pc = pc,
             .gas_remaining = @max(frame.gas_remaining, 0),
@@ -252,7 +290,7 @@ pub const DebuggingTracer = struct {
         self.total_instructions += 1;
         
         // Capture state after operation to complete the step record
-        self.captureStateForStep(pc, opcode, FrameType, frame) catch |err| {
+        self.captureStateForStep(pc, opcode, FrameType, frame, false) catch |err| {
             std.log.warn("Failed to capture after state: {}", .{err});
         };
         
@@ -288,10 +326,7 @@ pub const DebuggingTracer = struct {
         const gas = @max(frame.gas_remaining, 0);
         
         // Create stack copy
-        const stack_copy = try self.allocator.alloc(u256, frame.next_stack_index);
-        for (0..frame.next_stack_index) |i| {
-            stack_copy[i] = frame.stack[i];
-        }
+        const stack_copy = try self.copyStack(FrameType, frame);
         
         if (is_before) {
             // Start a new execution step
@@ -336,6 +371,18 @@ pub const DebuggingTracer = struct {
                 self.allocator.free(stack_copy);
             }
         }
+    }
+
+    /// Copy the current stack contents from a generic frame type.
+    fn copyStack(self: *Self, comptime FrameType: type, frame: *const FrameType) ![]u256 {
+        const slice_any = frame.stack.get_slice();
+        const count = slice_any.len;
+        var out = try self.allocator.alloc(u256, count);
+        var i: usize = 0;
+        while (i < count) : (i += 1) {
+            out[i] = @intCast(slice_any[i]);
+        }
+        return out;
     }
     
     /// Reset all debugging state
@@ -1244,18 +1291,22 @@ test "DebuggingTracer memory management" {
     
     // This test verifies that the tracer properly manages memory
     // when used with a mock frame
+    const MockStack = struct {
+        data: [16]u256 = [_]u256{0} ** 16,
+        used: usize = 0,
+        pub fn get_slice(self: *const @This()) []const u256 {
+            return self.data[0..self.used];
+        }
+    };
     const MockFrame = struct {
         gas_remaining: i64 = 1000,
         bytecode: []const u8,
-        next_stack_index: usize,
-        stack: [16]u256,
-        
+        stack: MockStack = .{},
         fn init() @This() {
             return .{
                 .gas_remaining = 1000,
                 .bytecode = &[_]u8{0x60, 0x05}, // PUSH1 5
-                .next_stack_index = 0,
-                .stack = [_]u256{0} ** 16,
+                .stack = .{},
             };
         }
     };
@@ -1274,4 +1325,72 @@ test "DebuggingTracer memory management" {
     try std.testing.expectEqual(@as(u32, 0), step.pc);
     try std.testing.expectEqual(@as(u8, 0x60), step.opcode);
     try std.testing.expectEqualStrings("PUSH1", step.opcode_name);
+}
+
+test "DebuggingTracer stepping basic: fused PUSH1 3 + ADD" {
+    const allocator = std.testing.allocator;
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const HostMock = @import("host_mock.zig").HostMock;
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    // Bytecode: PUSH1 5, PUSH1 3, ADD, STOP
+    const bytecode = [_]u8{ 0x60, 0x05, 0x60, 0x03, 0x01, 0x00 };
+
+    var interpreter = try Interpreter.init(allocator, &bytecode, 1_000_000, {}, HostMock.init());
+    defer interpreter.deinit(allocator);
+
+    var tracer = &interpreter.frame.tracer;
+
+    // 1) First step pauses at first trace_before (PC=0), no execution yet
+    var res = try tracer.stepSingle(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expectEqual(@as(?Interpreter.Plan.PcType, 0), interpreter.getCurrentPc());
+    try std.testing.expectEqual(@as(usize, 0), interpreter.frame.stack.size());
+
+    // 2) Execute PUSH1 5
+    res = try tracer.stepSingle(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expectEqual(@as(?Interpreter.Plan.PcType, 2), interpreter.getCurrentPc());
+    try std.testing.expectEqual(@as(usize, 1), interpreter.frame.stack.size());
+    try std.testing.expectEqual(@as(u256, 5), interpreter.frame.stack.peek_unsafe());
+
+    // 3) Next step executes fused (PUSH1 3 + ADD), and pauses at STOP (PC=5)
+    res = try tracer.stepSingle(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expectEqual(@as(?Interpreter.Plan.PcType, 5), interpreter.getCurrentPc());
+    try std.testing.expectEqual(@as(usize, 1), interpreter.frame.stack.size());
+    try std.testing.expectEqual(@as(u256, 8), interpreter.frame.stack.peek_unsafe());
+
+    // 4) Execute STOP -> Completed
+    res = try tracer.stepSingle(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Completed, res);
+}
+
+test "DebuggingTracer breakpoint: pause at STOP, then complete" {
+    const allocator = std.testing.allocator;
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const HostMock = @import("host_mock.zig").HostMock;
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    // Bytecode: PUSH1 5, PUSH1 3, ADD, STOP
+    const bytecode = [_]u8{ 0x60, 0x05, 0x60, 0x03, 0x01, 0x00 };
+
+    var interpreter = try Interpreter.init(allocator, &bytecode, 1_000_000, {}, HostMock.init());
+    defer interpreter.deinit(allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    // Break at PC=5 (STOP) to avoid dependence on fusion of PUSH+ADD
+    try tracer.addBreakpoint(5);
+
+    // Run until breakpoint: should pause before executing STOP
+    var res = try tracer.run_until_pause_or_stop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expectEqual(@as(?Interpreter.Plan.PcType, 5), interpreter.getCurrentPc());
+    // Ensure result is computed
+    try std.testing.expectEqual(@as(usize, 1), interpreter.frame.stack.size());
+    try std.testing.expectEqual(@as(u256, 8), interpreter.frame.stack.peek_unsafe());
+
+    // Resume: should execute STOP -> Completed
+    res = try tracer.run_until_pause_or_stop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Completed, res);
 }

--- a/src/evm/tracer.zig
+++ b/src/evm/tracer.zig
@@ -73,6 +73,8 @@ pub const DebuggingTracer = struct {
 
     // Control state
     step_mode: bool = false, // true = step through each instruction
+    /// If true, propagate interpreter errors. If false, pause and record them.
+    throw_on_error: bool = true,
     paused: bool = false, // true = execution is paused
     breakpoints: std.AutoHashMap(u32, void), // Set of PC values to break on
     resume_idx: ?u32 = null, // Resume index for paused execution (instruction stream index)
@@ -129,6 +131,22 @@ pub const DebuggingTracer = struct {
         };
     }
 
+    pub const Config = struct {
+        throw_on_error: bool = true,
+        step_mode: bool = false,
+        max_history: usize = 10000,
+    };
+
+    /// Configure tracer behavior. Safe to call at any time.
+    pub fn configure(self: *Self, cfg: Config) void {
+        self.throw_on_error = cfg.throw_on_error;
+        self.step_mode = cfg.step_mode;
+        if (cfg.max_history != self.max_history) {
+            self.max_history = cfg.max_history;
+            self.prune_to_max_history();
+        }
+    }
+
     pub fn deinit(self: *Self) void {
         // Free execution step memory
         for (self.steps.items) |*step| {
@@ -160,7 +178,17 @@ pub const DebuggingTracer = struct {
         interpreter.interpret() catch |err| switch (err) {
             error.ExecutionPaused => return .Paused,
             error.STOP => return .Completed,
-            else => return err,
+            else => {
+                // Call error hook, then either propagate or pause.
+                const pc_opt = interpreter.getCurrentPc();
+                const pc_u32: u32 = @intCast(pc_opt orelse 0);
+                self.onError(pc_u32, err, InterpreterType.Frame, &interpreter.frame);
+                if (self.throw_on_error) {
+                    return err;
+                } else {
+                    return .Paused;
+                }
+            },
         };
         // If interpret returns cleanly, treat as Completed
         return .Completed;
@@ -409,6 +437,21 @@ pub const DebuggingTracer = struct {
 
         // Keep breakpoints but reset execution state
         self.paused = false;
+    }
+
+    fn prune_to_max_history(self: *Self) void {
+        // Steps
+        while (self.steps.items.len > self.max_history) {
+            const old = self.steps.orderedRemove(0);
+            self.allocator.free(old.stack_before);
+            self.allocator.free(old.stack_after);
+            if (old.error_msg) |m| self.allocator.free(m);
+        }
+        // Snapshots
+        while (self.state_snapshots.items.len > self.max_history) {
+            const old = self.state_snapshots.orderedRemove(0);
+            self.allocator.free(old.stack);
+        }
     }
 
     /// Get debugging statistics
@@ -1393,4 +1436,157 @@ test "DebuggingTracer breakpoint: pause at STOP, then complete" {
     // Resume: should execute STOP -> Completed
     res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
     try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Completed, res);
+}
+
+test "DebuggingTracer configure and throw_on_error=false pauses on error" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &[_]u8{ 0xFE }, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    // Ensure error recorded on the step
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    try std.testing.expect(tracer.steps.items[tracer.steps.items.len - 1].error_occurred);
+}
+
+test "DebuggingTracer throw_on_error=false: invalid opcode" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &[_]u8{ 0xFE }, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "InvalidOpcode"));
+}
+
+test "DebuggingTracer throw_on_error=false: stack underflow" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    // POP with empty stack
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &[_]u8{ 0x50 }, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "StackUnderflow"));
+}
+
+test "DebuggingTracer throw_on_error=false: invalid jump" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    // PUSH1 0x10; JUMP; STOP (no JUMPDEST at 0x10)
+    const code = [_]u8{ 0x60, 0x10, 0x56, 0x00 };
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &code, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "InvalidJump"));
+}
+
+test "DebuggingTracer throw_on_error=false: stack overflow" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    // Build bytecode with 1025 PUSH1 0x01 to overflow stack (default stack size 1024)
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    var i: usize = 0;
+    while (i < 1025) : (i += 1) {
+        try buf.append(0x60); // PUSH1
+        try buf.append(0x01);
+    }
+    var interpreter = try Interpreter.init(std.heap.page_allocator, buf.items, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "StackOverflow"));
+}
+
+test "DebuggingTracer throw_on_error=false: out of gas at STOP" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    // POP; STOP with zero gas. POP consumes gas unchecked; STOP then checks and errors OutOfGas
+    const code = [_]u8{ 0x50, 0x00 };
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &code, 0, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "OutOfGas"));
+}
+
+test "DebuggingTracer throw_on_error=false: revert" {
+    const frame_interpreter_mod = @import("frame_interpreter.zig");
+    const Interpreter = frame_interpreter_mod.FrameInterpreter(.{ .TracerType = DebuggingTracer });
+
+    const host = createTestHost();
+    // PUSH1 0x00 (offset); PUSH1 0x00 (size); REVERT
+    const code = [_]u8{ 0x60, 0x00, 0x60, 0x00, 0xfd };
+    var interpreter = try Interpreter.init(std.heap.page_allocator, &code, 100000, null, host);
+    defer interpreter.deinit(std.heap.page_allocator);
+
+    var tracer = &interpreter.frame.tracer;
+    tracer.configure(.{ .throw_on_error = false });
+
+    const res = try tracer.runUntilPauseOrStop(Interpreter, &interpreter);
+    try std.testing.expectEqual(DebuggingTracer.ExecutionResult.Paused, res);
+    try std.testing.expect(tracer.steps.items.len >= 1);
+    const last = tracer.steps.items[tracer.steps.items.len - 1];
+    try std.testing.expect(last.error_occurred);
+    try std.testing.expect(last.error_msg != null);
+    try std.testing.expect(std.mem.eql(u8, last.error_msg.?, "REVERT"));
 }

--- a/src/evm/tracer.zig
+++ b/src/evm/tracer.zig
@@ -437,6 +437,8 @@ pub const DebuggingTracer = struct {
 
         // Keep breakpoints but reset execution state
         self.paused = false;
+        self.step_mode = false;
+        self.resume_idx = null;
     }
 
     fn prune_to_max_history(self: *Self) void {


### PR DESCRIPTION
# Implements comprehensive tracing infrastructure for EVM execution debugging and analysis, including step-by-step execution and breakpoint support.

## Changes

### tracer.zig (enhancement)

- Extended DebuggingTracer with pause/resume functionality
    - Added resume_idx field to track instruction stream resume points
    - Implemented run_until_pause_or_stop() generic method for interpreter control
    - Added stepSingle() for single-instruction execution
    - Introduced set_resume_idx() and take_resume_idx() helper methods
    - Added ExecutionResult enum (Completed, Paused) for execution status
    - Implemented copyStack() helper for safe stack content copying
- Tests:
    - Added step-by-step execution test (PUSH1, ADD, STOP sequence)
    - Added breakpoint pause/resume test
    - Verified proper PC tracking and stack state at each step

### frame_interpreter.zig (enhancement)

- Integrated tracing support with pause/resume capabilities
    - Extended Error type to include ExecutionPaused when tracing enabled
    - Modified trace_before_op_handler to support pause detection
    - Enhanced getCurrentPc() with neighbor probing for trace-injected streams
    - Updated interpret() to use current instruction_idx as start point
    - Added pause state checking with resume index handling
    - Improved PC and opcode resolution for trace handlers
- Technical:
    - Compile-time gated tracing code with config.TracerType checks
    - Zero-cost abstraction when tracing disabled
    - Proper instruction index advancement for trace handlers

### planner.zig (enhancement)

- Added trace handler injection into instruction streams
    - Added trace_before and trace_after handler fields (compile-time gated)
    - Implemented setTraceHandlers() configuration method
    - Modified instruction stream generation to inject trace handlers
- Modified:
    - Updated cache key generation to include inject_tracing flag
    - Injected trace_before before each opcode handler
    - Injected trace_after after each opcode handler
    - Maintained PC-to-instruction mapping integrity with trace injection

### plan.zig (bugfix)

- Fixed getNextInstruction to advance first, then return handler
    - Previous implementation returned current handler then advanced
    - Now advances index first (by 1 or 2 based on metadata), then returns handler at new position
    - Ensures correct instruction sequencing in traced execution

### planner_config.zig (feature)

- Added compile-time tracing configuration flag
    - inject_tracing: bool = false field in PlannerConfig
    - Enable/disable trace handler injection at compile time

### build.zig (feature)

- Added dedicated tracer test suite
    - Created tracer-test target for tracer.zig tests
    - Added test-tracer step for individual tracer testing
    - Added test-tracing step for all tracing-related tests

## Architecture

### Design Pattern: Continuation-Passing Style

Implements a continuation-passing style pattern where execution can be
paused at trace points and resumed from saved instruction indices.
This enables powerful debugging capabilities while maintaining
zero-cost abstraction when tracing is disabled.

### Key Features

- Step-by-step execution through EVM bytecode
- Breakpoint support at specific PC values
- Complete execution history capture
- Stack and state snapshots at each operation
- Pause/resume without losing execution context

### Performance

- Zero runtime cost when tracing disabled (compile-time gating)
- Minimal overhead when tracing enabled (function pointer indirection)
- Efficient PC resolution with neighbor probing strategy
- Cache-aware instruction stream layout preserved

## Testing

### Coverage

- Basic stepping through arithmetic operations
- Breakpoint triggering and resumption
- Stack state verification at each step
- PC tracking accuracy with injected trace handlers
- Memory management in tracer allocations