### PR TITLE
fix: add explicit usize casting for slice operations with u64 lengths

### DIFF
--- a/src/frame/frame.zig
+++ b/src/frame/frame.zig
@@ -421,7 +421,7 @@ pub fn Frame(comptime config: FrameConfig) type {
             } else null;
             errdefer if (length_prefixed) |ptr| {
                 const len = std.mem.readInt(u64, ptr[0..8], .little);
-                allocator.free(ptr[0 .. 8 + len]);
+                allocator.free(ptr[0 .. 8 + @as(usize, @intCast(len))]);
             };
 
             // log.debug("Frame.init: Successfully initialized frame components", .{});
@@ -716,7 +716,7 @@ pub fn Frame(comptime config: FrameConfig) type {
             // Read length from first 8 bytes
             const len = std.mem.readInt(u64, ptr[0..8], .little);
             // Return slice starting after length prefix
-            return ptr[8 .. 8 + len];
+            return ptr[8 .. 8 + @as(usize, @intCast(len))];
         }
 
         /// Get the EVM instance from the opaque pointer


### PR DESCRIPTION
**Problem**: Using `u64` arithmetic directly in slice operations fails on 32-bit platforms where slice indices must be `usize` (32-bit).

```zig
// BEFORE (fails on WASM32):
allocator.free(ptr[0 .. 8 + len]);  // len is u64
return ptr[8 .. 8 + len];           // len is u64

// AFTER (works on all platforms):
allocator.free(ptr[0 .. 8 + @as(usize, @intCast(len))]);
return ptr[8 .. 8 + @as(usize, @intCast(len))];
```

**Error on wasm32**:
```
error: expected type 'usize', found 'u64'
```