### PR TITLE
feat: show logs table in call result and history

### DIFF
--- a/apps/cli/internal/app/app.go
+++ b/apps/cli/internal/app/app.go
@@ -37,6 +37,7 @@ func InitialModel() Model {
 		historyManager: historyMgr,
 		historyTable:   ui.CreateHistoryTable(),
 		contractsTable: ui.CreateContractsTable(),
+		logsTable:      ui.CreateLogsTable(10),
 	}
 }
 

--- a/apps/cli/internal/app/handlers.go
+++ b/apps/cli/internal/app/handlers.go
@@ -264,43 +264,10 @@ func (m Model) executeReset() tea.Cmd {
 // getCopyContent returns the content to copy based on current state
 func (m *Model) getCopyContent() string {
 	switch m.state {
-	case types.StateCallResult:
-		if m.callResult != nil {
-			return ui.RenderCallResult(m.callResult, m.callParams)
-		}
-		
-	case types.StateCallParameterList:
-		params := GetCallParams(m.callParams)
-		if m.callParamCursor < len(params) {
-			return params[m.callParamCursor].Value
-		}
-		
-	case types.StateCallParameterEdit:
-		return m.textInput.Value()
-		
-	case types.StateCallHistory:
-		history := m.historyManager.GetAllCalls()
-		if m.historyTable.Cursor() < len(history) {
-			entry := history[m.historyTable.Cursor()]
-			return ui.RenderHistoryDetail(&entry, m.width-4, m.height-10)
-		}
-		
-	case types.StateCallHistoryDetail:
-		entry := m.historyManager.GetCall(m.selectedHistoryID)
-		if entry != nil {
-			return ui.RenderHistoryDetail(entry, m.width-4, m.height-10)
-		}
-		
-	case types.StateContracts:
-		contracts := m.historyManager.GetContracts()
-		if m.contractsTable.Cursor() < len(contracts) {
-			return contracts[m.contractsTable.Cursor()].Address
-		}
-		
 	case types.StateContractDetail:
 		contract := m.historyManager.GetContract(m.selectedContract)
 		if contract != nil {
-			return ui.RenderContractDetail(contract, m.width-4, m.height-10)
+			return contract.Address
 		}
 	}
 	

--- a/apps/cli/internal/app/model.go
+++ b/apps/cli/internal/app/model.go
@@ -35,8 +35,10 @@ type Model struct {
 	// View states
 	historyTable       table.Model
 	contractsTable     table.Model
+	logsTable          table.Model
 	selectedHistoryID  string
 	selectedContract   string
+	selectedLogIndex   int
 	
 	// UI state
 	showCopyFeedback   bool

--- a/apps/cli/internal/app/update.go
+++ b/apps/cli/internal/app/update.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"guillotine-cli/internal/types"
+	"guillotine-cli/internal/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -23,6 +24,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case callResultMsg:
 		m.callResult = msg.result
 		m.state = types.StateCallResult
+		
+		// Populate logs table if there are logs
+		if msg.result != nil && len(msg.result.Logs) > 0 {
+			rows := ui.ConvertLogsToRows(msg.result.Logs)
+			m.logsTable.SetRows(rows)
+		}
+		
 		return m, nil
 
 	case resetCompleteMsg:

--- a/apps/cli/internal/app/view.go
+++ b/apps/cli/internal/app/view.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"guillotine-cli/internal/config"
+	logs "guillotine-cli/internal/core"
 	"guillotine-cli/internal/types"
 	"guillotine-cli/internal/ui"
 
@@ -54,8 +55,24 @@ func (m Model) View() string {
 		
 	case types.StateCallResult:
 		header := ui.RenderHeader(config.CallResultTitle, config.CallResultSubtitle, config.TitleStyle, config.SubtitleStyle)
-		result := ui.RenderCallResult(m.callResult, m.callParams)
-		help := ui.RenderHelp(types.StateCallResult)
+		
+		// Create pure log display data
+		logDisplayData := ui.LogDisplayData{}
+		if m.callResult != nil && len(m.callResult.Logs) > 0 {
+			currentLines := 8 // Estimate for call result content + header
+			baseOverhead := 9 // borders, help, buffer
+			availableHeight := m.height - currentLines - baseOverhead
+			
+			logDisplayData = ui.LogDisplayData{
+				Logs:            m.callResult.Logs,
+				SelectedIndex:   m.logsTable.Cursor(), // Get current selection from table
+				AvailableHeight: availableHeight,
+			}
+		}
+		
+		result := ui.RenderCallResult(m.callResult, m.callParams, logDisplayData, m.width-4)
+		hasLogs := logs.HasLogs(m.callResult)
+		help := ui.RenderHelpWithLogs(types.StateCallResult, hasLogs)
 		content := layout.ComposeVertical(header, result, help)
 		return layout.RenderWithBox(content)
 		
@@ -69,8 +86,24 @@ func (m Model) View() string {
 	case types.StateCallHistoryDetail:
 		header := ui.RenderHeader(config.CallHistoryDetailTitle, config.CallHistoryDetailSubtitle, config.TitleStyle, config.SubtitleStyle)
 		entry := m.historyManager.GetCall(m.selectedHistoryID)
-		detail := ui.RenderHistoryDetail(entry, m.width-4, m.height-10)
-		help := ui.RenderHelp(types.StateCallHistoryDetail)
+		
+		// Create pure log display data
+		logDisplayData := ui.LogDisplayData{}
+		if logs.HasHistoryLogs(entry) {
+			currentLines := 12 // Estimate for history detail content + header
+			baseOverhead := 9  // borders, help, buffer
+			availableHeight := m.height - currentLines - baseOverhead
+			
+			logDisplayData = ui.LogDisplayData{
+				Logs:            entry.Result.Logs,
+				SelectedIndex:   m.logsTable.Cursor(),
+				AvailableHeight: availableHeight,
+			}
+		}
+		
+		detail := ui.RenderHistoryDetail(entry, logDisplayData, m.width-4)
+		hasLogs := logs.HasHistoryLogs(entry)
+		help := ui.RenderHelpWithLogs(types.StateCallHistoryDetail, hasLogs)
 		content := layout.ComposeVertical(header, detail, help)
 		return layout.RenderWithBox(content)
 		
@@ -91,13 +124,28 @@ func (m Model) View() string {
 		return layout.RenderWithBox(content)
 		
 	case types.StateConfirmReset:
-		header := ui.RenderHeader("Reset State", "Are you sure? This will clear all call history and contracts.", config.TitleStyle, config.SubtitleStyle)
+		header := ui.RenderHeader(config.ResetStateTitle, config.ResetStateSubtitle, config.TitleStyle, config.SubtitleStyle)
 		confirmText := lipgloss.NewStyle().
 			Bold(true).
 			Foreground(config.Destructive).
-			Render("Press ENTER to confirm reset or ESC to cancel")
+			Render(config.ResetConfirmMessage)
 		help := ui.RenderHelp(types.StateConfirmReset)
 		content := layout.ComposeVertical(header, confirmText, help)
+		return layout.RenderWithBox(content)
+		
+	case types.StateLogDetail:
+		header := ui.RenderHeader(config.LogDetailTitle, config.LogDetailSubtitle, config.TitleStyle, config.SubtitleStyle)
+		
+		// Get log using core domain logic
+		var selectedHistoryEntry *types.CallHistoryEntry
+		if m.selectedHistoryID != "" {
+			selectedHistoryEntry = m.historyManager.GetCall(m.selectedHistoryID)
+		}
+		
+		log := logs.GetSelectedLog(m.callResult, selectedHistoryEntry, m.selectedLogIndex)
+		detail := ui.RenderLogDetail(log, m.selectedLogIndex, m.width-4)
+		help := ui.RenderHelp(types.StateLogDetail)
+		content := layout.ComposeVertical(header, detail, help)
 		return layout.RenderWithBox(content)
 		
 	default:

--- a/apps/cli/internal/app/view.go
+++ b/apps/cli/internal/app/view.go
@@ -59,9 +59,9 @@ func (m Model) View() string {
 		// Create pure log display data
 		logDisplayData := ui.LogDisplayData{}
 		if m.callResult != nil && len(m.callResult.Logs) > 0 {
-			currentLines := 8 // Estimate for call result content + header
-			baseOverhead := 9 // borders, help, buffer
-			availableHeight := m.height - currentLines - baseOverhead
+			// Use a reasonable fixed height for logs that won't cause cropping
+			maxLogHeight := (m.height / 2) // Use at most half of screen for logs
+			availableHeight := min(maxLogHeight, 15) // Cap at 15 lines for logs
 			
 			logDisplayData = ui.LogDisplayData{
 				Logs:            m.callResult.Logs,
@@ -90,9 +90,10 @@ func (m Model) View() string {
 		// Create pure log display data
 		logDisplayData := ui.LogDisplayData{}
 		if logs.HasHistoryLogs(entry) {
-			currentLines := 12 // Estimate for history detail content + header
-			baseOverhead := 9  // borders, help, buffer
-			availableHeight := m.height - currentLines - baseOverhead
+			// Use a conservative fixed height for logs in history detail view
+			// This ensures the content is never cropped at the top
+			maxLogHeight := (m.height / 3) // Use at most 1/3 of screen for logs
+			availableHeight := min(maxLogHeight, 10) // Cap at 10 lines for logs
 			
 			logDisplayData = ui.LogDisplayData{
 				Logs:            entry.Result.Logs,

--- a/apps/cli/internal/config/help.go
+++ b/apps/cli/internal/config/help.go
@@ -10,6 +10,7 @@ type HelpEntry struct {
 var HelpCatalog = map[string]HelpEntry{
 	// Navigation
 	"navigate":     {Key: "↑/k ↓/j", Action: "navigate"},
+	"navigate_logs": {Key: "↑/k ↓/j", Action: "navigate logs"},
 	
 	// Selection and actions
 	"select":       {Key: "enter", Action: "select"},
@@ -17,6 +18,7 @@ var HelpCatalog = map[string]HelpEntry{
 	"edit":         {Key: "enter", Action: "edit"},
 	"save":         {Key: "enter", Action: "save"},
 	"view_details": {Key: "enter", Action: "view details"},
+	"view_log_detail": {Key: "enter", Action: "view log details"},
 	"continue":     {Key: "enter", Action: "continue"},
 	
 	// Execution
@@ -68,7 +70,6 @@ var StateHelpEntries = map[string][]string{
 		"cancel",
 	},
 	"call_result": {
-		"continue",
 		"back_to_menu",
 	},
 	"call_history": {
@@ -91,6 +92,9 @@ var StateHelpEntries = map[string][]string{
 	"confirm_reset": {
 		"enter",
 		"cancel",
+	},
+	"log_detail": {
+		"back",
 	},
 }
 
@@ -121,4 +125,27 @@ func GetHelpText(entries []HelpEntry) ([]string, []string) {
 	}
 	
 	return keys, actions
+}
+
+// GetHelpForStateWithLogs returns help entries for states that may have logs
+func GetHelpForStateWithLogs(stateKey string, hasLogs bool) []HelpEntry {
+	// Get base entries
+	keys, exists := StateHelpEntries[stateKey]
+	if !exists {
+		return nil
+	}
+	
+	// If there are logs, prepend log navigation entries
+	if hasLogs && (stateKey == "call_result" || stateKey == "call_history_detail") {
+		// Insert log navigation entries at the beginning
+		keys = append([]string{"navigate_logs", "view_log_detail"}, keys...)
+	}
+	
+	entries := make([]HelpEntry, 0, len(keys))
+	for _, key := range keys {
+		if entry, ok := HelpCatalog[key]; ok {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }

--- a/apps/cli/internal/config/messages.go
+++ b/apps/cli/internal/config/messages.go
@@ -62,6 +62,15 @@ const (
 	CallTypeDelegateCall = "DELEGATECALL"
 	CallTypeCreate       = "CREATE"
 	CallTypeCreate2      = "CREATE2"
+	
+	// Reset state messages
+	ResetStateTitle      = "Reset State"
+	ResetStateSubtitle   = "Are you sure? This will clear all call history and contracts."
+	ResetConfirmMessage  = "Press ENTER to confirm reset or ESC to cancel"
+	
+	// Log detail messages
+	LogDetailTitle       = "Log Details"
+	LogDetailSubtitle    = "Full log entry information"
 )
 
 // GetMenuItems returns the default menu items

--- a/apps/cli/internal/core/logs.go
+++ b/apps/cli/internal/core/logs.go
@@ -1,0 +1,35 @@
+package logs
+
+import (
+	gevmTypes "github.com/evmts/guillotine/bindings/go/evm"
+	"guillotine-cli/internal/types"
+)
+
+// GetSelectedLog returns the log entry for the given context
+func GetSelectedLog(callResult *gevmTypes.CallResult, selectedHistoryEntry *types.CallHistoryEntry, logIndex int) *gevmTypes.LogEntry {
+	var logs []gevmTypes.LogEntry
+	
+	// Determine source of logs
+	if selectedHistoryEntry != nil && selectedHistoryEntry.Result != nil {
+		logs = selectedHistoryEntry.Result.Logs
+	} else if callResult != nil {
+		logs = callResult.Logs
+	}
+	
+	// Validate index and return log
+	if logIndex >= 0 && logIndex < len(logs) {
+		return &logs[logIndex]
+	}
+	
+	return nil
+}
+
+// HasLogs checks if the given result has any logs
+func HasLogs(result *gevmTypes.CallResult) bool {
+	return result != nil && len(result.Logs) > 0
+}
+
+// HasHistoryLogs checks if the given history entry has any logs
+func HasHistoryLogs(entry *types.CallHistoryEntry) bool {
+	return entry != nil && entry.Result != nil && len(entry.Result.Logs) > 0
+}

--- a/apps/cli/internal/core/logs.go
+++ b/apps/cli/internal/core/logs.go
@@ -1,13 +1,14 @@
 package logs
 
 import (
-	gevmTypes "github.com/evmts/guillotine/bindings/go/evm"
 	"guillotine-cli/internal/types"
+
+	guillotine "github.com/evmts/guillotine/sdks/go"
 )
 
 // GetSelectedLog returns the log entry for the given context
-func GetSelectedLog(callResult *gevmTypes.CallResult, selectedHistoryEntry *types.CallHistoryEntry, logIndex int) *gevmTypes.LogEntry {
-	var logs []gevmTypes.LogEntry
+func GetSelectedLog(callResult *guillotine.CallResult, selectedHistoryEntry *types.CallHistoryEntry, logIndex int) *guillotine.LogEntry {
+	var logs []guillotine.LogEntry
 	
 	// Determine source of logs
 	if selectedHistoryEntry != nil && selectedHistoryEntry.Result != nil {
@@ -25,7 +26,7 @@ func GetSelectedLog(callResult *gevmTypes.CallResult, selectedHistoryEntry *type
 }
 
 // HasLogs checks if the given result has any logs
-func HasLogs(result *gevmTypes.CallResult) bool {
+func HasLogs(result *guillotine.CallResult) bool {
 	return result != nil && len(result.Logs) > 0
 }
 

--- a/apps/cli/internal/core/utils/clipboard.go
+++ b/apps/cli/internal/core/utils/clipboard.go
@@ -1,0 +1,28 @@
+package utils
+
+import "strings"
+
+// CleanMultilineForInput cleans multi-line content for single-line text input
+func CleanMultilineForInput(content string) string {
+	// First trim any leading/trailing whitespace
+	cleaned := strings.TrimSpace(content)
+	
+	// Remove newlines and carriage returns
+	cleaned = strings.ReplaceAll(cleaned, "\n", "")
+	cleaned = strings.ReplaceAll(cleaned, "\r", "")
+	
+	// For hex strings (starting with 0x), don't modify internal content
+	if strings.HasPrefix(cleaned, "0x") || strings.HasPrefix(cleaned, "0X") {
+		// Just remove tabs and ensure it's properly trimmed
+		cleaned = strings.ReplaceAll(cleaned, "\t", "")
+		return cleaned
+	}
+	
+	// For non-hex content, replace tabs with spaces and collapse multiple spaces
+	cleaned = strings.ReplaceAll(cleaned, "\t", " ")
+	for strings.Contains(cleaned, "  ") {
+		cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+	}
+	
+	return cleaned
+}

--- a/apps/cli/internal/types/app_state.go
+++ b/apps/cli/internal/types/app_state.go
@@ -14,6 +14,7 @@ const (
 	StateContracts
 	StateContractDetail
 	StateConfirmReset
+	StateLogDetail
 )
 
 type TabType int

--- a/apps/cli/internal/ui/call_input.go
+++ b/apps/cli/internal/ui/call_input.go
@@ -12,7 +12,6 @@ import (
 func CreateTextInput(paramName, currentValue string) textinput.Model {
 	ti := textinput.New()
 	ti.Focus()
-	ti.CharLimit = 256
 	ti.Width = 50
 	ti.SetValue(currentValue)
 	
@@ -29,11 +28,13 @@ func CreateTextInput(paramName, currentValue string) textinput.Model {
 		ti.CharLimit = 10
 		ti.Placeholder = "100000"
 	case config.CallParamInput, config.CallParamInputDeploy:
-		ti.CharLimit = 1000
+		ti.CharLimit = 0 // No limit for input data
 		ti.Placeholder = "0x"
 	case config.CallParamSalt:
 		ti.CharLimit = 66
 		ti.Placeholder = "0x0000..."
+	default:
+		ti.CharLimit = 256 // Default for unknown parameters
 	}
 	
 	return ti

--- a/apps/cli/internal/ui/contracts.go
+++ b/apps/cli/internal/ui/contracts.go
@@ -147,16 +147,6 @@ func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", width-len(s))
 }
 
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	if maxLen < 3 {
-		return s[:maxLen]
-	}
-	return s[:maxLen-3] + "..."
-}
-
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/apps/cli/internal/ui/help.go
+++ b/apps/cli/internal/ui/help.go
@@ -18,6 +18,7 @@ var stateToHelpKey = map[types.AppState]string{
 	types.StateContracts:          "contracts",
 	types.StateContractDetail:     "contract_detail",
 	types.StateConfirmReset:       "confirm_reset",
+	types.StateLogDetail:          "log_detail",
 }
 
 // RenderHelp renders help text for the given state
@@ -27,6 +28,18 @@ func RenderHelp(state types.AppState) string {
 		return ""
 	}
 	return renderHelpForKey(stateKey)
+}
+
+// RenderHelpWithLogs renders help text for states that may have logs
+func RenderHelpWithLogs(state types.AppState, hasLogs bool) string {
+	stateKey, exists := stateToHelpKey[state]
+	if !exists {
+		return ""
+	}
+	
+	entries := config.GetHelpForStateWithLogs(stateKey, hasLogs)
+	keys, actions := config.GetHelpText(entries)
+	return renderHelpText(keys, actions)
 }
 
 // renderHelpForKey renders help for a given state key

--- a/apps/cli/internal/ui/history.go
+++ b/apps/cli/internal/ui/history.go
@@ -104,7 +104,7 @@ func formatGas(gas uint64) string {
 	return fmt.Sprintf("%.2fM", float64(gas)/1000000)
 }
 
-func RenderHistoryDetail(entry *types.CallHistoryEntry, width, height int) string {
+func RenderHistoryDetail(entry *types.CallHistoryEntry, logDisplayData LogDisplayData, width int) string {
 	if entry == nil {
 		return config.DimmedStyle.Render("No entry selected")
 	}
@@ -176,16 +176,19 @@ func RenderHistoryDetail(entry *types.CallHistoryEntry, width, height int) strin
 			b.WriteString("\n")
 		}
 
-		if len(entry.Result.Logs) > 0 {
+		// Render created address if available
+		if entry.Result.CreatedAddress != nil {
 			b.WriteString("\n")
-			b.WriteString(config.LabelStyle.Render(fmt.Sprintf("Logs (%d):", len(entry.Result.Logs))))
+			b.WriteString(config.LabelStyle.Render("Created Address:"))
 			b.WriteString("\n")
-			for i, log := range entry.Result.Logs {
-				b.WriteString(config.DimmedStyle.Render(fmt.Sprintf("  [%d] Topics: %d, Data: %d bytes", 
-					i, len(log.Topics), len(log.Data))))
-				b.WriteString("\n")
-			}
+			b.WriteString(config.DimmedStyle.Render(entry.Result.CreatedAddress.String()))
+			b.WriteString("\n")
 		}
+		
+		// Render logs if available
+		baseContent := b.String()
+		logsContent := RenderLogsDisplay(logDisplayData, width)
+		return baseContent + logsContent
 	}
 
 	return b.String()

--- a/apps/cli/internal/ui/logs.go
+++ b/apps/cli/internal/ui/logs.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/evmts/guillotine/bindings/go/evm"
+	guillotine "github.com/evmts/guillotine/sdks/go"
 )
 
 // LogDisplayData contains pure data for log display
 type LogDisplayData struct {
-	Logs             []evm.LogEntry
+	Logs             []guillotine.LogEntry
 	SelectedIndex    int
 	AvailableHeight  int
 }
@@ -32,7 +32,7 @@ func RenderLogsDisplay(displayData LogDisplayData, width int) string {
 }
 
 // RenderLogsAsTable renders logs in a pure table format with proper scrolling
-func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableHeight int) string {
+func RenderLogsAsTable(logs []guillotine.LogEntry, selectedIndex int, width, availableHeight int) string {
 	if len(logs) == 0 {
 		emptyStyle := config.DimmedStyle
 		return emptyStyle.Render("No logs emitted")
@@ -103,7 +103,7 @@ func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableH
 		
 		// Format address to exactly 16 chars for alignment
 		addr := formatFixedAddress(log.Address.String(), 16)
-		data := formatLogData(log.Data.Data(), 30)
+		data := formatLogData(log.Data, 30)
 		
 		row := fmt.Sprintf("%-4d %-16s %-7d %s", 
 			i, 
@@ -119,7 +119,7 @@ func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableH
 }
 
 // RenderLogsSection renders a simple logs section without a table (for when table is not available)
-func RenderLogsSection(logs []evm.LogEntry, width int) string {
+func RenderLogsSection(logs []guillotine.LogEntry, width int) string {
 	if len(logs) == 0 {
 		return ""
 	}
@@ -141,7 +141,7 @@ func RenderLogsSection(logs []evm.LogEntry, width int) string {
 }
 
 // ConvertLogsToRows converts log entries to table rows
-func ConvertLogsToRows(logs []evm.LogEntry) []table.Row {
+func ConvertLogsToRows(logs []guillotine.LogEntry) []table.Row {
 	rows := make([]table.Row, 0, len(logs))
 	
 	for i, log := range logs {
@@ -149,7 +149,7 @@ func ConvertLogsToRows(logs []evm.LogEntry) []table.Row {
 			fmt.Sprintf("%d", i),
 			formatFixedAddress(log.Address.String(), 16),
 			fmt.Sprintf("%d", len(log.Topics)),
-			formatLogData(log.Data.Data(), 40),
+			formatLogData(log.Data, 40),
 		}
 		rows = append(rows, row)
 	}
@@ -157,7 +157,7 @@ func ConvertLogsToRows(logs []evm.LogEntry) []table.Row {
 	return rows
 }
 
-func renderLogEntry(index int, log evm.LogEntry, width int) string {
+func renderLogEntry(index int, log guillotine.LogEntry, width int) string {
 	var b strings.Builder
 	
 	indexStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
@@ -183,7 +183,7 @@ func renderLogEntry(index int, log evm.LogEntry, width int) string {
 	}
 	
 	// Data
-	data := log.Data.Data()
+	data := log.Data
 	if len(data) > 0 {
 		b.WriteString("    ")
 		b.WriteString(config.LabelStyle.Render("Data: "))
@@ -250,7 +250,7 @@ func formatLogData(data []byte, maxChars int) string {
 
 
 // RenderLogDetail renders detailed view of a single log entry
-func RenderLogDetail(log *evm.LogEntry, index int, width int) string {
+func RenderLogDetail(log *guillotine.LogEntry, index int, width int) string {
 	if log == nil {
 		return config.DimmedStyle.Render("No log selected")
 	}
@@ -280,7 +280,7 @@ func RenderLogDetail(log *evm.LogEntry, index int, width int) string {
 	}
 	
 	// Data - intelligently wrap based on terminal width
-	data := log.Data.Data()
+	data := log.Data
 	if len(data) > 0 {
 		b.WriteString(config.LabelStyle.Render("Data:"))
 		b.WriteString("\n")

--- a/apps/cli/internal/ui/logs.go
+++ b/apps/cli/internal/ui/logs.go
@@ -31,7 +31,7 @@ func RenderLogsDisplay(displayData LogDisplayData, width int) string {
 	}
 }
 
-// RenderLogsAsTable renders logs in a pure table format without using table.Model
+// RenderLogsAsTable renders logs in a pure table format with proper scrolling
 func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableHeight int) string {
 	if len(logs) == 0 {
 		emptyStyle := config.DimmedStyle
@@ -40,32 +40,76 @@ func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableH
 
 	var content strings.Builder
 	
-	// Table header
+	// Logs title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
+	content.WriteString(titleStyle.Render(fmt.Sprintf("Logs (%d):", len(logs))))
+	content.WriteString("\n\n")
+	
+	// Table header with proper alignment
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
-	content.WriteString(headerStyle.Render("#    Address          Topics  Data"))
+	// Use consistent formatting for header to match data rows
+	header := fmt.Sprintf("%-4s %-16s %-7s %s", "#", "Address", "Topics", "Data")
+	content.WriteString(headerStyle.Render(header))
 	content.WriteString("\n")
 	
-	// Table rows
-	maxRows := availableHeight - 3 // Account for header and some padding
-	if maxRows < 1 {
-		maxRows = 1
+	// Calculate scrolling viewport (account for title, header and some padding)
+	maxRows := max(availableHeight - 4, 1)
+	
+	// Ensure selectedIndex is within bounds
+	selectedIndex = min(selectedIndex, len(logs) - 1)
+	selectedIndex = max(selectedIndex, 0)
+	
+	// Calculate scroll offset to keep selected item visible
+	var startIndex int
+	if len(logs) <= maxRows {
+		// All logs fit, show everything
+		startIndex = 0
+	} else {
+		// Calculate offset to center selected item when possible
+		centerOffset := maxRows / 2
+		
+		if selectedIndex < centerOffset {
+			// Near the beginning, show from start
+			startIndex = 0
+		} else if selectedIndex >= len(logs)-centerOffset {
+			// Near the end, show the last maxRows entries
+			startIndex = len(logs) - maxRows
+		} else {
+			// In the middle, center the selected item
+			startIndex = selectedIndex - centerOffset
+		}
+		
+		// Ensure startIndex is within bounds
+		if startIndex < 0 {
+			startIndex = 0
+		}
+		if startIndex+maxRows > len(logs) {
+			startIndex = len(logs) - maxRows
+		}
 	}
 	
-	for i, log := range logs {
-		if i >= maxRows {
-			break
-		}
+	// Calculate end index
+	endIndex := startIndex + maxRows
+	endIndex = min(endIndex, len(logs))
+	
+	// Render visible rows
+	for i := startIndex; i < endIndex; i++ {
+		log := logs[i]
 		
 		rowStyle := config.DimmedStyle
 		if i == selectedIndex {
 			rowStyle = lipgloss.NewStyle().Bold(true).Background(config.Amber).Foreground(config.Background)
 		}
 		
+		// Format address to exactly 16 chars for alignment
+		addr := formatFixedAddress(log.Address.String(), 16)
+		data := formatLogData(log.Data.Data(), 30)
+		
 		row := fmt.Sprintf("%-4d %-16s %-7d %s", 
 			i, 
-			formatAddress(log.Address.String(), 16),
+			addr,
 			len(log.Topics),
-			formatLogData(log.Data.Data(), 30))
+			data)
 		
 		content.WriteString(rowStyle.Render(row))
 		content.WriteString("\n")
@@ -103,7 +147,7 @@ func ConvertLogsToRows(logs []evm.LogEntry) []table.Row {
 	for i, log := range logs {
 		row := table.Row{
 			fmt.Sprintf("%d", i),
-			formatAddress(log.Address.String(), 8),
+			formatFixedAddress(log.Address.String(), 16),
 			fmt.Sprintf("%d", len(log.Topics)),
 			formatLogData(log.Data.Data(), 40),
 		}
@@ -122,7 +166,7 @@ func renderLogEntry(index int, log evm.LogEntry, width int) string {
 	
 	// Address
 	b.WriteString(config.LabelStyle.Render("Address: "))
-	b.WriteString(formatAddress(log.Address.String(), 10))
+	b.WriteString(formatFixedAddress(log.Address.String(), 10))
 	b.WriteString("\n")
 	
 	// Topics
@@ -164,6 +208,28 @@ func formatTopic(topic string, maxWidth int) string {
 	return fmt.Sprintf("%s…%s", topic[:maxWidth/2], topic[len(topic)-maxWidth/2+1:])
 }
 
+// formatFixedAddress formats an address to exactly the specified width
+func formatFixedAddress(addr string, width int) string {
+	if !strings.HasPrefix(addr, "0x") {
+		addr = "0x" + addr
+	}
+	
+	// If address is shorter than width, pad it
+	if len(addr) <= width {
+		return addr + strings.Repeat(" ", width-len(addr))
+	}
+	
+	// If we need to truncate, use ellipsis but ensure fixed width
+	if width < 8 {
+		return addr[:width]
+	}
+	
+	// Show beginning and end with ellipsis in middle
+	prefixLen := (width - 3) / 2  // Reserve 3 chars for "..."
+	suffixLen := width - 3 - prefixLen
+	return addr[:prefixLen] + "..." + addr[len(addr)-suffixLen:]
+}
+
 func formatLogData(data []byte, maxChars int) string {
 	if len(data) == 0 {
 		return "0x"
@@ -178,7 +244,8 @@ func formatLogData(data []byte, maxChars int) string {
 		return hex[:maxChars]
 	}
 	
-	return fmt.Sprintf("%s…%s", hex[:maxChars/2], hex[len(hex)-maxChars/2+1:])
+	// Use three dots instead of ellipsis character for consistent width
+	return fmt.Sprintf("%s...%s", hex[:maxChars/2-1], hex[len(hex)-maxChars/2+2:])
 }
 
 

--- a/apps/cli/internal/ui/logs.go
+++ b/apps/cli/internal/ui/logs.go
@@ -1,0 +1,262 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"guillotine-cli/internal/config"
+
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/evmts/guillotine/bindings/go/evm"
+)
+
+// LogDisplayData contains pure data for log display
+type LogDisplayData struct {
+	Logs             []evm.LogEntry
+	SelectedIndex    int
+	AvailableHeight  int
+}
+
+// RenderLogsDisplay renders logs as a table if space allows, otherwise as simple list
+func RenderLogsDisplay(displayData LogDisplayData, width int) string {
+	if len(displayData.Logs) == 0 {
+		return ""
+	}
+	
+	if displayData.AvailableHeight > 5 {
+		return "\n\n" + RenderLogsAsTable(displayData.Logs, displayData.SelectedIndex, width, displayData.AvailableHeight)
+	} else {
+		return "\n\n" + RenderLogsSection(displayData.Logs, width)
+	}
+}
+
+// RenderLogsAsTable renders logs in a pure table format without using table.Model
+func RenderLogsAsTable(logs []evm.LogEntry, selectedIndex int, width, availableHeight int) string {
+	if len(logs) == 0 {
+		emptyStyle := config.DimmedStyle
+		return emptyStyle.Render("No logs emitted")
+	}
+
+	var content strings.Builder
+	
+	// Table header
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
+	content.WriteString(headerStyle.Render("#    Address          Topics  Data"))
+	content.WriteString("\n")
+	
+	// Table rows
+	maxRows := availableHeight - 3 // Account for header and some padding
+	if maxRows < 1 {
+		maxRows = 1
+	}
+	
+	for i, log := range logs {
+		if i >= maxRows {
+			break
+		}
+		
+		rowStyle := config.DimmedStyle
+		if i == selectedIndex {
+			rowStyle = lipgloss.NewStyle().Bold(true).Background(config.Amber).Foreground(config.Background)
+		}
+		
+		row := fmt.Sprintf("%-4d %-16s %-7d %s", 
+			i, 
+			formatAddress(log.Address.String(), 16),
+			len(log.Topics),
+			formatLogData(log.Data.Data(), 30))
+		
+		content.WriteString(rowStyle.Render(row))
+		content.WriteString("\n")
+	}
+	
+	return content.String()
+}
+
+// RenderLogsSection renders a simple logs section without a table (for when table is not available)
+func RenderLogsSection(logs []evm.LogEntry, width int) string {
+	if len(logs) == 0 {
+		return ""
+	}
+	
+	var b strings.Builder
+	
+	labelStyle := config.LabelStyle
+	b.WriteString(labelStyle.Render(fmt.Sprintf("Logs (%d entries):", len(logs))))
+	b.WriteString("\n\n")
+	
+	for i, log := range logs {
+		b.WriteString(renderLogEntry(i, log, width))
+		if i < len(logs)-1 {
+			b.WriteString("\n")
+		}
+	}
+	
+	return b.String()
+}
+
+// ConvertLogsToRows converts log entries to table rows
+func ConvertLogsToRows(logs []evm.LogEntry) []table.Row {
+	rows := make([]table.Row, 0, len(logs))
+	
+	for i, log := range logs {
+		row := table.Row{
+			fmt.Sprintf("%d", i),
+			formatAddress(log.Address.String(), 8),
+			fmt.Sprintf("%d", len(log.Topics)),
+			formatLogData(log.Data.Data(), 40),
+		}
+		rows = append(rows, row)
+	}
+	
+	return rows
+}
+
+func renderLogEntry(index int, log evm.LogEntry, width int) string {
+	var b strings.Builder
+	
+	indexStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
+	b.WriteString(indexStyle.Render(fmt.Sprintf("[%d]", index)))
+	b.WriteString(" ")
+	
+	// Address
+	b.WriteString(config.LabelStyle.Render("Address: "))
+	b.WriteString(formatAddress(log.Address.String(), 10))
+	b.WriteString("\n")
+	
+	// Topics
+	if len(log.Topics) > 0 {
+		b.WriteString("    ")
+		b.WriteString(config.LabelStyle.Render("Topics: "))
+		for i, topic := range log.Topics {
+			if i > 0 {
+				b.WriteString("\n            ")
+			}
+			b.WriteString(config.DimmedStyle.Render(formatTopic(topic.String(), width-12)))
+		}
+		b.WriteString("\n")
+	}
+	
+	// Data
+	data := log.Data.Data()
+	if len(data) > 0 {
+		b.WriteString("    ")
+		b.WriteString(config.LabelStyle.Render("Data: "))
+		b.WriteString(config.DimmedStyle.Render(formatLogData(data, width-10)))
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}
+
+
+func formatTopic(topic string, maxWidth int) string {
+	if !strings.HasPrefix(topic, "0x") {
+		topic = "0x" + topic
+	}
+	if len(topic) <= maxWidth {
+		return topic
+	}
+	if maxWidth < 20 {
+		return topic[:maxWidth]
+	}
+	return fmt.Sprintf("%s…%s", topic[:maxWidth/2], topic[len(topic)-maxWidth/2+1:])
+}
+
+func formatLogData(data []byte, maxChars int) string {
+	if len(data) == 0 {
+		return "0x"
+	}
+	
+	hex := fmt.Sprintf("0x%x", data)
+	if len(hex) <= maxChars {
+		return hex
+	}
+	
+	if maxChars < 10 {
+		return hex[:maxChars]
+	}
+	
+	return fmt.Sprintf("%s…%s", hex[:maxChars/2], hex[len(hex)-maxChars/2+1:])
+}
+
+
+// RenderLogDetail renders detailed view of a single log entry
+func RenderLogDetail(log *evm.LogEntry, index int, width int) string {
+	if log == nil {
+		return config.DimmedStyle.Render("No log selected")
+	}
+	
+	var b strings.Builder
+	
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(config.Amber)
+	b.WriteString(titleStyle.Render(fmt.Sprintf("Log Entry #%d", index)))
+	b.WriteString("\n\n")
+	
+	// Address - always show full on one line
+	b.WriteString(config.LabelStyle.Render("Address:"))
+	b.WriteString("\n")
+	b.WriteString(config.DimmedStyle.Render(log.Address.String()))
+	b.WriteString("\n\n")
+	
+	// Topics - always show full on one line each
+	if len(log.Topics) > 0 {
+		b.WriteString(config.LabelStyle.Render(fmt.Sprintf("Topics (%d):", len(log.Topics))))
+		b.WriteString("\n")
+		for i, topic := range log.Topics {
+			b.WriteString(config.DimmedStyle.Render(fmt.Sprintf("  [%d] %s", i, topic.String())))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	
+	// Data - intelligently wrap based on terminal width
+	data := log.Data.Data()
+	if len(data) > 0 {
+		b.WriteString(config.LabelStyle.Render("Data:"))
+		b.WriteString("\n")
+		
+		hex := fmt.Sprintf("0x%x", data)
+		
+		// Account for margins and indentation (approximately 4 chars)
+		availableWidth := width - 4
+		
+		if len(hex) <= availableWidth {
+			// Fits on one line
+			b.WriteString(config.DimmedStyle.Render(hex))
+			b.WriteString("\n")
+		} else {
+			// Need to wrap - break on byte boundaries
+			// Skip "0x" prefix for wrapping calculation
+			hexData := hex[2:]
+			
+			// Each byte is 2 hex chars, calculate chars per line
+			// Make it even to avoid breaking bytes
+			charsPerLine := availableWidth - 2 // Reserve space for "0x" on first line
+			if charsPerLine%2 != 0 {
+				charsPerLine--
+			}
+			
+			// First line with 0x prefix
+			b.WriteString(config.DimmedStyle.Render("0x" + hexData[:min(charsPerLine, len(hexData))]))
+			b.WriteString("\n")
+			
+			// Subsequent lines without prefix, indented by 2 spaces
+			for i := charsPerLine; i < len(hexData); i += charsPerLine + 2 {
+				end := min(i+charsPerLine+2, len(hexData))
+				b.WriteString(config.DimmedStyle.Render("  " + hexData[i:end]))
+				b.WriteString("\n")
+			}
+		}
+		
+		// Show data size
+		b.WriteString("\n")
+		b.WriteString(config.LabelStyle.Render("Data Size: "))
+		b.WriteString(config.DimmedStyle.Render(fmt.Sprintf("%d bytes", len(data))))
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}

--- a/apps/cli/internal/ui/table_factory.go
+++ b/apps/cli/internal/ui/table_factory.go
@@ -31,6 +31,18 @@ func CreateContractsTable() table.Model {
 	return createStyledTable(columns, config.DefaultTableHeight)
 }
 
+// CreateLogsTable creates a new styled table for logs display
+func CreateLogsTable(height int) table.Model {
+	columns := []table.Column{
+		{Title: "#", Width: 4},
+		{Title: "Address", Width: 18},
+		{Title: "Topics", Width: 8},
+		{Title: "Data", Width: 50},
+	}
+
+	return createStyledTable(columns, height)
+}
+
 // createStyledTable creates a table with common styling
 func createStyledTable(columns []table.Column, height int) table.Model {
 	t := table.New(

--- a/src/evm_c_api.zig
+++ b/src/evm_c_api.zig
@@ -559,9 +559,9 @@ fn convertCallResultToEvmResult(result: anytype, allocator: std.mem.Allocator) ?
                 const topics_copy = allocator.alloc([32]u8, log_item.topics.len) catch {
                     setError("Failed to allocate topics", .{});
                     // Clean up already allocated
-                    for (logs_copy[0..i]) |prev_log_entry| {
-                        if (prev_log_entry.topics_len > 0) allocator.free(prev_log_entry.topics[0..prev_log_entry.topics_len]);
-                        if (prev_log_entry.data_len > 0) allocator.free(prev_log_entry.data[0..prev_log_entry.data_len]);
+                    for (logs_copy[0..i]) |prev_log| {
+                        if (prev_log.topics_len > 0) allocator.free(prev_log.topics[0..prev_log.topics_len]);
+                        if (prev_log.data_len > 0) allocator.free(prev_log.data[0..prev_log.data_len]);
                     }
                     allocator.free(logs_copy);
                     if (evm_result.output_len > 0) allocator.free(evm_result.output[0..evm_result.output_len]);
@@ -584,9 +584,9 @@ fn convertCallResultToEvmResult(result: anytype, allocator: std.mem.Allocator) ?
                     setError("Failed to allocate log data", .{});
                     // Clean up
                     if (logs_copy[i].topics_len > 0) allocator.free(logs_copy[i].topics[0..logs_copy[i].topics_len]);
-                    for (logs_copy[0..i]) |prev_log_entry| {
-                        if (prev_log_entry.topics_len > 0) allocator.free(prev_log_entry.topics[0..prev_log_entry.topics_len]);
-                        if (prev_log_entry.data_len > 0) allocator.free(prev_log_entry.data[0..prev_log_entry.data_len]);
+                    for (logs_copy[0..i]) |prev_log| {
+                        if (prev_log.topics_len > 0) allocator.free(prev_log.topics[0..prev_log.topics_len]);
+                        if (prev_log.data_len > 0) allocator.free(prev_log.data[0..prev_log.data_len]);
                     }
                     allocator.free(logs_copy);
                     if (evm_result.output_len > 0) allocator.free(evm_result.output[0..evm_result.output_len]);

--- a/src/evm_c_api.zig
+++ b/src/evm_c_api.zig
@@ -559,9 +559,9 @@ fn convertCallResultToEvmResult(result: anytype, allocator: std.mem.Allocator) ?
                 const topics_copy = allocator.alloc([32]u8, log_item.topics.len) catch {
                     setError("Failed to allocate topics", .{});
                     // Clean up already allocated
-                    for (logs_copy[0..i]) |prev_log| {
-                        if (prev_log.topics_len > 0) allocator.free(prev_log.topics[0..prev_log.topics_len]);
-                        if (prev_log.data_len > 0) allocator.free(prev_log.data[0..prev_log.data_len]);
+                    for (logs_copy[0..i]) |prev_log_entry| {
+                        if (prev_log_entry.topics_len > 0) allocator.free(prev_log_entry.topics[0..prev_log_entry.topics_len]);
+                        if (prev_log_entry.data_len > 0) allocator.free(prev_log_entry.data[0..prev_log_entry.data_len]);
                     }
                     allocator.free(logs_copy);
                     if (evm_result.output_len > 0) allocator.free(evm_result.output[0..evm_result.output_len]);
@@ -584,9 +584,9 @@ fn convertCallResultToEvmResult(result: anytype, allocator: std.mem.Allocator) ?
                     setError("Failed to allocate log data", .{});
                     // Clean up
                     if (logs_copy[i].topics_len > 0) allocator.free(logs_copy[i].topics[0..logs_copy[i].topics_len]);
-                    for (logs_copy[0..i]) |prev_log| {
-                        if (prev_log.topics_len > 0) allocator.free(prev_log.topics[0..prev_log.topics_len]);
-                        if (prev_log.data_len > 0) allocator.free(prev_log.data[0..prev_log.data_len]);
+                    for (logs_copy[0..i]) |prev_log_entry| {
+                        if (prev_log_entry.topics_len > 0) allocator.free(prev_log_entry.topics[0..prev_log_entry.topics_len]);
+                        if (prev_log_entry.data_len > 0) allocator.free(prev_log_entry.data[0..prev_log_entry.data_len]);
                     }
                     allocator.free(logs_copy);
                     if (evm_result.output_len > 0) allocator.free(evm_result.output[0..evm_result.output_len]);


### PR DESCRIPTION
### TL;DR

Added log viewing functionality to the Guillotine CLI, allowing users to browse and inspect EVM logs in call results and history entries.

[Enregistrement de l’écran 2025-09-05 à 13.29.23.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/6bae5fd0-f870-40ee-a1a0-bf635353e143.mov" />](https://app.graphite.dev/user-attachments/video/6bae5fd0-f870-40ee-a1a0-bf635353e143.mov)

### What changed?

- Added a dedicated logs table component to display logs in call results and history details
- Created a new log detail view to show comprehensive information about individual log entries
- Implemented navigation between logs in call results and history entries
- Added support for viewing log topics, data, and addresses in a structured format
- Enhanced clipboard handling to better support multi-line content and hex data
- Updated help text to include log navigation instructions when logs are present
- Improved parameter display by truncating very long values

### How to test?

1. Execute a transaction that emits logs
2. Navigate through the logs using up/down keys in the call result screen
3. Press Enter to view detailed information about a selected log
4. Test clipboard functionality with multi-line content
5. Verify that log navigation works in both call results and history detail views

### Why make this change?

Logs are a critical part of EVM transactions, containing important event data emitted by smart contracts. This enhancement makes it easier for users to browse, inspect, and understand logs produced during contract execution, improving the overall debugging and analysis capabilities of the Guillotine CLI.