### PR TITLE
bug: DELEGATECALL incorrectly modifies delegate's storage instead of caller's storage

### DIFF
--- a/src/evm.zig
+++ b/src/evm.zig
@@ -697,7 +697,7 @@ pub fn Evm(comptime config: EvmConfig) type {
                         code,
                         params.input,
                         params.gas,
-                        params.to,
+                        params.caller,
                         params.caller, // Preserve original caller
                         current_value, // Preserve value from parent context
                         false,

--- a/test/delegatecall_storage_context_test.zig
+++ b/test/delegatecall_storage_context_test.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const testing = std.testing;
+const primitives = @import("primitives");
+const evm = @import("evm");
+
+// Test demonstrating DELEGATECALL storage context issue
+// 
+// Issue: DELEGATECALL should execute the target contract's code but in the caller's storage context.
+// This means storage operations (SSTORE) should modify the caller's storage, not the delegate's.
+//
+// Current bug: The executeDelegatecall function in src/evm.zig passes params.to as the 
+// address parameter to execute_frame, which causes storage operations to happen in the 
+// delegate's context instead of the caller's context.
+//
+// Expected behavior:
+// - When contract A does DELEGATECALL to contract B
+// - B's code executes, but any SSTORE operations should modify A's storage
+// - B's storage should remain unchanged
+test "DELEGATECALL should store in caller's context, not delegate's context" {
+    const allocator = testing.allocator;
+    
+    // Initialize database and EVM
+    var db = evm.Database.init(allocator);
+    defer db.deinit();
+    
+    const block_info = evm.BlockInfo{
+        .chain_id = 1,
+        .number = 1,
+        .timestamp = 1000,
+        .difficulty = 100,
+        .gas_limit = 30000000,
+        .coinbase = primitives.Address.ZERO_ADDRESS,
+        .base_fee = 0,
+        .prev_randao = [_]u8{0} ** 32,
+    };
+    
+    const tx_context = evm.TransactionContext{
+        .gas_limit = 1000000,
+        .coinbase = primitives.Address.ZERO_ADDRESS,
+        .chain_id = 1,
+    };
+    
+    var vm = try evm.Evm(.{}).init(allocator, &db, block_info, tx_context, 0, primitives.Address.ZERO_ADDRESS, .BERLIN);
+    defer vm.deinit();
+    
+    // Create two addresses: caller and delegate
+    const caller_addr = primitives.Address{ .bytes = [_]u8{0x01} ** 20 };
+    const delegate_addr = primitives.Address{ .bytes = [_]u8{0x02} ** 20 };
+    
+    // Set up initial state
+    // Caller has initial storage value 0xAA at slot 0
+    try db.set_storage(caller_addr.bytes, 0, 0xAA);
+    try db.set_account(caller_addr.bytes, evm.Account{
+        .balance = 1_000_000,
+        .nonce = 0,
+        .code_hash = [_]u8{0} ** 32,
+        .storage_root = [_]u8{0} ** 32,
+    });
+    
+    // Delegate has no initial storage (should remain 0)
+    try db.set_account(delegate_addr.bytes, evm.Account{
+        .balance = 1_000_000,
+        .nonce = 0,
+        .code_hash = [_]u8{0} ** 32,
+        .storage_root = [_]u8{0} ** 32,
+    });
+    
+    // Delegate's code: PUSH1 0xCC PUSH1 0x00 SSTORE
+    // This stores value 0xCC at storage slot 0
+    const delegate_code = [_]u8{ 0x60, 0xCC, 0x60, 0x00, 0x55 };
+    const code_hash = try db.set_code(&delegate_code);
+    
+    // Update the delegate account with the code hash
+    try db.set_account(delegate_addr.bytes, evm.Account{
+        .balance = 1_000_000,
+        .nonce = 0,
+        .code_hash = code_hash,
+        .storage_root = [_]u8{0} ** 32,
+    });
+    
+    // Execute DELEGATECALL from caller to delegate
+    const call_params = evm.Evm(.{}).CallParams{
+        .delegatecall = .{
+            .caller = caller_addr,
+            .to = delegate_addr,
+            .input = &[_]u8{},
+            .gas = 100_000,
+        },
+    };
+    
+    const result = vm.call(call_params);
+    
+    // Verify the call succeeded
+    try testing.expect(result.success);
+    
+    // CRITICAL TEST: Verify storage was modified in caller's context
+    const caller_storage = try db.get_storage(caller_addr.bytes, 0);
+    try testing.expectEqual(@as(u256, 0xCC), caller_storage);
+    
+    // CRITICAL TEST: Verify delegate's storage remained unchanged
+    const delegate_storage = try db.get_storage(delegate_addr.bytes, 0);
+    try testing.expectEqual(@as(u256, 0), delegate_storage);
+    
+    // This test currently FAILS because executeDelegatecall passes params.to (delegate_addr)
+    // as the address parameter to execute_frame, causing storage operations to happen
+    // in the wrong context.
+    //
+    // The fix is to pass params.caller as the address parameter instead, so that
+    // storage operations happen in the caller's context.
+}


### PR DESCRIPTION
### Problem
DELEGATECALL is incorrectly storing values in the delegate contract's storage instead of the caller's storage. This violates the fundamental semantics of DELEGATECALL, which should execute the target contract's code but operate on the caller's storage and context.

### Root Cause
In `src/evm.zig:696-700`, the `executeDelegatecall` function is passing the wrong address parameter to `execute_frame`. The function is passing the delegate's address (`params.to`) instead of the caller's address, causing all storage operations to target the wrong contract's storage.

### Impact
- DELEGATECALL incorrectly modifies the delegate contract's storage
- The caller's storage remains unchanged when it should be modified
- This breaks compatibility with standard EVM behavior and violates DELEGATECALL semantics

### Testing
Added comprehensive test in `test/delegatecall_storage_context_test.zig` that verifies:
1. Storage writes during DELEGATECALL affect the caller's storage
2. The delegate's storage remains unchanged

### How to run the test

Add the following to your build.zig file (after line 147 where test_step is defined):

```zig
// DELEGATECALL storage context test
const delegatecall_test_mod = b.createModule(.{
    .root_source_file = b.path("test/delegatecall_storage_context_test.zig"),
    .target = target,
    .optimize = optimize,
});
delegatecall_test_mod.addImport("primitives", modules.primitives_mod);
delegatecall_test_mod.addImport("evm", modules.evm_mod);

const delegatecall_test = b.addTest(.{
    .root_module = delegatecall_test_mod,
});
delegatecall_test.linkLibrary(c_kzg_lib);
delegatecall_test.linkLibrary(blst_lib);
if (bn254_lib) |bn254| delegatecall_test.linkLibrary(bn254);
delegatecall_test.linkLibC();

const run_delegatecall_test = b.addRunArtifact(delegatecall_test);
const delegatecall_test_step = b.step("test-delegatecall", "Run DELEGATECALL storage context test");
delegatecall_test_step.dependOn(&run_delegatecall_test.step);
```

Then run:
```bash
zig build test-delegatecall
```

The test will currently FAIL with:
```
error: 'delegatecall_storage_context_test.test.DELEGATECALL should store in caller's context, not delegate's context' failed: expected 204, found 170
```

This shows the bug: storage value 0xCC (204) should be stored in the caller's storage, but instead the original value 0xAA (170) remains, proving that storage operations are happening in the wrong context.

### References
- EVM Yellow Paper: DELEGATECALL specification
- Similar implementations: revm, geth, erigon