### PR TITLE
fix: use getTailCallModifier in getTracedOpcodeHandlers

### DIFF
--- a/src/frame/frame_handlers.zig
+++ b/src/frame/frame_handlers.zig
@@ -234,9 +234,9 @@ pub fn getTracedOpcodeHandlers(
                         }
                     }
 
-                    // Call the base handler with tail call optimization
+                    // Call the base handler with tail call optimization where supported
                     // Note: Since handlers are noreturn, we don't need afterOp
-                    return @call(.always_tail, base_handler, .{ frame, cursor });
+                    return @call(FrameType.getTailCallModifier(), base_handler, .{ frame, cursor });
                 }
             }.handler;
             return &wrapper;


### PR DESCRIPTION
## Description
Use platform-specific tail call optimization in frame handlers

This PR modifies the frame handler implementation to use platform-specific tail call optimization by replacing the hardcoded `.always_tail` call modifier with a dynamic one obtained from `FrameType.getTailCallModifier()`. This allows the code to adapt to platforms where tail call optimization may not be fully supported.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactoring

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I understand and take responsibility for all code in this PR