### PR TITLE
refactor: return unpadded 20-byte contract address from CREATE/CREATE2

### DIFF
--- a/src/evm/evm_tests.zig
+++ b/src/evm/evm_tests.zig
@@ -1162,10 +1162,10 @@ test "EVM CREATE operation - basic contract creation" {
     // Verify successful creation
     try std.testing.expect(result.success);
     try std.testing.expect(result.gas_left > 0);
-    try std.testing.expectEqual(@as(usize, 32), result.output.len);
+    try std.testing.expectEqual(@as(usize, 20), result.output.len);
 
-    // Extract contract address from output (last 20 bytes)
-    const contract_address: primitives.Address = result.output[12..32].*;
+    // Extract contract address from output
+    const contract_address: primitives.Address = result.output[0..20].*;
 
     // Verify contract was created
     const created_account = (try db.get_account(contract_address)).?;
@@ -1230,7 +1230,7 @@ test "EVM CREATE operation - with value transfer" {
     try std.testing.expect(result.success);
 
     // Extract contract address
-    const contract_address: primitives.Address = result.output[12..32].*;
+    const contract_address: primitives.Address = result.output[0..20].*;
 
     // Verify balances
     const caller_after = (try db.get_account(caller_address)).?;
@@ -1347,10 +1347,10 @@ test "EVM CREATE2 operation - deterministic address creation" {
     // Verify successful creation
     try std.testing.expect(result.success);
     try std.testing.expect(result.gas_left > 0);
-    try std.testing.expectEqual(@as(usize, 32), result.output.len);
+    try std.testing.expectEqual(@as(usize, 20), result.output.len);
 
     // Extract contract address
-    const contract_address: primitives.Address = result.output[12..32].*;
+    const contract_address: primitives.Address = result.output[0..20].*;
 
     // Verify contract was created
     const created_account = (try db.get_account(contract_address)).?;
@@ -1426,7 +1426,7 @@ test "EVM CREATE2 operation - same parameters produce same address" {
 
     try std.testing.expect(result.success);
 
-    const actual_address: primitives.Address = result.output[12..32].*;
+    const actual_address: primitives.Address = result.output[0..20].*;
     try std.testing.expectEqualSlices(u8, &expected_address, &actual_address);
 }
 
@@ -1561,7 +1561,7 @@ test "EVM CREATE operation - init code execution and storage" {
 
     try std.testing.expect(result.success);
 
-    const contract_address: primitives.Address = result.output[12..32].*;
+    const contract_address: primitives.Address = result.output[0..20].*;
 
     // Verify the storage was set during init
     const stored_value = try db.get_storage(contract_address, 0);
@@ -1651,10 +1651,10 @@ test "EVM CREATE/CREATE2 - nested contract creation" {
     defer if (result.output.len > 0) evm.allocator.free(result.output);
 
     try std.testing.expect(result.success);
-    try std.testing.expectEqual(@as(usize, 32), result.output.len);
+    try std.testing.expectEqual(@as(usize, 20), result.output.len);
 
     // The output should contain the address of the created child contract
-    const child_address: primitives.Address = result.output[12..32].*;
+    const child_address: primitives.Address = result.output[0..20].*;
 
     // Verify child contract exists
     const child_account = try db.get_account(child_address);
@@ -3995,7 +3995,7 @@ test "CREATE interaction - factory creates and initializes child contracts" {
 
     // Extract child contract address from output
     var child_address: primitives.Address = undefined;
-    @memcpy(&child_address, factory_result.output[12..32]); // Address is in bytes 12-31
+    @memcpy(&child_address, factory_result.output[0..20]); // Contract address
 
     // Call child contract to verify initialization
     const verify_result = try evm_instance.call(.{
@@ -4902,11 +4902,11 @@ test "CREATE stores deployed code bytes" {
     });
 
     try std.testing.expect(result.success);
-    try std.testing.expectEqual(@as(usize, 32), result.output.len);
+    try std.testing.expectEqual(@as(usize, 20), result.output.len);
 
     // Extract created contract address from output
     var created_address: primitives.Address = undefined;
-    @memcpy(&created_address, result.output[12..32]);
+    @memcpy(&created_address, result.output[0..20]);
 
     // Verify the deployed contract exists and has the correct code
     const deployed_code = try db.get_code_by_address(created_address);
@@ -5066,11 +5066,11 @@ test "CREATE2 stores deployed code bytes" {
     });
 
     try std.testing.expect(result.success);
-    try std.testing.expectEqual(@as(usize, 32), result.output.len);
+    try std.testing.expectEqual(@as(usize, 20), result.output.len);
 
     // Extract created contract address from output
     var created_address: primitives.Address = undefined;
-    @memcpy(&created_address, result.output[12..32]);
+    @memcpy(&created_address, result.output[0..20]);
 
     // Verify the deployed contract exists and has the correct code
     const deployed_code = try db.get_code_by_address(created_address);


### PR DESCRIPTION
### TL;DR

Changed contract address return format from 32-byte padded to 20-byte unpadded in CREATE and CREATE2 operations.

### Why

`src/evm/handlers_system.zig`, [at create](https://github.com/evmts/guillotine/blob/main/src/evm/handlers_system.zig#L495) and [at create2](https://github.com/evmts/guillotine/blob/main/src/evm/handlers_system.zig#L580) expects the output (created address) to be 20 bytes.

### What changed?

Modified the EVM's contract creation operations to return the contract address as a 20-byte value instead of a 32-byte value with 12 bytes of zero padding. This affects both CREATE and CREATE2 operations. Updated all related tests to expect and handle 20-byte addresses instead of extracting the address from bytes 12-32 of the result.

The key change is in the contract creation result handling:
- Before: Returned 32 bytes (12 zero bytes + 20-byte address)
- After: Returns 20 bytes (unpadded address)

Added a comment noting that the handler will convert the address to u256 when pushing to stack.