### PR TITLE
feat: add dynamic gas cost tracking to EVM debugger

### DIFF
--- a/src/devtool/debug_state.zig
+++ b/src/devtool/debug_state.zig
@@ -65,6 +65,11 @@ pub const InstructionJson = struct {
     opcode: []const u8,
     hex: []const u8,
     data: []const u8,
+    // Runtime dynamic gas info
+    dynGasCost: u32 = 0,
+    dynGasCandidate: bool = false,
+    // Static base gas cost for this opcode (excludes runtime dynamics)
+    staticGasCost: u32 = 0,
 };
 
 pub const PreanalyzedBlock = struct {
@@ -181,11 +186,47 @@ pub fn collect_blocks_for_interpreter(
                     allocator.free(data_owned);
                     data_owned = try format_bytes_hex(allocator, slice);
                 }
+                // Mark dynamic-gas candidate opcodes
+                const may_dyn: bool = switch (op) {
+                    0x51, // MLOAD
+                    0x52, // MSTORE
+                    0x53, // MSTORE8
+                    0x5e, // MCOPY
+                    0x37, // CALLDATACOPY
+                    0x39, // CODECOPY
+                    0x3c, // EXTCODECOPY
+                    0x3e, // RETURNDATACOPY
+                    0x54, // SLOAD
+                    0x55, // SSTORE
+                    0x20, // KECCAK256
+                    0x31, // BALANCE
+                    0x3b, // EXTCODESIZE
+                    0x3f, // EXTCODEHASH
+                    0xa0, // LOG0
+                    0xa1, // LOG1
+                    0xa2, // LOG2
+                    0xa3, // LOG3
+                    0xa4, // LOG4
+                    0xf0, // CREATE
+                    0xf1, // CALL
+                    0xf2, // CALLCODE
+                    0xf4, // DELEGATECALL
+                    0xf5, // CREATE2
+                    0xfa, // STATICCALL
+                    => true,
+                    else => false,
+                };
+                // Static base gas from opcode table
+                const static_gas: u32 = @intCast(evm.OpcodeData.OPCODE_INFO[op].gas_cost);
+
                 try instrs.append(allocator, .{
                     .pc = @intCast(scan),
                     .opcode = name_owned,
                     .hex = hex_owned,
                     .data = data_owned,
+                    .dynGasCost = 0,
+                    .dynGasCandidate = may_dyn,
+                    .staticGasCost = static_gas,
                 });
             }
         }

--- a/src/devtool/evm.zig
+++ b/src/devtool/evm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Evm = @import("evm");
 const debug_state = @import("debug_state.zig");
+const OpcodeData = Evm.OpcodeData;
 
 const DevtoolEvm = @This();
 
