### PR TITLE
refactor: Remove constant folding fusion pattern

### DIFF
--- a/src/frame/frame_handlers.zig
+++ b/src/frame/frame_handlers.zig
@@ -219,7 +219,7 @@ pub fn getSyntheticHandler(comptime FrameType: type, synthetic_opcode: u8) Frame
         @intFromEnum(OpcodeSynthetic.PUSH_MSTORE8_INLINE) => &MemorySyntheticHandlers.push_mstore8_inline,
         @intFromEnum(OpcodeSynthetic.PUSH_MSTORE8_POINTER) => &MemorySyntheticHandlers.push_mstore8_pointer,
         // Advanced fusion patterns
-        @intFromEnum(OpcodeSynthetic.CONSTANT_FOLD) => &AdvancedSyntheticHandlers.constant_fold,
+        // Note: CONSTANT_FOLD (0xBD) removed - compiler handles constant folding
         @intFromEnum(OpcodeSynthetic.MULTI_PUSH_2) => &AdvancedSyntheticHandlers.multi_push_2,
         @intFromEnum(OpcodeSynthetic.MULTI_PUSH_3) => &AdvancedSyntheticHandlers.multi_push_3,
         @intFromEnum(OpcodeSynthetic.MULTI_POP_2) => &AdvancedSyntheticHandlers.multi_pop_2,

--- a/src/instructions/handlers_advanced_synthetic.zig
+++ b/src/instructions/handlers_advanced_synthetic.zig
@@ -24,23 +24,7 @@ pub fn Handlers(comptime FrameType: type) type {
             return @call(FrameType.getTailCallModifier(), next_cursor[0].opcode_handler, .{ self, next_cursor });
         }
 
-        /// CONSTANT_FOLD - Push pre-computed value from constant folding
-        /// This replaces sequences like PUSH1 5, PUSH1 3, ADD with a single push of 8
-        pub fn constant_fold(self: *FrameType, cursor: [*]const Dispatch.Item) Error!noreturn {
-            // The folded value is stored in the next dispatch item
-            const value_item = cursor[1];
-            
-            // Push the pre-computed value onto the stack
-            if (value_item == .push_inline) {
-                self.stack.push_unsafe(value_item.push_inline.value);
-            } else if (value_item == .push_pointer) {
-                self.stack.push_unsafe(value_item.push_pointer.value.*);
-            } else {
-                unreachable; // Should never happen with proper dispatch
-            }
-            
-            return next_instruction(self, cursor);
-        }
+        // Note: constant_fold handler removed - compiler handles constant folding
 
         /// MULTI_PUSH_2 - Push two values in a single operation
         pub fn multi_push_2(self: *FrameType, cursor: [*]const Dispatch.Item) Error!noreturn {

--- a/src/opcodes/opcode_synthetic.zig
+++ b/src/opcodes/opcode_synthetic.zig
@@ -43,7 +43,7 @@ pub const OpcodeSynthetic = enum(u8) {
     PUSH_MSTORE8_INLINE = 0xBB,
     PUSH_MSTORE8_POINTER = 0xBC,
     // Advanced fusion patterns (3+ opcodes)
-    CONSTANT_FOLD = 0xBD,        // Pre-computed arithmetic results
+    // Note: 0xBD reserved but not used (constant folding handled by compiler)
     MULTI_PUSH_2 = 0xBE,          // Two consecutive PUSH operations
     MULTI_PUSH_3 = 0xBF,          // Three consecutive PUSH operations
     MULTI_POP_2 = 0xC0,           // Two consecutive POP operations

--- a/src/preprocessor/dispatch.zig
+++ b/src/preprocessor/dispatch.zig
@@ -243,21 +243,6 @@ pub fn Dispatch(comptime FrameType: type) type {
                         try schedule_items.append(allocator, .{ .opcode_handler = opcode_handlers.*[@intFromEnum(Opcode.INVALID)] });
                     },
                     // Advanced fusion patterns - use optimized handlers
-                    .constant_fold => |cf| {
-                        // Use the optimized constant fold handler
-                        const frame_handlers = @import("../frame/frame_handlers.zig");
-                        const handler = frame_handlers.getSyntheticHandler(FrameType, @intFromEnum(OpcodeSynthetic.CONSTANT_FOLD));
-                        try schedule_items.append(allocator, .{ .opcode_handler = handler });
-                        
-                        // Add the folded value as metadata
-                        if (cf.value <= std.math.maxInt(u64)) {
-                            try schedule_items.append(allocator, .{ .push_inline = .{ .value = @intCast(cf.value) } });
-                        } else {
-                            const value_ptr = try allocator.create(FrameType.WordType);
-                            value_ptr.* = cf.value;
-                            try schedule_items.append(allocator, .{ .push_pointer = .{ .value = value_ptr } });
-                        }
-                    },
                     .multi_push => |mp| {
                         // Use optimized multi-push handler
                         const frame_handlers = @import("../frame/frame_handlers.zig");
@@ -565,9 +550,6 @@ pub fn Dispatch(comptime FrameType: type) type {
                         schedule_index += 1; // Handler
                     },
                     // Advanced fusion patterns
-                    .constant_fold => {
-                        schedule_index += 2; // Handler + folded value
-                    },
                     .multi_push => |mp| {
                         schedule_index += @as(usize, mp.count) * 2; // Each push: handler + value
                     },


### PR DESCRIPTION
## Summary
Removes the constant folding fusion pattern from the runtime since the compiler already handles these optimizations.

## Rationale
The compiler will pre-compute constant expressions like `PUSH1 5, PUSH1 3, ADD` at compile time, converting them to a single `PUSH1 8`. Having this optimization in the runtime fusion patterns is redundant and adds unnecessary complexity.

## Changes
- Removed `CONSTANT_FOLD` synthetic opcode (0xBD) 
- Removed `checkConstantFoldingPattern` detection function
- Removed `constant_fold` handler implementation
- Removed associated tests
- Updated comments to note that 0xBD is reserved but unused

## Impact
- Simplifies the fusion pattern system
- Reduces code complexity
- No performance impact (compiler already optimizes these patterns)
- Other fusion patterns remain intact:
  - Multi-PUSH sequences (2-3 consecutive PUSH operations)
  - Multi-POP sequences (2-3 consecutive POP operations)
  - ISZERO-JUMPI pattern (common in Solidity if-statements)
  - DUP2-MSTORE-PUSH pattern (memory operations)

## Test Plan
- [x] Build passes: `zig build`
- [x] Remaining fusion patterns still detected correctly
- [ ] Integration tests pass
- [ ] No performance regression

🤖 Generated with [Claude Code](https://claude.ai/code)