### PR TITLE
feat: add breakpoint management UI to devtool

### DIFF
--- a/src/devtool/app.zig
+++ b/src/devtool/app.zig
@@ -48,8 +48,8 @@ fn alloc_error_json(allocator: std.mem.Allocator, msg: []const u8) ![]u8 {
     return try std.fmt.allocPrint(allocator, "{{\"error\":\"{s}\"}}", .{msg});
 }
 
-fn alloc_breakpoints_json(allocator: std.mem.Allocator, bps: []const u32) ![]u8 {
-    var s = try allocator.dupe(u8, "{\"breakpoints\":[");
+fn alloc_breakpoints_array_json(allocator: std.mem.Allocator, bps: []const u32) ![]u8 {
+    var s = try allocator.dupe(u8, "[");
     errdefer allocator.free(s);
     var i: usize = 0;
     while (i < bps.len) : (i += 1) {
@@ -62,7 +62,7 @@ fn alloc_breakpoints_json(allocator: std.mem.Allocator, bps: []const u32) ![]u8 
         allocator.free(s);
         s = next2;
     }
-    const out = try std.fmt.allocPrint(allocator, "{s}]}}", .{s});
+    const out = try std.fmt.allocPrint(allocator, "{s}]", .{s});
     allocator.free(s);
     return out;
 }
@@ -297,7 +297,7 @@ fn addBreakpointHandler(e: *webui.Event) void {
         };
         defer app.allocator.free(bps);
 
-        const json = alloc_breakpoints_json(app.allocator, bps) catch {
+        const json = alloc_breakpoints_array_json(app.allocator, bps) catch {
             e.return_string("{\"error\":\"Failed to format breakpoints\"}");
             return;
         };
@@ -353,7 +353,7 @@ fn removeBreakpointHandler(e: *webui.Event) void {
         };
         defer app.allocator.free(bps);
 
-        const json = alloc_breakpoints_json(app.allocator, bps) catch {
+        const json = alloc_breakpoints_array_json(app.allocator, bps) catch {
             e.return_string("{\"error\":\"Failed to format breakpoints\"}");
             return;
         };
@@ -377,7 +377,7 @@ fn clearBreakpointsHandler(e: *webui.Event) void {
     if (app.devtool_evm) |*evm| {
         evm.clearBreakpoints();
         const empty: []const u32 = &.{};
-        const json = alloc_breakpoints_json(app.allocator, empty) catch {
+        const json = alloc_breakpoints_array_json(app.allocator, empty) catch {
             e.return_string("{\"error\":\"Failed to format breakpoints\"}");
             return;
         };
@@ -409,7 +409,7 @@ fn getBreakpointsHandler(e: *webui.Event) void {
         };
         defer app.allocator.free(bps);
 
-        const json = alloc_breakpoints_json(app.allocator, bps) catch {
+        const json = alloc_breakpoints_array_json(app.allocator, bps) catch {
             e.return_string("{\"error\":\"Failed to format breakpoints\"}");
             return;
         };
@@ -441,7 +441,7 @@ fn getAvailableBreakpointsHandler(e: *webui.Event) void {
         };
         defer app.allocator.free(bps);
 
-        const json = alloc_breakpoints_json(app.allocator, bps) catch {
+        const json = alloc_breakpoints_array_json(app.allocator, bps) catch {
             e.return_string("{\"error\":\"Failed to format breakpoints\"}");
             return;
         };

--- a/src/devtool/evm.zig
+++ b/src/devtool/evm.zig
@@ -467,6 +467,72 @@ test "DevtoolEvm init + hex load + single step" {
     const s1 = try dv.singleStep();
     try std.testing.expect(!s1.completed);
     const json = try dv.serializeEvmState();
-    defer a.free(json);
+    // serializeEvmState allocates with dv.allocator (c_allocator); free accordingly
+    defer dv.allocator.free(json);
     try std.testing.expect(json.len > 0);
+}
+
+test "DevtoolEvm available breakpoints extraction" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const a = gpa.allocator();
+
+    var dv = try DevtoolEvm.init(a);
+    defer dv.deinit();
+
+    // Program: PUSH1 1 (pc=0), PUSH1 2 (pc=2), ADD (pc=4)
+    try dv.loadBytecodeHex("0x6001600201");
+
+    const avail = try dv.getAvailableBreakpoints(a);
+    defer a.free(avail);
+
+    try std.testing.expectEqual(@as(usize, 3), avail.len);
+    // Should contain 0, 2, 4 in some order (we will sort a copy for comparison)
+    const sorted = try a.dupe(u32, avail);
+    defer a.free(sorted);
+    std.sort.block(u32, sorted, {}, comptime std.sort.asc(u32));
+    try std.testing.expectEqual(@as(u32, 0), sorted[0]);
+    try std.testing.expectEqual(@as(u32, 2), sorted[1]);
+    try std.testing.expectEqual(@as(u32, 4), sorted[2]);
+}
+
+test "DevtoolEvm add/remove/clear breakpoints and pause on hit" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const a = gpa.allocator();
+
+    var dv = try DevtoolEvm.init(a);
+    defer dv.deinit();
+
+    // Program: PUSH1 1 (pc=0), PUSH1 2 (pc=2), ADD (pc=4), STOP (pc=5)
+    // Note: STOP isn't explicitly present here, execution will end after ADD in our tracer.
+    try dv.loadBytecodeHex("0x6001600201");
+
+    // Add a breakpoint at pc=2 and verify it is reported
+    try dv.addBreakpoint(2);
+    const bps = try dv.getBreakpoints(a);
+    defer a.free(bps);
+    try std.testing.expect(bps.len == 1);
+    // order is arbitrary, so check membership
+    var found = false;
+    for (bps) |pc| {
+        if (pc == 2) found = true;
+    }
+    try std.testing.expect(found);
+
+    // Run until pause and ensure we paused before executing pc=2
+    const res1 = try dv.runUntilHalt();
+    try std.testing.expect(res1 == .paused);
+    const pc1_opt = dv.interpreter.?.getCurrentPc();
+    try std.testing.expect(pc1_opt != null);
+    try std.testing.expectEqual(@as(usize, 2), pc1_opt.?);
+
+    // Remove that breakpoint
+    const removed = try dv.removeBreakpoint(2);
+    try std.testing.expect(removed);
+    // Clear breakpoints to ensure cleanup APIs work
+    dv.clearBreakpoints();
+    const bps2 = try dv.getBreakpoints(a);
+    defer a.free(bps2);
+    try std.testing.expectEqual(@as(usize, 0), bps2.len);
 }

--- a/src/devtool/solid/components/evm-debugger/Breakpoints.tsx
+++ b/src/devtool/solid/components/evm-debugger/Breakpoints.tsx
@@ -142,7 +142,7 @@ const Breakpoints: Component<BreakpointsProps> = (props) => {
 						<div class="flex flex-wrap gap-2">
 							<For each={groupedOpcodes()}>
 								{(op) => (
-									<Badge variant="secondary" class="gap-1">
+									<Badge variant="secondary" class="gap-1 h-8">
 										{op}
 										<Button
 											variant="ghost"
@@ -168,7 +168,7 @@ const Breakpoints: Component<BreakpointsProps> = (props) => {
 						<div class="flex flex-wrap gap-2">
 							<For each={customPcs()}>
 								{(pc) => (
-									<Badge variant="secondary" class="gap-1 font-mono">
+									<Badge variant="secondary" class="gap-1 font-mono h-8">
 										0x{pc.toString(16)}
 										<Button
 											variant="ghost"

--- a/src/devtool/solid/components/evm-debugger/Breakpoints.tsx
+++ b/src/devtool/solid/components/evm-debugger/Breakpoints.tsx
@@ -1,0 +1,193 @@
+import ArrowDownToDot from 'lucide-solid/icons/arrow-down-to-dot'
+import PlusIcon from 'lucide-solid/icons/plus'
+import Trash2Icon from 'lucide-solid/icons/trash-2'
+import XIcon from 'lucide-solid/icons/x'
+import { type Component, createEffect, createMemo, createSignal, For, Show } from 'solid-js'
+import InfoTooltip from '~/components/InfoTooltip'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
+import { Combobox, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxTrigger } from '~/components/ui/combobox'
+import type { EvmState, PreanalyzedBlockJson } from '~/lib/types'
+import { addBreakpoint, clearBreakpoints, removeBreakpoint } from '~/lib/utils'
+
+interface BreakpointsProps {
+	bytecode: string
+	state: EvmState
+	breakpoints: number[]
+	refreshBreakpoints: () => Promise<void>
+	togglePcBreakpoint: (pc: number) => Promise<void>
+}
+
+const Breakpoints: Component<BreakpointsProps> = (props) => {
+	const [availableOpcodes, setAvailableOpcodes] = createSignal<string[]>([])
+	const [selectedOpcode, setSelectedOpcode] = createSignal<string>('')
+
+	// Build opcode -> PCs mapping from preanalyzed blocks
+	const opToPcs = createMemo(() => {
+		const map = new Map<string, number[]>()
+		for (const blk of props.state.preanalyzedBlocks as PreanalyzedBlockJson[]) {
+			for (const ins of blk.instructions) {
+				const list = map.get(ins.opcode) ?? []
+				list.push(ins.pc)
+				map.set(ins.opcode, list)
+			}
+		}
+		return map
+	})
+
+	const refresh = async () => {
+		const set = new Set<string>()
+		for (const blk of props.state.preanalyzedBlocks as PreanalyzedBlockJson[]) {
+			for (const ins of blk.instructions) set.add(ins.opcode)
+		}
+		setAvailableOpcodes(Array.from(set).sort())
+		await props.refreshBreakpoints()
+	}
+
+	createEffect(() => {
+		void props.bytecode
+		void props.state.currentPreanalyzedBlockStartIndex
+		void refresh()
+	})
+
+	const groupedOpcodes = createMemo(() => {
+		const res: string[] = []
+		const bps = new Set(props.breakpoints)
+		for (const [op, pcs] of opToPcs()) {
+			if (pcs.length > 0 && pcs.every((pc) => bps.has(pc))) res.push(op)
+		}
+		return res.sort()
+	})
+
+	const customPcs = createMemo(() => {
+		const bps = new Set(props.breakpoints)
+		const covered = new Set<number>()
+		for (const op of groupedOpcodes()) {
+			for (const pc of opToPcs().get(op) ?? []) covered.add(pc)
+		}
+		const out: number[] = []
+		for (const pc of bps) if (!covered.has(pc)) out.push(pc)
+		return out.sort((a, b) => a - b)
+	})
+
+	const onAddOpcode = async () => {
+		const op = selectedOpcode()
+		if (!op) return
+		for (const pc of opToPcs().get(op) ?? []) if (!props.breakpoints.includes(pc)) await addBreakpoint(pc)
+		await props.refreshBreakpoints()
+	}
+
+	const onRemovePc = async (pc: number) => {
+		await removeBreakpoint(pc)
+		await props.refreshBreakpoints()
+	}
+
+	const onClear = async () => {
+		await clearBreakpoints()
+		await props.refreshBreakpoints()
+	}
+
+	return (
+		<Card class="max-w-7xl rounded-sm border-none bg-transparent shadow-none">
+			<CardHeader class="flex flex-col justify-between gap-2 p-0 pb-2 sm:flex-row sm:items-center">
+				<div class="space-y-1">
+					<CardTitle>Breakpoints</CardTitle>
+				</div>
+				<div class="flex items-center gap-2">
+					<Button
+						size="sm"
+						variant="ghost"
+						class="mr-4 h-7 px-2 text-xs"
+						onClick={onClear}
+						aria-label="Clear breakpoints"
+					>
+						<Trash2Icon class="mr-1 h-3.5 w-3.5" />
+						Clear all
+					</Button>
+					<Combobox
+						value={selectedOpcode()}
+						onChange={(value) => setSelectedOpcode(value || '')}
+						options={availableOpcodes()}
+						placeholder="Add opcode breakpoint"
+						itemComponent={(props) => (
+							<ComboboxItem item={props.item}>
+								<div class="flex flex-col items-start">
+									<span class="font-medium">{props.item.rawValue}</span>
+								</div>
+							</ComboboxItem>
+						)}
+					>
+						<ComboboxTrigger class="w-[260px]" aria-label="Add opcode breakpoint">
+							<div class="flex items-center gap-2">
+								<ArrowDownToDot class="h-4 w-4" />
+								<ComboboxInput placeholder="Select opcode" />
+							</div>
+						</ComboboxTrigger>
+						<ComboboxContent />
+					</Combobox>
+					<Button size="sm" variant="secondary" onClick={onAddOpcode} aria-label="Add opcode breakpoint" class="gap-2">
+						<PlusIcon class="h-4 w-4" />
+						Add
+					</Button>
+					<InfoTooltip>
+						Add a breakpoint for an opcode or use the execution steps to add a breakpoint at a specific PC.
+					</InfoTooltip>
+				</div>
+			</CardHeader>
+			<CardContent class="flex flex-col gap-3 p-0">
+				<div class="flex flex-col gap-2">
+					<div class="font-medium text-xs">Opcode breakpoints</div>
+					<Show when={groupedOpcodes().length > 0} fallback={<div class="text-muted-foreground text-sm">None</div>}>
+						<div class="flex flex-wrap gap-2">
+							<For each={groupedOpcodes()}>
+								{(op) => (
+									<Badge variant="secondary" class="gap-1">
+										{op}
+										<Button
+											variant="ghost"
+											size="icon"
+											class="ml-1 inline-flex items-center"
+											onClick={async () => {
+												for (const pc of opToPcs().get(op) ?? []) await removeBreakpoint(pc)
+												await props.refreshBreakpoints()
+											}}
+											aria-label={`Remove opcode breakpoint ${op}`}
+										>
+											<XIcon class="h-3.5 w-3.5 opacity-70" />
+										</Button>
+									</Badge>
+								)}
+							</For>
+						</div>
+					</Show>
+				</div>
+				<div class="flex flex-col gap-2">
+					<div class="font-medium text-xs">Custom</div>
+					<Show when={customPcs().length > 0} fallback={<div class="text-muted-foreground text-sm">None</div>}>
+						<div class="flex flex-wrap gap-2">
+							<For each={customPcs()}>
+								{(pc) => (
+									<Badge variant="secondary" class="gap-1 font-mono">
+										0x{pc.toString(16)}
+										<Button
+											variant="ghost"
+											size="icon"
+											class="ml-1 inline-flex items-center"
+											onClick={() => onRemovePc(pc)}
+											aria-label={`Remove breakpoint at 0x${pc.toString(16)}`}
+										>
+											<XIcon class="h-3.5 w-3.5 opacity-70" />
+										</Button>
+									</Badge>
+								)}
+							</For>
+						</div>
+					</Show>
+				</div>
+			</CardContent>
+		</Card>
+	)
+}
+
+export default Breakpoints

--- a/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
+++ b/src/devtool/solid/components/evm-debugger/EvmDebugger.tsx
@@ -1,4 +1,5 @@
-import { type Accessor, createSignal, type Setter, Show } from 'solid-js'
+import { type Accessor, createEffect, createSignal, type Setter, Show } from 'solid-js'
+import Breakpoints from '~/components/evm-debugger/Breakpoints'
 import BytecodeLoader from '~/components/evm-debugger/BytecodeLoader'
 import Controls from '~/components/evm-debugger/Controls'
 import ErrorAlert from '~/components/evm-debugger/ErrorAlert'
@@ -11,6 +12,7 @@ import Stack from '~/components/evm-debugger/Stack'
 import StateDiff from '~/components/evm-debugger/StateDiff'
 import StateSummary from '~/components/evm-debugger/StateSummary'
 import type { EvmState } from '~/lib/types'
+import { addBreakpoint, getBreakpoints, removeBreakpoint } from '~/lib/utils'
 
 interface EvmDebuggerProps {
 	isDarkMode: Accessor<boolean>
@@ -31,6 +33,31 @@ interface EvmDebuggerProps {
 
 const EvmDebugger = (props: EvmDebuggerProps) => {
 	const [activePanel, setActivePanel] = createSignal('all')
+	const [breakpoints, setBreakpoints] = createSignal<number[]>([])
+
+	const refreshBreakpoints = async () => {
+		try {
+			setBreakpoints(await getBreakpoints())
+		} catch {
+			setBreakpoints([])
+		}
+	}
+
+	// Keep breakpoints refreshed on first load and when instruction advances
+	createEffect(() => {
+		void props.state.currentInstructionIndex
+		void props.state.pc
+		void refreshBreakpoints()
+	})
+
+	const togglePcBreakpoint = async (pc: number) => {
+		if (breakpoints().includes(pc)) {
+			await removeBreakpoint(pc)
+		} else {
+			await addBreakpoint(pc)
+		}
+		await refreshBreakpoints()
+	}
 
 	return (
 		<div class="min-h-screen bg-background text-foreground">
@@ -59,12 +86,21 @@ const EvmDebugger = (props: EvmDebuggerProps) => {
 			<div class="mx-auto flex max-w-7xl flex-col gap-6 px-3 pb-6 sm:px-6">
 				<ErrorAlert error={props.error()} setError={props.setError} />
 				<StateSummary state={props.state as EvmState} isUpdating={props.isRunning()} />
-				<Show when={activePanel() === 'all' || activePanel() === 'bytecode'}>
+				<Breakpoints
+					bytecode={props.bytecode()}
+					state={props.state as EvmState}
+					breakpoints={breakpoints()}
+					refreshBreakpoints={refreshBreakpoints}
+					togglePcBreakpoint={togglePcBreakpoint}
+				/>
+				<Show when={activePanel() === 'all' || activePanel() === 'execution'}>
 					<ExecutionStepsView
 						preanalyzedBlocks={props.state.preanalyzedBlocks}
 						currentPreanalyzedBlockStartIndex={props.state.currentPreanalyzedBlockStartIndex}
 						currentInstructionIndex={props.state.currentInstructionIndex}
 						rawBytecode={props.bytecode()}
+						breakpoints={breakpoints()}
+						togglePcBreakpoint={togglePcBreakpoint}
 					/>
 				</Show>
 

--- a/src/devtool/solid/components/evm-debugger/ExecutionStepsView.tsx
+++ b/src/devtool/solid/components/evm-debugger/ExecutionStepsView.tsx
@@ -1,7 +1,9 @@
+import ArrowDownToDot from 'lucide-solid/icons/arrow-down-to-dot'
 import { type Component, createMemo, For } from 'solid-js'
 import Code from '~/components/Code'
 import InfoTooltip from '~/components/InfoTooltip'
 import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
 import { cn } from '~/lib/cn'
@@ -12,6 +14,8 @@ interface BlocksViewProps {
 	currentInstructionIndex: number
 	currentPreanalyzedBlockStartIndex: number
 	rawBytecode: string
+	breakpoints: number[]
+	togglePcBreakpoint: (pc: number) => Promise<void>
 }
 
 const ExecutionStepsView: Component<BlocksViewProps> = (props) => {
@@ -74,7 +78,7 @@ const ExecutionStepsView: Component<BlocksViewProps> = (props) => {
 													return (
 														<div
 															class={cn(
-																'grid grid-cols-[100px_100px_140px_100px_auto] gap-3 py-1',
+																'grid grid-cols-[100px_100px_140px_100px_auto_28px] gap-3 py-1',
 																idx() !== blk.instructions.length - 1 && 'border-border/40 border-b',
 															)}
 														>
@@ -91,7 +95,19 @@ const ExecutionStepsView: Component<BlocksViewProps> = (props) => {
 																{instr.opcode}
 															</Badge>
 															<Code class="inline-block w-fit text-xs">{instr.hex}</Code>
-															{instr.data ? <Code class="inline-block w-fit text-xs">{instr.data}</Code> : null}
+															{instr.data ? <Code class="inline-block w-fit text-xs">{instr.data}</Code> : <div />}
+															<Button
+																variant="ghost"
+																class={cn(
+																	'h-5 w-5 p-0 hover:bg-amber-500/70 dark:hover:bg-amber-400/70',
+																	props.breakpoints.includes(instr.pc)
+																		? 'bg-amber-500 dark:bg-amber-400'
+																		: 'text-muted-foreground',
+																)}
+																onClick={() => props.togglePcBreakpoint(instr.pc)}
+															>
+																<ArrowDownToDot class="h-3 w-3" />
+															</Button>
 														</div>
 													)
 												}}

--- a/src/devtool/solid/components/evm-debugger/Header.tsx
+++ b/src/devtool/solid/components/evm-debugger/Header.tsx
@@ -48,6 +48,14 @@ const Header: Component<HeaderProps> = (props) => {
 							All panels
 						</ToggleButton>
 						<ToggleButton
+							pressed={props.activePanel === 'execution'}
+							onChange={() => props.setActivePanel('execution')}
+							size="sm"
+							class="whitespace-nowrap hover:bg-amber-100 data-[pressed]:bg-amber-100 dark:data-[pressed]:bg-amber-950 dark:hover:bg-amber-950"
+						>
+							Execution
+						</ToggleButton>
+						<ToggleButton
 							pressed={props.activePanel === 'stack'}
 							onChange={() => props.setActivePanel('stack')}
 							size="sm"
@@ -78,14 +86,6 @@ const Header: Component<HeaderProps> = (props) => {
 							class="whitespace-nowrap hover:bg-amber-100 data-[pressed]:bg-amber-100 dark:data-[pressed]:bg-amber-950 dark:hover:bg-amber-950"
 						>
 							Logs
-						</ToggleButton>
-						<ToggleButton
-							pressed={props.activePanel === 'bytecode'}
-							onChange={() => props.setActivePanel('bytecode')}
-							size="sm"
-							class="whitespace-nowrap hover:bg-amber-100 data-[pressed]:bg-amber-100 dark:data-[pressed]:bg-amber-950 dark:hover:bg-amber-950"
-						>
-							Bytecode
 						</ToggleButton>
 						<ToggleButton
 							pressed={props.activePanel === 'gas'}

--- a/src/devtool/solid/lib/utils.ts
+++ b/src/devtool/solid/lib/utils.ts
@@ -236,8 +236,8 @@ export const opcodeToString = (opcode: number): string => {
 export async function addBreakpoint(pc: number | string): Promise<number[]> {
 	try {
 		const arg = typeof pc === 'number' ? String(pc) : pc
-		const breakpoints = assertJson(await window.add_breakpoint(arg))
-		return Array.isArray(breakpoints) ? breakpoints : []
+		const resp = await window.add_breakpoint(arg)
+		return assertJson<number[]>(resp)
 	} catch (err) {
 		throw new Error(`Failed to add breakpoint: ${err}`)
 	}
@@ -246,8 +246,8 @@ export async function addBreakpoint(pc: number | string): Promise<number[]> {
 export async function removeBreakpoint(pc: number | string): Promise<number[]> {
 	try {
 		const arg = typeof pc === 'number' ? String(pc) : pc
-		const breakpoints = assertJson(await window.remove_breakpoint(arg))
-		return Array.isArray(breakpoints) ? breakpoints : []
+		const resp = await window.remove_breakpoint(arg)
+		return assertJson<number[]>(resp)
 	} catch (err) {
 		throw new Error(`Failed to remove breakpoint: ${err}`)
 	}
@@ -255,8 +255,8 @@ export async function removeBreakpoint(pc: number | string): Promise<number[]> {
 
 export async function clearBreakpoints(): Promise<number[]> {
 	try {
-		const breakpoints = assertJson(await window.clear_breakpoints())
-		return Array.isArray(breakpoints) ? breakpoints : []
+		const resp = await window.clear_breakpoints()
+		return assertJson<number[]>(resp)
 	} catch (err) {
 		throw new Error(`Failed to clear breakpoints: ${err}`)
 	}
@@ -264,8 +264,8 @@ export async function clearBreakpoints(): Promise<number[]> {
 
 export async function getBreakpoints(): Promise<number[]> {
 	try {
-		const breakpoints = assertJson(await window.get_breakpoints())
-		return Array.isArray(breakpoints) ? breakpoints : []
+		const resp = await window.get_breakpoints()
+		return assertJson<number[]>(resp)
 	} catch (err) {
 		throw new Error(`Failed to get breakpoints: ${err}`)
 	}
@@ -273,8 +273,8 @@ export async function getBreakpoints(): Promise<number[]> {
 
 export async function getAvailableBreakpoints(): Promise<number[]> {
 	try {
-		const breakpoints = assertJson(await window.get_available_breakpoints())
-		return Array.isArray(breakpoints) ? breakpoints : []
+		const resp = await window.get_available_breakpoints()
+		return assertJson<number[]>(resp)
 	} catch (err) {
 		throw new Error(`Failed to get available breakpoints: ${err}`)
 	}


### PR DESCRIPTION
# Breakpoint Management UI for Guillotine Devtool

## Summary

This PR adds a comprehensive breakpoint management interface to the Guillotine EVM devtool, enabling developers to set breakpoints at specific program counters (PCs) or opcodes during EVM bytecode debugging. The feature includes both UI components and backend logic for managing breakpoints during execution.

https://github.com/user-attachments/assets/b530dfa7-f30e-4652-882f-16e1c38a3a91

## Key Features

### Visual Breakpoint Management Panel

A new dedicated Breakpoints component provides:

- **Opcode-based breakpoints**: Set breakpoints for all instances of specific opcodes (e.g., all `ADD` operations)
- **Custom PC breakpoints**: Target specific program counter positions
- **Inline breakpoint toggles**: Click breakpoint icons next to instructions in the execution view
- **Clear all functionality**: Remove all breakpoints with one click

### Grouped Display

The UI intelligently groups breakpoints:

- **Opcode breakpoints**: Shows badges for opcodes where ALL instances have breakpoints
- **Custom breakpoints**: Shows individual PC values not covered by opcode groups

```
// Example display:
// Opcode breakpoints: [ADD] [MUL] [SSTORE]
// Custom: [0x14] [0x2a]
```