@@ -390,6 +391,36 @@ pub fn serializeEvmState(self: *DevtoolEvm) ![]u8 {
 
     // Minimal preanalyzed blocks via planner/plan helper
     const preanalyzed_blocks = try debug_state.collect_blocks_for_interpreter(Interpreter, self.allocator, interp);
+    // Fill dynamic gas per instruction from tracer steps
+    {
+        // Build a temporary PC -> (block_idx, instr_idx) map for quick lookup
+        var pc_map = std.AutoHashMap(u32, struct { b: usize, i: usize }).init(self.allocator);
+        defer pc_map.deinit();
+        var bi2: usize = 0;
+        while (bi2 < preanalyzed_blocks.len) : (bi2 += 1) {
+            const blk = preanalyzed_blocks[bi2];
+            var ii2: usize = 0;
+            while (ii2 < blk.instructions.len) : (ii2 += 1) {
+                const pc_u32 = blk.instructions[ii2].pc;
+                // ignore put errors silently for duplicates
+                _ = pc_map.put(pc_u32, .{ .b = bi2, .i = ii2 }) catch {};
+            }
+        }
+        // Walk over recorded steps and attribute dynamic gas
+        const trace_steps = interp.frame.tracer.steps.items;
+        var si: usize = 0;
+        while (si < trace_steps.len) : (si += 1) {
+            const stp = trace_steps[si];
+            const pc: u32 = stp.pc;
+            if (pc_map.get(pc)) |pos| {
+                const base: u32 = OpcodeData.OPCODE_INFO[stp.opcode].gas_cost;
+                const total: u32 = @intCast(@max(0, stp.gas_before - stp.gas_after));
+                const dyn: u32 = if (total > base) total - base else 0;
+                // Set dynGasCost at the matched instruction
+                preanalyzed_blocks[pos.b].instructions[pos.i].dynGasCost = dyn;
+            }
+        }
+    }
     const cur_idx_usize: usize = interp.instruction_idx;
     var current_block_start_idx: usize = 0;
     // Choose the largest block.firstInstructionIndex <= current instruction index

--- a/src/devtool/solid/components/evm-debugger/ExecutionStepsView.tsx
+++ b/src/devtool/solid/components/evm-debugger/ExecutionStepsView.tsx
@@ -44,73 +44,128 @@ const ExecutionStepsView: Component<BlocksViewProps> = (props) => {
 					<TableHeader class="sticky top-0 z-10 bg-background">
 						<TableRow>
 							<TableHead class="text-xs uppercase">Begin</TableHead>
-							<TableHead class="text-xs uppercase">Gas</TableHead>
 							<TableHead class="text-xs uppercase">
-								<div class="grid grid-cols-[100px_100px_140px_100px_auto] gap-3">
-									<span class="leading-tight">Instructions</span>
-									<span class="text-[10px] text-muted-foreground">PC</span>
-									<span class="text-[10px] text-muted-foreground">Opcode</span>
-									<span class="text-[10px] text-muted-foreground">Hex</span>
-									<span class="text-[10px] text-muted-foreground">Data</span>
+								<div class="flex items-center gap-1">
+									<span>Gas</span>
+									<span class="text-[10px] text-muted-foreground">(static)</span>
+									<InfoTooltip>Per-instruction base cost from opcode table (no runtime overhead).</InfoTooltip>
 								</div>
 							</TableHead>
+							<TableHead class="text-xs uppercase">
+								<div class="flex items-center gap-1">
+									<span>Gas</span>
+									<span class="text-[10px] text-muted-foreground">(dynamic)</span>
+									<InfoTooltip>
+										Per-instruction runtime overhead. "-" until executed, then "+N" once known. "0" for ops with no
+										dynamic overhead.
+									</InfoTooltip>
+								</div>
+							</TableHead>
+							<TableHead class="text-[10px] uppercase">PC</TableHead>
+							<TableHead class="text-[10px] uppercase">Opcode</TableHead>
+							<TableHead class="text-[10px] uppercase">Hex</TableHead>
+							<TableHead class="text-[10px] uppercase">Data</TableHead>
+							<TableHead class="text-[10px] uppercase">BP</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
 						<For each={props.preanalyzedBlocks}>
 							{(blk) => (
 								<TableRow
-									class={blk.firstInstructionIndex === props.currentPreanalyzedBlockStartIndex ? 'bg-accent/50' : ''}
+									class={cn(blk.firstInstructionIndex === props.currentPreanalyzedBlockStartIndex && 'bg-accent/50')}
 								>
 									<TableCell class="align-top font-mono text-xs">
-										<span class="inline-block py-2">{blk.firstInstructionIndex}</span>
+										<span class="inline-block py-1">{blk.firstInstructionIndex}</span>
 									</TableCell>
 									<TableCell class="align-top font-mono text-xs">
-										<span class="inline-block py-2">{blk.gasCost}</span>
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr) => <span class="inline-flex h-5.5 items-center">{instr.staticGasCost}</span>}
+											</For>
+										</div>
 									</TableCell>
-									<TableCell class="py-2" colSpan={1}>
-										<div class="flex flex-col gap-1">
+									<TableCell class="align-top font-mono text-xs">
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr, idx) => {
+													const canDyn = instr.dynGasCandidate
+													const v = instr.dynGasCost
+													const insnIndex = blk.firstInstructionIndex + 1 + idx()
+													const isPast = insnIndex < props.currentInstructionIndex
+													const display = v > 0 ? `+${v}` : isPast ? '0' : canDyn ? '-' : '0'
+													const muted = v === 0 && !isPast
+													return (
+														<span class={cn('flex h-5.5 items-center', muted && 'text-muted-foreground')}>
+															{display}
+														</span>
+													)
+												}}
+											</For>
+										</div>
+									</TableCell>
+									<TableCell class="align-top">
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr) => <Code class="inline-block w-fit text-xs">0x{instr.pc.toString(16)}</Code>}
+											</For>
+										</div>
+									</TableCell>
+									<TableCell class="align-top">
+										<div class="flex flex-col gap-2">
 											<For each={blk.instructions}>
 												{(instr, idx) => {
 													const isActive =
 														blk.firstInstructionIndex === props.currentPreanalyzedBlockStartIndex &&
 														idx() === Math.max(0, props.currentInstructionIndex - blk.firstInstructionIndex - 1)
 													return (
-														<div
-															class={cn(
-																'grid grid-cols-[100px_100px_140px_100px_auto_28px] gap-3 py-1',
-																idx() !== blk.instructions.length - 1 && 'border-border/40 border-b',
-															)}
+														<Badge
+															variant={isActive ? 'default' : 'secondary'}
+															class={`inline-flex w-fit font-mono text-xs transition-colors duration-150 ${
+																isActive
+																	? 'bg-amber-500 text-black hover:bg-amber-400'
+																	: 'bg-amber-500/15 text-amber-700 hover:bg-amber-500/20 dark:text-amber-300 dark:hover:bg-amber-400/20'
+															}`}
 														>
-															<span />
-															<Code class="inline-block w-fit text-xs">0x{instr.pc.toString(16)}</Code>
-															<Badge
-																variant={isActive ? 'default' : 'secondary'}
-																class={`inline-flex w-fit font-mono text-xs transition-colors duration-150 ${
-																	isActive
-																		? 'bg-amber-500 text-black hover:bg-amber-400'
-																		: 'bg-amber-500/15 text-amber-700 hover:bg-amber-500/20 dark:text-amber-300 dark:hover:bg-amber-400/20'
-																}`}
-															>
-																{instr.opcode}
-															</Badge>
-															<Code class="inline-block w-fit text-xs">{instr.hex}</Code>
-															{instr.data ? <Code class="inline-block w-fit text-xs">{instr.data}</Code> : <div />}
-															<Button
-																variant="ghost"
-																class={cn(
-																	'h-5 w-5 p-0 hover:bg-amber-500/70 dark:hover:bg-amber-400/70',
-																	props.breakpoints.includes(instr.pc)
-																		? 'bg-amber-500 dark:bg-amber-400'
-																		: 'text-muted-foreground',
-																)}
-																onClick={() => props.togglePcBreakpoint(instr.pc)}
-															>
-																<ArrowDownToDot class="h-3 w-3" />
-															</Button>
-														</div>
+															{instr.opcode}
+														</Badge>
 													)
 												}}
