### PR TITLE
fix: comptime parameter errors in opcode handler generation

### DIFF
--- a/src/evm/frame_handlers.zig
+++ b/src/evm/frame_handlers.zig
@@ -128,19 +128,19 @@ pub fn getOpcodeHandlers(comptime FrameType: type) [256]FrameType.OpcodeHandler 
     h[@intFromEnum(Opcode.TSTORE)] = &StorageHandlers.tstore;
     // PUSH
     h[@intFromEnum(Opcode.PUSH0)] = &StackHandlers.push0;
-    for (1..33) |i| {
+    inline for (1..33) |i| {
         const push_n = @as(u8, @intCast(i));
         const opcode = @as(Opcode, @enumFromInt(@intFromEnum(Opcode.PUSH0) + push_n));
         h[@intFromEnum(opcode)] = StackHandlers.generatePushHandler(push_n);
     }
     // DUP
-    for (1..17) |i| {
+    inline for (1..17) |i| {
         const dup_n = @as(u8, @intCast(i));
         const opcode = @as(Opcode, @enumFromInt(@intFromEnum(Opcode.DUP1) + dup_n - 1));
         h[@intFromEnum(opcode)] = StackHandlers.generateDupHandler(dup_n);
     }
     // SWAP
-    for (1..17) |i| {
+    inline for (1..17) |i| {
         const swap_n = @as(u8, @intCast(i));
         const opcode = @as(Opcode, @enumFromInt(@intFromEnum(Opcode.SWAP1) + swap_n - 1));
         h[@intFromEnum(opcode)] = StackHandlers.generateSwapHandler(swap_n);


### PR DESCRIPTION
## Summary
  - Fixed compilation errors in frame_handlers.zig where handler generation functions require comptime parameters

  ## Problem
  The `generatePushHandler`, `generateDupHandler`, and `generateSwapHandler` functions require comptime parameters, but were being called with runtime loop variables from regular `for` loops. This caused compilation
  errors when the bytecode disassembly module tried to use these handlers.

  ## Solution
  - Changed `for` loops to `inline for` loops in frame_handlers.zig to provide comptime values