### PR TITLE
:bug: fix: undefined opcode handling in EVM

### DIFF
--- a/src/evm/frame_handlers.zig
+++ b/src/evm/frame_handlers.zig
@@ -42,9 +42,10 @@ pub fn getOpcodeHandlers(comptime FrameType: type) [256]FrameType.OpcodeHandler 
     // The default opcode handler used for any opcode that is not supported by the EVM
     const invalid = struct {
         fn handler(frame: *FrameType, cursor: [*]const FrameType.Dispatch.Item) FrameType.Error!noreturn {
-            _ = frame;
             _ = cursor;
-            return FrameType.Error.InvalidOpcode;
+            // Invalid opcodes consume all remaining gas and revert
+            frame.gas_remaining = 0;
+            return FrameType.Error.OutOfGas;
         }
     }.handler;
 


### PR DESCRIPTION
## Summary

- Fixed bytecode validation to accept undefined opcodes (0x28, 0x26, 0xde, etc.) rather than failing validation
- Changed invalid opcode handler to consume all gas and return OutOfGas error (EVM specification behavior) 
- Updated Solidity metadata parsing to support both IPFS and Swarm formats

## Problem

The differential tests were failing immediately with InvalidOpcode errors when encountering undefined opcodes. According to the EVM specification, undefined opcodes should be treated as INVALID operations that consume all remaining gas and revert, not fail validation.

## Solution

1. Modified `buildBitmapsAndValidate()` in bytecode.zig to treat undefined opcodes as INVALID rather than returning an error
2. Updated the invalid opcode handler in frame_handlers.zig to consume all gas and return OutOfGas instead of InvalidOpcode
3. Enhanced Solidity metadata parsing to handle both IPFS and Swarm metadata formats

## Test Results

This fix allows tests to progress further - they now execute bytecode instead of failing immediately on validation. There are still 13 tests failing with other issues (StackUnderflow, InvalidJump, etc.) that need to be addressed separately.

## Related Issues

Part of ongoing differential test fixes to achieve 100% test pass rate with production-ready code.

🤖 Generated with [Claude Code](https://claude.ai/code)