+											</For>
+										</div>
+									</TableCell>
+									<TableCell class="align-top">
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr) => <Code class="inline-block w-fit text-xs">{instr.hex}</Code>}
+											</For>
+										</div>
+									</TableCell>
+									<TableCell class="align-top">
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr) =>
+													instr.data ? <Code class="inline-block w-fit text-xs">{instr.data}</Code> : <span />
+												}
+											</For>
+										</div>
+									</TableCell>
+									<TableCell class="align-top">
+										<div class="flex flex-col gap-2">
+											<For each={blk.instructions}>
+												{(instr) => (
+													<Button
+														variant="ghost"
+														class={cn(
+															'h-5 w-5 p-0 hover:bg-amber-500/70 dark:hover:bg-amber-400/70',
+															props.breakpoints.includes(instr.pc)
+																? 'bg-amber-500 dark:bg-amber-400'
+																: 'text-muted-foreground',
+														)}
+														onClick={() => props.togglePcBreakpoint(instr.pc)}
+													>
+														<ArrowDownToDot class="h-3 w-3" />
+													</Button>
+												)}
 											</For>
 										</div>
 									</TableCell>

--- a/src/devtool/solid/lib/types.ts
+++ b/src/devtool/solid/lib/types.ts
@@ -23,6 +23,9 @@ export interface InstructionJson {
 	opcode: string
 	hex: string
 	data: string
+	dynGasCost: number
+	dynGasCandidate: boolean
+	staticGasCost: number
 }
 
 export interface EvmState {


### PR DESCRIPTION
# Add dynamic gas cost tracking to EVM debugger

### TL;DR

Added dynamic gas cost tracking and display in the EVM debugger to help developers understand gas consumption patterns.

https://github.com/user-attachments/assets/3c18d041-951b-40e7-b4bd-bfbc6b1de7e7

### What changed?

- Enhanced `InstructionJson` struct to track both static and dynamic gas costs
- Added logic to identify opcodes that may have dynamic gas costs
- Implemented gas attribution from tracer steps to instructions
- Redesigned the ExecutionStepsView UI to display gas information in dedicated columns:
    - Static gas (base cost from opcode table)
    - Dynamic gas (runtime overhead)
- Improved the instruction display with a cleaner, more readable table layout

### How to test?

1. Open the EVM debugger
2. Execute a transaction with opcodes that have dynamic gas costs (e.g., SSTORE, CALL)
3. Observe the gas columns in the execution steps view:
    - Static gas shows the base cost
    - Dynamic gas shows "-" for unexecuted instructions, "0" for instructions with no overhead, and "+N" for executed instructions with dynamic costs

### Why make this change?

Understanding gas consumption is critical for Ethereum developers. This change makes it easier to:

- Identify which operations are expensive at runtime
- Distinguish between static and dynamic gas costs
- Visualize gas consumption patterns during execution
- Optimize smart contracts by targeting high-gas operations