### PR TITLE
refactor: restructure WASM build for C API compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,7 @@ __pycache__/
 *$py.class
 *.so
 .Python
-build/
+sdks/*/build/
 develop-eggs/
 dist/
 downloads/

--- a/build/bindings/wasm.zig
+++ b/build/bindings/wasm.zig
@@ -12,54 +12,52 @@ pub fn createWasmSteps(
     const wasm_primitives_mod = wasm.createWasmModule(b, "src/primitives/root.zig", wasm_target, wasm_optimize);
 
     const wasm_crypto_mod = wasm.createWasmModule(b, "src/crypto/root.zig", wasm_target, wasm_optimize);
+    // crypto - primitives dependency is circular as in main build
     wasm_crypto_mod.addImport("primitives", wasm_primitives_mod);
+    wasm_primitives_mod.addImport("crypto", wasm_crypto_mod);
 
-    const wasm_evm_mod = wasm.createWasmModule(b, "src/evm/root.zig", wasm_target, wasm_optimize);
+    // Build the EVM library module (needed by C API)
+    const wasm_evm_mod = wasm.createWasmModule(b, "src/root.zig", wasm_target, wasm_optimize);
     wasm_evm_mod.addImport("primitives", wasm_primitives_mod);
     wasm_evm_mod.addImport("crypto", wasm_crypto_mod);
     wasm_evm_mod.addImport("build_options", build_options_mod);
 
-    const wasm_lib_mod = wasm.createWasmModule(b, "src/root.zig", wasm_target, wasm_optimize);
-    wasm_lib_mod.addImport("primitives", wasm_primitives_mod);
-    wasm_lib_mod.addImport("evm", wasm_evm_mod);
+    // Build the C API module that exports functions for WASM
+    // Using evm_c.zig which has WASM-specific allocator support
+    const wasm_c_api_mod = wasm.createWasmModule(b, "src/evm_c.zig", wasm_target, wasm_optimize);
+    wasm_c_api_mod.addImport("primitives", wasm_primitives_mod);
+    wasm_c_api_mod.addImport("evm", wasm_evm_mod);
 
     const wasm_lib_build = wasm.buildWasmExecutable(b, .{
         .name = "guillotine",
-        .root_source_file = "src/root.zig",
+        .root_source_file = "src/evm_c.zig",
         .dest_sub_path = "guillotine.wasm",
-    }, wasm_lib_mod);
-
-    const wasm_primitives_lib_mod = wasm.createWasmModule(b, "src/primitives_c.zig", wasm_target, wasm_optimize);
-    wasm_primitives_lib_mod.addImport("primitives", wasm_primitives_mod);
-
-    const wasm_primitives_build = wasm.buildWasmExecutable(b, .{
-        .name = "guillotine-primitives",
-        .root_source_file = "src/primitives_c.zig",
-        .dest_sub_path = "guillotine-primitives.wasm",
-    }, wasm_primitives_lib_mod);
+    }, wasm_c_api_mod);
 
     const wasm_size_step = wasm.addWasmSizeReportStep(
         b,
-        &[_][]const u8{ "guillotine.wasm", "guillotine-primitives.wasm" },
+        &[_][]const u8{"guillotine.wasm"},
         &[_]*std.Build.Step{
             &wasm_lib_build.install.step,
-            &wasm_primitives_build.install.step,
         },
     );
 
-    const wasm_step = b.step("wasm", "Build all WASM libraries and show bundle sizes");
+    const wasm_step = b.step("wasm", "Build WASM library and show bundle size");
     wasm_step.dependOn(&wasm_size_step.step);
 
-    const wasm_primitives_step = b.step("wasm-primitives", "Build primitives-only WASM library");
-    wasm_primitives_step.dependOn(&wasm_primitives_build.install.step);
+    // Debug builds need the same module structure
+    const wasm_evm_debug_mod = wasm.createWasmModule(b, "src/root.zig", wasm_target, .Debug);
+    wasm_evm_debug_mod.addImport("primitives", wasm_primitives_mod);
+    wasm_evm_debug_mod.addImport("crypto", wasm_crypto_mod);
+    wasm_evm_debug_mod.addImport("build_options", build_options_mod);
 
-    const wasm_debug_mod = wasm.createWasmModule(b, "src/root.zig", wasm_target, .Debug);
+    const wasm_debug_mod = wasm.createWasmModule(b, "src/evm_c.zig", wasm_target, .Debug);
     wasm_debug_mod.addImport("primitives", wasm_primitives_mod);
-    wasm_debug_mod.addImport("evm", wasm_evm_mod);
+    wasm_debug_mod.addImport("evm", wasm_evm_debug_mod);
 
     const wasm_debug_build = wasm.buildWasmExecutable(b, .{
         .name = "guillotine-debug",
-        .root_source_file = "src/root.zig",
+        .root_source_file = "src/evm_c.zig",
         .dest_sub_path = "../bin/guillotine-debug.wasm",
         .debug_build = true,
     }, wasm_debug_mod);

--- a/build/bindings/wasm.zig
+++ b/build/bindings/wasm.zig
@@ -14,6 +14,7 @@ pub fn createWasmSteps(
     const wasm_crypto_mod = wasm.createWasmModule(b, "src/crypto/root.zig", wasm_target, wasm_optimize);
     // crypto - primitives dependency is circular as in main build
     wasm_crypto_mod.addImport("primitives", wasm_primitives_mod);
+    wasm_crypto_mod.addImport("build_options", build_options_mod);
     wasm_primitives_mod.addImport("crypto", wasm_crypto_mod);
 
     // Build the EVM library module (needed by C API)

--- a/build/steps/wasm.zig
+++ b/build/steps/wasm.zig
@@ -74,7 +74,7 @@ pub fn addWasmSizeReportStep(
         const seg1 = std.fmt.allocPrint(b.allocator, "echo '{s} WASM build:' && ", .{name}) catch @panic("OOM");
         defer b.allocator.free(seg1);
         script.appendSlice(b.allocator, seg1) catch @panic("OOM");
-        const seg2 = std.fmt.allocPrint(b.allocator, "ls -lh zig-out/bin/{s} | awk '{{print \\\"  Size: \\\" $5}}' && ", .{file}) catch @panic("OOM");
+        const seg2 = std.fmt.allocPrint(b.allocator, "ls -lh zig-out/bin/{s} | awk '{{print \"  Size: \" $5}}' && ", .{file}) catch @panic("OOM");
         defer b.allocator.free(seg2);
         script.appendSlice(b.allocator, seg2) catch @panic("OOM");
     }

--- a/src/crypto/root.zig
+++ b/src/crypto/root.zig
@@ -47,7 +47,51 @@ pub const Keccak256_Accel = @import("keccak256_accel.zig");
 pub const keccak_asm = @import("keccak_asm.zig");
 
 // KZG commitments for EIP-4844
-pub const c_kzg = @import("c_kzg");
+const builtin = @import("builtin");
+pub const c_kzg = if (builtin.target.cpu.arch != .wasm32) 
+    @import("c_kzg") 
+else struct {
+    // Stub for WASM builds - KZG operations not supported
+    pub const KZGCommitment = [48]u8;
+    pub const KZGProof = [48]u8;
+    pub const Bytes32 = [32]u8;
+    pub const Blob = [131072]u8;
+    
+    pub fn verifyKZGProof(commitment: *const KZGCommitment, z: *const Bytes32, y: *const Bytes32, proof: *const KZGProof) !bool {
+        _ = commitment;
+        _ = z;
+        _ = y;
+        _ = proof;
+        return error.NotSupported;
+    }
+    
+    pub fn blobToKZGCommitment(blob: *const Blob) !KZGCommitment {
+        _ = blob;
+        return error.NotSupported;
+    }
+    
+    pub fn computeKZGProof(blob: *const Blob, z: *const Bytes32) !struct { proof: KZGProof, y: Bytes32 } {
+        _ = blob;
+        _ = z;
+        return error.NotSupported;
+    }
+    
+    pub fn loadTrustedSetupFile(path: []const u8, precompute: usize) !void {
+        _ = path;
+        _ = precompute;
+        return error.NotSupported;
+    }
+    
+    pub fn loadTrustedSetupFromText(data: []const u8, precompute: usize) !void {
+        _ = data;
+        _ = precompute;
+        return error.NotSupported;
+    }
+    
+    pub fn freeTrustedSetup() !void {
+        return error.NotSupported;
+    }
+};
 
 // BN254 for precompiles
 pub const bn254 = @import("bn254.zig");

--- a/src/evm_c.zig
+++ b/src/evm_c.zig
@@ -1,3 +1,6 @@
+//! C ABI wrapper for Guillotine EVM - WASM version
+//! Provides FFI-compatible exports for TypeScript bindings
+
 const std = @import("std");
 const builtin = @import("builtin");
 
@@ -19,41 +22,86 @@ pub const std_options = std.Options{
     }.logFn,
 };
 
-const evm_root = @import("evm");
+const evm = @import("evm");
 const primitives = @import("primitives");
 
-// Simple inline logging that compiles out for freestanding WASM
-fn log(comptime level: std.log.Level, comptime scope: @TypeOf(.enum_literal), comptime format: []const u8, args: anytype) void {
-    _ = level;
-    _ = scope;
-    _ = format;
-    _ = args;
-    // Logging disabled for WASM to avoid Thread dependencies
-}
+// Import types from evm module
+const DefaultEvm = evm.DefaultEvm;
+const TracerEvm = evm.Evm(.{ .TracerType = evm.tracer.JSONRPCTracer });
+const Database = evm.Database;
+const BlockInfo = evm.BlockInfo;
+const TransactionContext = evm.TransactionContext;
+const Hardfork = evm.Hardfork;
+const Account = evm.Account;
 
-const DefaultEvm = evm_root.DefaultEvm;
-const Database = evm_root.Database;
-const MemoryDatabase = evm_root.MemoryDatabase;
-const CallParams = evm_root.CallParams;
-const CallResult = evm_root.CallResult;
-const Address = primitives.Address;
-const Frame = evm_root.Frame;
-const FrameConfig = evm_root.FrameConfig;
-const NoOpTracer = evm_root.NoOpTracer;
-const BlockInfo = evm_root.BlockInfo;
-const TransactionContext = evm_root.TransactionContext;
-const Hardfork = evm_root.Hardfork;
-const Account = evm_root.Account;
+// Opaque handle for EVM instance
+pub const EvmHandle = opaque {};
 
-// Define a specific Frame type for C API use
-// Using a void type for DatabaseType since Frame won't have database access
-const VoidDatabase = struct {};
-const DefaultFrameConfig = FrameConfig{
-    .stack_size = 1024,
-    .DatabaseType = VoidDatabase,
-    .TracerType = null,
+// Log entry for FFI
+pub const LogEntry = extern struct {
+    address: [20]u8,
+    topics: [*]const [32]u8,
+    topics_len: usize,
+    data: [*]const u8,
+    data_len: usize,
 };
-const DefaultFrame = Frame(DefaultFrameConfig);
+
+// Self-destruct record for FFI
+pub const SelfDestructRecord = extern struct {
+    contract: [20]u8,
+    beneficiary: [20]u8,
+};
+
+// Storage access record for FFI
+pub const StorageAccessRecord = extern struct {
+    address: [20]u8,
+    slot: [32]u8,
+};
+
+// Result structure for FFI - matches evm_c_api.zig
+pub const EvmResult = extern struct {
+    success: bool align(4), // Align to 4 bytes for C compatibility
+    gas_left: u64,
+    output: [*]const u8,
+    output_len: usize,
+    error_message: [*:0]const u8,
+    logs: [*]const LogEntry,
+    logs_len: usize,
+    selfdestructs: [*]const SelfDestructRecord,
+    selfdestructs_len: usize,
+    accessed_addresses: [*]const [20]u8,
+    accessed_addresses_len: usize,
+    accessed_storage: [*]const StorageAccessRecord,
+    accessed_storage_len: usize,
+    created_address: [20]u8,
+    has_created_address: bool,
+    trace_json: [*]const u8,
+    trace_json_len: usize,
+};
+
+// Call parameters for FFI
+pub const CallParams = extern struct {
+    caller: [20]u8,
+    to: [20]u8,
+    value: [32]u8, // u256 as bytes
+    input: [*]const u8,
+    input_len: usize,
+    gas: u64,
+    call_type: u8, // 0=CALL, 1=CALLCODE, 2=DELEGATECALL, 3=STATICCALL, 4=CREATE, 5=CREATE2
+    salt: [32]u8, // For CREATE2
+};
+
+// Block info for FFI
+pub const BlockInfoFFI = extern struct {
+    number: u64,
+    timestamp: u64,
+    gas_limit: u64,
+    coinbase: [20]u8,
+    base_fee: u64,
+    chain_id: u64,
+    difficulty: u64,
+    prev_randao: [32]u8,
+};
 
 // Use page allocator for WASM (no libc dependency)
 const allocator = if (builtin.target.cpu.arch == .wasm32 and builtin.target.os.tag == .freestanding)
@@ -61,665 +109,746 @@ const allocator = if (builtin.target.cpu.arch == .wasm32 and builtin.target.os.t
 else
     std.heap.c_allocator;
 
-// Global VM instance
-var vm_instance: ?*DefaultEvm = null;
+// Thread-local allocator for FFI (in WASM this is just global)
+var ffi_allocator: ?std.mem.Allocator = null;
+var last_error: [256]u8 = undefined;
+var last_error_z: [257]u8 = undefined;
+const empty_error: [1]u8 = .{0};
+const empty_buffer: [0]u8 = .{};
 
-// C-compatible error codes
-const EvmError = enum(c_int) {
-    EVM_OK = 0,
-    EVM_ERROR_MEMORY = 1,
-    EVM_ERROR_INVALID_PARAM = 2,
-    EVM_ERROR_VM_NOT_INITIALIZED = 3,
-    EVM_ERROR_EXECUTION_FAILED = 4,
-    EVM_ERROR_INVALID_ADDRESS = 5,
-    EVM_ERROR_INVALID_BYTECODE = 6,
-};
+fn setError(comptime fmt: []const u8, args: anytype) void {
+    const slice = std.fmt.bufPrint(&last_error, fmt, args) catch "Unknown error";
+    @memcpy(last_error_z[0..slice.len], slice);
+    last_error_z[slice.len] = 0;
+}
 
-// C-compatible execution result
-const CExecutionResult = extern struct {
-    success: c_int,
-    gas_used: c_ulonglong,
-    return_data_ptr: [*]const u8,
-    return_data_len: usize,
-    error_code: c_int,
-};
-
-/// Initialize the EVM
-/// @return Error code (0 = success)
-export fn evm_init() c_int {
-    log(.info, .evm_c, "Initializing EVM", .{});
-
-    if (vm_instance != null) {
-        log(.warn, .evm_c, "VM already initialized", .{});
-        return @intFromEnum(EvmError.EVM_OK);
+// Initialize FFI
+export fn guillotine_init() void {
+    if (ffi_allocator == null) {
+        ffi_allocator = allocator;
     }
+}
 
-    const memory_db = allocator.create(MemoryDatabase) catch {
-        log(.err, .evm_c, "Failed to allocate memory for database", .{});
-        return @intFromEnum(EvmError.EVM_ERROR_MEMORY);
+// Cleanup FFI
+export fn guillotine_cleanup() void {
+    ffi_allocator = null;
+}
+
+// Create EVM instance
+export fn guillotine_evm_create(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle {
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized. Call guillotine_init() first", .{});
+        return null;
     };
-    memory_db.* = MemoryDatabase.init(allocator);
-    const db_ptr = @as(*Database, @ptrCast(memory_db));
 
-    const vm = allocator.create(DefaultEvm) catch {
-        log(.err, .evm_c, "Failed to allocate memory for VM", .{});
-        return @intFromEnum(EvmError.EVM_ERROR_MEMORY);
+    // Create database
+    const db = alloc.create(evm.Database) catch {
+        setError("Failed to allocate database", .{});
+        return null;
+    };
+    db.* = evm.Database.init(alloc);
+
+    // Set up block info
+    const block_info = BlockInfo{
+        .number = block_info_ptr.number,
+        .timestamp = block_info_ptr.timestamp,
+        .gas_limit = block_info_ptr.gas_limit,
+        .coinbase = primitives.Address{ .bytes = block_info_ptr.coinbase },
+        .base_fee = block_info_ptr.base_fee,
+        .chain_id = block_info_ptr.chain_id,
+        .difficulty = block_info_ptr.difficulty,
+        .prev_randao = block_info_ptr.prev_randao,
     };
 
-    // Initialize with default configuration
-    const block_info = BlockInfo.init();
+    // Create transaction context
     const tx_context = TransactionContext{
-        .gas_limit = 30_000_000,
-        .coinbase = primitives.ZERO_ADDRESS,
-        .chain_id = 1,
-    };
-    const gas_price: u256 = 0;
-    const origin = primitives.ZERO_ADDRESS;
-    const hardfork = Hardfork.CANCUN;
-    
-    vm.* = DefaultEvm.init(allocator, db_ptr, block_info, tx_context, gas_price, origin, hardfork) catch |err| {
-        log(.err, .evm_c, "Failed to initialize VM: {}", .{err});
-        allocator.destroy(vm);
-        return @intFromEnum(EvmError.EVM_ERROR_MEMORY);
+        .gas_limit = block_info.gas_limit,
+        .coinbase = block_info.coinbase,
+        .chain_id = @intCast(block_info.chain_id),
+        .blob_versioned_hashes = &.{},
     };
 
-    vm_instance = vm;
-    log(.info, .evm_c, "EVM initialized successfully", .{});
-    return @intFromEnum(EvmError.EVM_OK);
-}
-
-/// Cleanup and destroy the EVM
-export fn evm_deinit() void {
-    log(.info, .evm_c, "Destroying EVM", .{});
-
-    if (vm_instance) |vm| {
-        vm.deinit();
-        allocator.destroy(vm);
-        vm_instance = null;
-    }
-}
-
-/// Execute bytecode on the EVM
-/// @param bytecode_ptr Pointer to bytecode
-/// @param bytecode_len Length of bytecode
-/// @param caller_ptr Pointer to caller address (20 bytes)
-/// @param value Value to transfer (as bytes, little endian)
-/// @param gas_limit Gas limit for execution
-/// @param result_ptr Pointer to result structure to fill
-/// @return Error code (0 = success)
-export fn evm_execute(
-    bytecode_ptr: [*]const u8,
-    bytecode_len: usize,
-    caller_ptr: [*]const u8,
-    value: c_ulonglong,
-    gas_limit: c_ulonglong,
-    result_ptr: *CExecutionResult,
-) c_int {
-    log(.info, .evm_c, "Executing bytecode: {} bytes, gas_limit: {}", .{ bytecode_len, gas_limit });
-
-    const vm = vm_instance orelse {
-        log(.err, .evm_c, "VM not initialized", .{});
-        return @intFromEnum(EvmError.EVM_ERROR_VM_NOT_INITIALIZED);
-    };
-
-    // Validate inputs
-    if (bytecode_len == 0) {
-        log(.err, .evm_c, "Invalid bytecode", .{});
-        return @intFromEnum(EvmError.EVM_ERROR_INVALID_BYTECODE);
-    }
-
-    // Convert inputs
-    const bytecode = bytecode_ptr[0..bytecode_len];
-    const caller_bytes = caller_ptr[0..20];
-    const caller_address = Address{ .bytes = caller_bytes.* };
-
-    // Create a temporary address for the code execution
-    const target_address = primitives.ZERO_ADDRESS; // Use zero address for contract execution
-
-    // Set bytecode in state
-    const code_hash = vm.database.set_code(bytecode) catch |err| {
-        log(.err, .evm_c, "Failed to set bytecode: {}", .{err});
-        result_ptr.success = 0;
-        result_ptr.error_code = @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-        return @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-    };
-    
-    // Create account with the code
-    var account = Account.zero();
-    account.code_hash = code_hash;
-    vm.database.set_account(target_address.bytes, account) catch |err| {
-        log(.err, .evm_c, "Failed to set account: {}", .{err});
-        result_ptr.success = 0;
-        result_ptr.error_code = @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-        return @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-    };
-
-    // Create call parameters
-    const call_params = CallParams{
-        .call = .{
-            .caller = caller_address,
-            .to = target_address,
-            .value = @as(u256, value),
-            .input = &[_]u8{},
-            .gas = gas_limit,
-        },
-    };
-
-    // Execute call - vm.call returns CallResult directly, not an error union
-    const run_result = vm.call(call_params);
-
-    // Fill result structure
-    result_ptr.success = if (run_result.success) 1 else 0;
-    result_ptr.gas_used = @intCast(gas_limit - run_result.gas_left);
-    if (run_result.output.len > 0) {
-        result_ptr.return_data_ptr = run_result.output.ptr;
-        result_ptr.return_data_len = run_result.output.len;
-    } else {
-        const empty: []const u8 = &[_]u8{};
-        result_ptr.return_data_ptr = empty.ptr;
-        result_ptr.return_data_len = 0;
-    }
-    result_ptr.error_code = @intFromEnum(EvmError.EVM_OK);
-
-    log(.info, .evm_c, "Execution completed: success={}, gas_used={}", .{ run_result.success, gas_limit - run_result.gas_left });
-    return @intFromEnum(EvmError.EVM_OK);
-}
-
-/// Get the current VM state (for debugging)
-/// @return 1 if VM is initialized, 0 otherwise
-export fn evm_is_initialized() c_int {
-    return if (vm_instance != null) 1 else 0;
-}
-
-/// Get version string
-/// @return Pointer to null-terminated version string
-export fn evm_version() [*:0]const u8 {
-    return "1.0.0";
-}
-
-// Test to ensure this compiles
-test "C interface compilation" {
-    std.testing.refAllDecls(@This());
-}
-
-// Additional FFI types and functions for Rust benchmarking
-
-// Opaque types for C
-pub const GuillotineVm = opaque {};
-pub const GuillotineDatabase = opaque {};
-
-// C-compatible types
-pub const GuillotineAddress = extern struct {
-    bytes: [20]u8,
-};
-
-pub const GuillotineU256 = extern struct {
-    bytes: [32]u8, // Little-endian representation
-};
-
-pub const GuillotineExecutionResult = extern struct {
-    success: bool,
-    gas_used: u64,
-    output: [*]u8,
-    output_len: usize,
-    error_message: ?[*:0]const u8,
-};
-
-// Internal VM structure
-const VmState = struct {
-    vm: *DefaultEvm,
-    memory_db: *MemoryDatabase,
-    database: *Database,
-    allocator: std.mem.Allocator,
-};
-
-// VM creation and destruction
-export fn guillotine_vm_create() ?*GuillotineVm {
-    
-    const state = allocator.create(VmState) catch return null;
-    
-    state.allocator = allocator;
-    state.memory_db = allocator.create(MemoryDatabase) catch {
-        allocator.destroy(state);
+    // Create EVM instance
+    const evm_ptr = alloc.create(DefaultEvm) catch {
+        alloc.destroy(db);
+        setError("Failed to allocate EVM instance", .{});
         return null;
     };
-    state.memory_db.* = MemoryDatabase.init(allocator);
-    
-    state.database = @as(*Database, @ptrCast(state.memory_db));
-    state.vm = allocator.create(DefaultEvm) catch {
-        state.memory_db.deinit();
-        allocator.destroy(state.memory_db);
-        allocator.destroy(state);
-        return null;
-    };
-    
-    // Initialize with default configuration
-    const block_info = BlockInfo.init();
-    const tx_context = TransactionContext{
-        .gas_limit = 30_000_000,
-        .coinbase = primitives.ZERO_ADDRESS,
-        .chain_id = 1,
-    };
-    const gas_price: u256 = 0;
-    const origin = primitives.ZERO_ADDRESS;
-    const hardfork = Hardfork.CANCUN;
-    
-    state.vm.* = DefaultEvm.init(allocator, state.database, block_info, tx_context, gas_price, origin, hardfork) catch {
-        state.memory_db.deinit();
-        allocator.destroy(state.memory_db);
-        allocator.destroy(state.vm);
-        allocator.destroy(state);
-        return null;
-    };
-    
-    return @ptrCast(state);
-}
 
-export fn guillotine_vm_destroy(vm: ?*GuillotineVm) void {
-    if (vm) |v| {
-        const state: *VmState = @ptrCast(@alignCast(v));
-        state.vm.deinit();
-        state.allocator.destroy(state.vm);
-        state.memory_db.deinit();
-        state.allocator.destroy(state.memory_db);
-        state.allocator.destroy(state);
-    }
-}
-
-// State management
-export fn guillotine_set_balance(vm: ?*GuillotineVm, address: ?*const GuillotineAddress, balance: ?*const GuillotineU256) bool {
-    if (vm == null or address == null or balance == null) return false;
-    
-    const state: *VmState = @ptrCast(@alignCast(vm.?));
-    const addr = address.?.bytes;
-    const value = u256_from_bytes(&balance.?.bytes);
-    
-    // Get current account or create new one
-    var account = state.database.get_account(addr) catch return false;
-    if (account == null) {
-        account = Account.zero();
-    }
-    account.?.balance = value;
-    state.database.set_account(addr, account.?) catch return false;
-    return true;
-}
-
-export fn guillotine_set_code(vm: ?*GuillotineVm, address: ?*const GuillotineAddress, code: ?[*]const u8, code_len: usize) bool {
-    if (vm == null or address == null) return false;
-    
-    const state: *VmState = @ptrCast(@alignCast(vm.?));
-    const addr = address.?.bytes;
-    
-    const code_slice = if (code) |c| c[0..code_len] else &[_]u8{};
-    // Set code and update account
-    const code_hash = state.database.set_code(code_slice) catch return false;
-    
-    // Get current account or create new one
-    var account = state.database.get_account(addr) catch return false;
-    if (account == null) {
-        account = Account.zero();
-    }
-    account.?.code_hash = code_hash;
-    state.database.set_account(addr, account.?) catch return false;
-    return true;
-}
-
-// Execution
-export fn guillotine_execute(
-    vm: ?*GuillotineVm,
-    from: ?*const GuillotineAddress,
-    to: ?*const GuillotineAddress,
-    value: ?*const GuillotineU256,
-    input: ?[*]const u8,
-    input_len: usize,
-    gas_limit: u64,
-) GuillotineExecutionResult {
-    var result = GuillotineExecutionResult{
-        .success = false,
-        .gas_used = 0,
-        .output = &[_]u8{},
-        .output_len = 0,
-        .error_message = null,
-    };
-    
-    if (vm == null or from == null) return result;
-    
-    const state: *VmState = @ptrCast(@alignCast(vm.?));
-    const from_addr = Address{ .bytes = from.?.bytes };
-    const value_u256 = if (value) |v| u256_from_bytes(&v.bytes) else 0;
-    const input_slice = if (input) |i| i[0..input_len] else &[_]u8{};
-    
-    // Create call parameters
-    const to_addr = if (to) |t| Address{ .bytes = t.bytes } else primitives.ZERO_ADDRESS;
-    const call_params = CallParams{
-        .call = .{
-            .caller = from_addr,
-            .to = to_addr,
-            .value = value_u256,
-            .input = input_slice,
-            .gas = gas_limit,
-        },
-    };
-    
-    // Execute - vm.call returns CallResult directly
-    const exec_result = state.vm.call(call_params);
-    
-    result.success = exec_result.success;
-    result.gas_used = gas_limit - exec_result.gas_left;
-    
-    // Copy output if any
-    if (exec_result.output.len > 0) {
-        const output_copy = state.allocator.alloc(u8, exec_result.output.len) catch return result;
-        @memcpy(output_copy, exec_result.output);
-        result.output = output_copy.ptr;
-        result.output_len = output_copy.len;
-    }
-    
-    return result;
-}
-
-// Utility functions
-export fn guillotine_u256_from_u64(value: u64, out_u256: ?*GuillotineU256) void {
-    if (out_u256 == null) return;
-    
-    // Clear the bytes first
-    @memset(&out_u256.?.bytes, 0);
-    
-    // Set the lower 8 bytes (little-endian)
-    const value_bytes = std.mem.asBytes(&value);
-    @memcpy(out_u256.?.bytes[0..8], value_bytes);
-}
-
-// Frame API exports for direct frame manipulation
-// These are separate from the main EVM API and allow low-level frame control
-
-
-// Frame handle type
-const FrameHandle = struct {
-    frame: *DefaultFrame,
-    allocator: std.mem.Allocator,
-    bytecode: []const u8,
-    initial_gas: u64,
-};
-
-// Error codes for frame operations
-const FrameError = enum(c_int) {
-    FRAME_OK = 0,
-    FRAME_ERROR_MEMORY = 1,
-    FRAME_ERROR_INVALID_PARAM = 2,
-    FRAME_ERROR_EXECUTION_FAILED = 3,
-    FRAME_ERROR_STACK_OVERFLOW = 4,
-    FRAME_ERROR_STACK_UNDERFLOW = 5,
-    FRAME_ERROR_OUT_OF_GAS = 6,
-};
-
-/// Create a new frame for execution
-/// @param bytecode_ptr Pointer to bytecode
-/// @param bytecode_len Length of bytecode
-/// @param initial_gas Initial gas amount
-/// @return Pointer to frame handle or null on error
-export fn evm_frame_create(bytecode_ptr: [*]const u8, bytecode_len: usize, initial_gas: u64) ?*anyopaque {
-    if (bytecode_len == 0) return null;
-    
-    const bytecode = bytecode_ptr[0..bytecode_len];
-    
-    const handle = allocator.create(FrameHandle) catch return null;
-    
-    // Allocate and copy bytecode
-    handle.bytecode = allocator.alloc(u8, bytecode_len) catch {
-        allocator.destroy(handle);
-        return null;
-    };
-    @memcpy(@constCast(handle.bytecode), bytecode);
-    
-    handle.initial_gas = initial_gas;
-    
-    // Create frame
-    handle.frame = allocator.create(DefaultFrame) catch {
-        allocator.free(handle.bytecode);
-        allocator.destroy(handle);
-        return null;
-    };
-    
-    // Initialize frame 
-    // Need to provide all required parameters for Frame.init
-    const default_value: u256 = 0;
-    const default_caller = primitives.ZERO_ADDRESS;
-    const empty_calldata: []const u8 = &[_]u8{};
-    const void_database = VoidDatabase{};
-    // Use a dummy struct as placeholder for evm_ptr
-    var dummy_evm: u8 = 0;
-    const null_evm_ptr: *anyopaque = @ptrCast(&dummy_evm);
-    
-    handle.frame.* = DefaultFrame.init(
-        allocator,
-        @intCast(initial_gas),
-        void_database,
-        default_caller,
-        &default_value,
-        empty_calldata,
-        null_evm_ptr
+    evm_ptr.* = DefaultEvm.init(
+        alloc,
+        db,
+        block_info,
+        tx_context,
+        0, // gas_price
+        primitives.Address.zero(), // origin
+        Hardfork.DEFAULT,
     ) catch {
-        allocator.destroy(handle.frame);
-        allocator.free(handle.bytecode);
-        allocator.destroy(handle);
+        alloc.destroy(db);
+        alloc.destroy(evm_ptr);
+        setError("Failed to initialize EVM", .{});
+        return null;
+    };
+
+    return @ptrCast(evm_ptr);
+}
+
+// Create tracing EVM instance
+export fn guillotine_evm_create_tracing(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle {
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized. Call guillotine_init() first", .{});
+        return null;
+    };
+
+    // Create database
+    const db = alloc.create(evm.Database) catch {
+        setError("Failed to allocate database", .{});
+        return null;
+    };
+    db.* = evm.Database.init(alloc);
+
+    // Set up block info
+    const block_info = BlockInfo{
+        .number = block_info_ptr.number,
+        .timestamp = block_info_ptr.timestamp,
+        .gas_limit = block_info_ptr.gas_limit,
+        .coinbase = primitives.Address{ .bytes = block_info_ptr.coinbase },
+        .base_fee = block_info_ptr.base_fee,
+        .chain_id = block_info_ptr.chain_id,
+        .difficulty = block_info_ptr.difficulty,
+        .prev_randao = block_info_ptr.prev_randao,
+    };
+
+    // Create transaction context
+    const tx_context = TransactionContext{
+        .gas_limit = block_info.gas_limit,
+        .coinbase = block_info.coinbase,
+        .chain_id = @intCast(block_info.chain_id),
+        .blob_versioned_hashes = &.{},
+    };
+
+    // Create tracing EVM instance
+    const evm_ptr = alloc.create(TracerEvm) catch {
+        alloc.destroy(db);
+        setError("Failed to allocate tracing EVM instance", .{});
+        return null;
+    };
+
+    evm_ptr.* = TracerEvm.init(
+        alloc,
+        db,
+        block_info,
+        tx_context,
+        0, // gas_price
+        primitives.Address.zero(), // origin
+        Hardfork.DEFAULT,
+    ) catch {
+        alloc.destroy(db);
+        alloc.destroy(evm_ptr);
+        setError("Failed to initialize tracing EVM", .{});
+        return null;
+    };
+
+    return @ptrCast(evm_ptr);
+}
+
+// Destroy EVM instance
+export fn guillotine_evm_destroy(handle: *EvmHandle) void {
+    const alloc = ffi_allocator orelse return;
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    
+    // Deinit database
+    const db_ptr: *evm.Database = @ptrCast(@alignCast(evm_ptr.database));
+    db_ptr.deinit();
+    alloc.destroy(db_ptr);
+    
+    // Destroy EVM
+    evm_ptr.deinit();
+    alloc.destroy(evm_ptr);
+}
+
+// Destroy tracing EVM instance
+export fn guillotine_evm_destroy_tracing(handle: *EvmHandle) void {
+    const alloc = ffi_allocator orelse return;
+    const evm_ptr: *TracerEvm = @ptrCast(@alignCast(handle));
+
+    // Deinit database
+    const db_ptr: *evm.Database = @ptrCast(@alignCast(evm_ptr.database));
+    db_ptr.deinit();
+    alloc.destroy(db_ptr);
+
+    // Destroy EVM
+    evm_ptr.deinit();
+    alloc.destroy(evm_ptr);
+}
+
+// Set balance
+export fn guillotine_set_balance(handle: *EvmHandle, address: *const [20]u8, balance: *const [32]u8) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    
+    const balance_value = std.mem.readInt(u256, balance, .big);
+    var account = evm_ptr.database.get_account(address.*) catch {
+        setError("Failed to get account", .{});
+        return false;
+    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
+    account.balance = balance_value;
+    
+    evm_ptr.database.set_account(address.*, account) catch {
+        setError("Failed to set account balance", .{});
+        return false;
+    };
+    
+    return true;
+}
+
+// Set balance for tracing EVM
+export fn guillotine_set_balance_tracing(handle: *EvmHandle, address: *const [20]u8, balance: *const [32]u8) bool {
+    const evm_ptr: *TracerEvm = @ptrCast(@alignCast(handle));
+    const balance_value = std.mem.readInt(u256, balance, .big);
+    var account = evm_ptr.database.get_account(address.*) catch {
+        setError("Failed to get account", .{});
+        return false;
+    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
+    account.balance = balance_value;
+    evm_ptr.database.set_account(address.*, account) catch {
+        setError("Failed to set account balance", .{});
+        return false;
+    };
+    return true;
+}
+
+// Set code
+export fn guillotine_set_code(handle: *EvmHandle, address: *const [20]u8, code: [*]const u8, code_len: usize) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    
+    const code_slice = code[0..code_len];
+    const code_hash = evm_ptr.database.set_code(code_slice) catch {
+        setError("Failed to set code", .{});
+        return false;
+    };
+    
+    var account = evm_ptr.database.get_account(address.*) catch {
+        setError("Failed to get account", .{});
+        return false;
+    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
+    account.code_hash = code_hash;
+    
+    evm_ptr.database.set_account(address.*, account) catch {
+        setError("Failed to update account code hash", .{});
+        return false;
+    };
+    
+    return true;
+}
+
+// Set code for tracing EVM
+export fn guillotine_set_code_tracing(handle: *EvmHandle, address: *const [20]u8, code: [*]const u8, code_len: usize) bool {
+    const evm_ptr: *TracerEvm = @ptrCast(@alignCast(handle));
+    const code_slice = code[0..code_len];
+    const code_hash = evm_ptr.database.set_code(code_slice) catch {
+        setError("Failed to set code", .{});
+        return false;
+    };
+    var account = evm_ptr.database.get_account(address.*) catch {
+        setError("Failed to get account", .{});
+        return false;
+    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
+    account.code_hash = code_hash;
+    evm_ptr.database.set_account(address.*, account) catch {
+        setError("Failed to update account code hash", .{});
+        return false;
+    };
+    return true;
+}
+
+// Helper function to convert CallResult to EvmResult
+fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*EvmResult {
+    // Allocate result structure on heap
+    const evm_result = alloc.create(EvmResult) catch {
+        setError("Failed to allocate result", .{});
         return null;
     };
     
-    handle.allocator = allocator;
-    return @ptrCast(handle);
-}
-
-/// Destroy a frame
-/// @param frame_ptr Pointer to frame handle
-export fn evm_frame_destroy(frame_ptr: ?*anyopaque) void {
-    if (frame_ptr) |ptr| {
-        const handle: *FrameHandle = @ptrCast(@alignCast(ptr));
+    // Set basic fields
+    evm_result.success = result.success;
+    evm_result.gas_left = result.gas_left;
+    evm_result.error_message = if (result.error_info) |info| blk: {
+        _ = std.fmt.bufPrintZ(&last_error_z, "{s}", .{info}) catch "Unknown error";
+        break :blk @ptrCast(&last_error_z);
+    } else if (!result.success) @ptrCast(&last_error_z) else @as([*:0]const u8, @ptrCast(&empty_error));
+    
+    // Copy output if present
+    if (result.output.len > 0) {
+        const output_copy = alloc.alloc(u8, result.output.len) catch {
+            setError("Failed to allocate output buffer", .{});
+            alloc.destroy(evm_result);
+            return null;
+        };
+        @memcpy(output_copy, result.output);
+        evm_result.output = output_copy.ptr;
+        evm_result.output_len = output_copy.len;
+    } else {
+        evm_result.output = @as([*]const u8, @ptrCast(&empty_error));
+        evm_result.output_len = 0;
+    }
+    
+    // Copy logs if present
+    if (result.logs.len > 0) {
+        const logs_copy = alloc.alloc(LogEntry, result.logs.len) catch {
+            setError("Failed to allocate logs", .{});
+            if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+            alloc.destroy(evm_result);
+            return null;
+        };
         
-        // Deinit and destroy frame
-        handle.frame.deinit(handle.allocator);
-        handle.allocator.destroy(handle.frame);
-        handle.allocator.free(handle.bytecode);
-        handle.allocator.destroy(handle);
+        for (result.logs, 0..) |log, i| {
+            logs_copy[i].address = log.address.bytes;
+            
+            // Copy topics
+            if (log.topics.len > 0) {
+                const topics_copy = alloc.alloc([32]u8, log.topics.len) catch {
+                    setError("Failed to allocate topics", .{});
+                    // Clean up already allocated
+                    for (logs_copy[0..i]) |prev_log| {
+                        if (prev_log.topics_len > 0) alloc.free(prev_log.topics[0..prev_log.topics_len]);
+                        if (prev_log.data_len > 0) alloc.free(prev_log.data[0..prev_log.data_len]);
+                    }
+                    alloc.free(logs_copy);
+                    if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+                    alloc.destroy(evm_result);
+                    return null;
+                };
+                for (log.topics, 0..) |topic, j| {
+                    std.mem.writeInt(u256, &topics_copy[j], topic, .big);
+                }
+                logs_copy[i].topics = topics_copy.ptr;
+                logs_copy[i].topics_len = topics_copy.len;
+            } else {
+                logs_copy[i].topics = @as([*]const [32]u8, @ptrCast(&empty_buffer));
+                logs_copy[i].topics_len = 0;
+            }
+            
+            // Copy data
+            if (log.data.len > 0) {
+                const data_copy = alloc.alloc(u8, log.data.len) catch {
+                    setError("Failed to allocate log data", .{});
+                    // Clean up
+                    if (logs_copy[i].topics_len > 0) alloc.free(logs_copy[i].topics[0..logs_copy[i].topics_len]);
+                    for (logs_copy[0..i]) |prev_log| {
+                        if (prev_log.topics_len > 0) alloc.free(prev_log.topics[0..prev_log.topics_len]);
+                        if (prev_log.data_len > 0) alloc.free(prev_log.data[0..prev_log.data_len]);
+                    }
+                    alloc.free(logs_copy);
+                    if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+                    alloc.destroy(evm_result);
+                    return null;
+                };
+                @memcpy(data_copy, log.data);
+                logs_copy[i].data = data_copy.ptr;
+                logs_copy[i].data_len = data_copy.len;
+            } else {
+                logs_copy[i].data = @as([*]const u8, @ptrCast(&empty_buffer));
+                logs_copy[i].data_len = 0;
+            }
+        }
+        
+        evm_result.logs = logs_copy.ptr;
+        evm_result.logs_len = logs_copy.len;
+    } else {
+        evm_result.logs = @as([*]const LogEntry, @ptrCast(@alignCast(&empty_buffer)));
+        evm_result.logs_len = 0;
+    }
+    
+    // Copy selfdestructs if present
+    if (result.selfdestructs.len > 0) {
+        const selfdestructs_copy = alloc.alloc(SelfDestructRecord, result.selfdestructs.len) catch {
+            setError("Failed to allocate selfdestructs", .{});
+            // Clean up logs
+            if (evm_result.logs_len > 0) {
+                for (evm_result.logs[0..evm_result.logs_len]) |log| {
+                    if (log.topics_len > 0) alloc.free(log.topics[0..log.topics_len]);
+                    if (log.data_len > 0) alloc.free(log.data[0..log.data_len]);
+                }
+                alloc.free(evm_result.logs[0..evm_result.logs_len]);
+            }
+            if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+            alloc.destroy(evm_result);
+            return null;
+        };
+        
+        for (result.selfdestructs, 0..) |sd, i| {
+            selfdestructs_copy[i].contract = sd.contract.bytes;
+            selfdestructs_copy[i].beneficiary = sd.beneficiary.bytes;
+        }
+        
+        evm_result.selfdestructs = selfdestructs_copy.ptr;
+        evm_result.selfdestructs_len = selfdestructs_copy.len;
+    } else {
+        evm_result.selfdestructs = @as([*]const SelfDestructRecord, @ptrCast(&empty_buffer));
+        evm_result.selfdestructs_len = 0;
+    }
+    
+    // Copy accessed addresses if present
+    if (result.accessed_addresses.len > 0) {
+        const addresses_copy = alloc.alloc([20]u8, result.accessed_addresses.len) catch {
+            setError("Failed to allocate accessed addresses", .{});
+            // Clean up previous allocations
+            if (evm_result.selfdestructs_len > 0) alloc.free(evm_result.selfdestructs[0..evm_result.selfdestructs_len]);
+            if (evm_result.logs_len > 0) {
+                for (evm_result.logs[0..evm_result.logs_len]) |log| {
+                    if (log.topics_len > 0) alloc.free(log.topics[0..log.topics_len]);
+                    if (log.data_len > 0) alloc.free(log.data[0..log.data_len]);
+                }
+                alloc.free(evm_result.logs[0..evm_result.logs_len]);
+            }
+            if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+            alloc.destroy(evm_result);
+            return null;
+        };
+        
+        for (result.accessed_addresses, 0..) |addr, i| {
+            addresses_copy[i] = addr.bytes;
+        }
+        
+        evm_result.accessed_addresses = addresses_copy.ptr;
+        evm_result.accessed_addresses_len = addresses_copy.len;
+    } else {
+        evm_result.accessed_addresses = @as([*]const [20]u8, @ptrCast(&empty_buffer));
+        evm_result.accessed_addresses_len = 0;
+    }
+    
+    // Copy accessed storage if present
+    if (result.accessed_storage.len > 0) {
+        const storage_copy = alloc.alloc(StorageAccessRecord, result.accessed_storage.len) catch {
+            setError("Failed to allocate accessed storage", .{});
+            // Clean up
+            if (evm_result.accessed_addresses_len > 0) alloc.free(evm_result.accessed_addresses[0..evm_result.accessed_addresses_len]);
+            if (evm_result.selfdestructs_len > 0) alloc.free(evm_result.selfdestructs[0..evm_result.selfdestructs_len]);
+            if (evm_result.logs_len > 0) {
+                for (evm_result.logs[0..evm_result.logs_len]) |log| {
+                    if (log.topics_len > 0) alloc.free(log.topics[0..log.topics_len]);
+                    if (log.data_len > 0) alloc.free(log.data[0..log.data_len]);
+                }
+                alloc.free(evm_result.logs[0..evm_result.logs_len]);
+            }
+            if (evm_result.output_len > 0) alloc.free(evm_result.output[0..evm_result.output_len]);
+            alloc.destroy(evm_result);
+            return null;
+        };
+        
+        for (result.accessed_storage, 0..) |access, i| {
+            storage_copy[i].address = access.address.bytes;
+            std.mem.writeInt(u256, &storage_copy[i].slot, access.slot, .big);
+        }
+        
+        evm_result.accessed_storage = storage_copy.ptr;
+        evm_result.accessed_storage_len = storage_copy.len;
+    } else {
+        evm_result.accessed_storage = @as([*]const StorageAccessRecord, @ptrCast(&empty_buffer));
+        evm_result.accessed_storage_len = 0;
+    }
+    
+    // Handle created address
+    if (result.created_address) |addr| {
+        evm_result.created_address = addr.bytes;
+        evm_result.has_created_address = true;
+    } else {
+        evm_result.created_address = [_]u8{0} ** 20;
+        evm_result.has_created_address = false;
+    }
+    
+    // TODO: Add trace JSON support if available
+    evm_result.trace_json = @as([*]const u8, @ptrCast(&empty_buffer));
+    evm_result.trace_json_len = 0;
+    
+    return evm_result;
+}
+
+// Execute a call
+export fn guillotine_call(handle: *EvmHandle, params: *const CallParams) ?*EvmResult {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized", .{});
+        return null;
+    };
+    
+    // Convert parameters
+    const value = std.mem.readInt(u256, &params.value, .big);
+    const salt = std.mem.readInt(u256, &params.salt, .big);
+    const input = if (params.input_len > 0) params.input[0..params.input_len] else &[_]u8{};
+    
+    // Determine call type
+    const call_params = switch (params.call_type) {
+        4 => evm.CallParams{ .create = .{ 
+            .caller = primitives.Address{ .bytes = params.caller }, 
+            .value = value, 
+            .init_code = input, 
+            .gas = params.gas 
+        }},
+        5 => evm.CallParams{ .create2 = .{ 
+            .caller = primitives.Address{ .bytes = params.caller }, 
+            .value = value, 
+            .init_code = input, 
+            .salt = salt, 
+            .gas = params.gas 
+        }},
+        0 => evm.CallParams{ .call = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        1 => evm.CallParams{ .callcode = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        2 => evm.CallParams{ .delegatecall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        3 => evm.CallParams{ .staticcall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        else => {
+            setError("Invalid call type: {}", .{params.call_type});
+            return null;
+        },
+    };
+    
+    // Execute the call
+    const result = evm_ptr.call(call_params);
+    
+    return convertCallResultToEvmResult(result, alloc);
+}
+
+// Execute a call with tracing
+export fn guillotine_call_tracing(handle: *EvmHandle, params: *const CallParams) ?*EvmResult {
+    const evm_ptr: *TracerEvm = @ptrCast(@alignCast(handle));
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized", .{});
+        return null;
+    };
+    
+    // Convert parameters
+    const value = std.mem.readInt(u256, &params.value, .big);
+    const salt = std.mem.readInt(u256, &params.salt, .big);
+    const input = if (params.input_len > 0) params.input[0..params.input_len] else &[_]u8{};
+    
+    // Determine call type
+    const call_params = switch (params.call_type) {
+        4 => evm.CallParams{ .create = .{ 
+            .caller = primitives.Address{ .bytes = params.caller }, 
+            .value = value, 
+            .init_code = input, 
+            .gas = params.gas 
+        }},
+        5 => evm.CallParams{ .create2 = .{ 
+            .caller = primitives.Address{ .bytes = params.caller }, 
+            .value = value, 
+            .init_code = input, 
+            .salt = salt, 
+            .gas = params.gas 
+        }},
+        0 => evm.CallParams{ .call = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        1 => evm.CallParams{ .callcode = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        2 => evm.CallParams{ .delegatecall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        3 => evm.CallParams{ .staticcall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        else => {
+            setError("Invalid call type: {}", .{params.call_type});
+            return null;
+        },
+    };
+    
+    // Execute the call
+    const result = evm_ptr.call(call_params);
+    
+    // TODO: Include trace JSON in result
+    return convertCallResultToEvmResult(result, alloc);
+}
+
+// Get balance
+export fn guillotine_get_balance(handle: *EvmHandle, address: *const [20]u8, balance_out: *[32]u8) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    
+    const balance = evm_ptr.database.get_balance(address.*) catch {
+        setError("Failed to get balance", .{});
+        return false;
+    };
+    
+    std.mem.writeInt(u256, balance_out, balance, .big);
+    return true;
+}
+
+// Get code
+export fn guillotine_get_code(handle: *EvmHandle, address: *const [20]u8, code_out: *[*]u8, len_out: *usize) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized", .{});
+        return false;
+    };
+    
+    const account = evm_ptr.database.get_account(address.*) catch {
+        setError("Failed to get account", .{});
+        return false;
+    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
+    
+    if (std.mem.eql(u8, &account.code_hash, &primitives.EMPTY_CODE_HASH)) {
+        code_out.* = @constCast(@ptrCast(@alignCast(&empty_buffer)));
+        len_out.* = 0;
+        return true;
+    }
+    
+    const code = evm_ptr.database.get_code(account.code_hash) catch {
+        setError("Failed to get code", .{});
+        return false;
+    };
+    
+    if (code.len == 0) {
+        code_out.* = @constCast(@ptrCast(@alignCast(&empty_buffer)));
+        len_out.* = 0;
+        return true;
+    }
+    
+    const code_copy = alloc.alloc(u8, code.len) catch {
+        setError("Failed to allocate code buffer", .{});
+        return false;
+    };
+    @memcpy(code_copy, code);
+    
+    code_out.* = code_copy.ptr;
+    len_out.* = code_copy.len;
+    return true;
+}
+
+// Free code memory
+export fn guillotine_free_code(code: [*]u8, len: usize) void {
+    const alloc = ffi_allocator orelse return;
+    if (len > 0) {
+        alloc.free(code[0..len]);
     }
 }
 
-/// Execute the frame until completion or error
-/// @param frame_ptr Pointer to frame handle
-/// @return Error code (0 = success)
-export fn evm_frame_execute(frame_ptr: ?*anyopaque) c_int {
-    if (frame_ptr == null) return @intFromEnum(FrameError.FRAME_ERROR_INVALID_PARAM);
+// Set storage
+export fn guillotine_set_storage(handle: *EvmHandle, address: *const [20]u8, key: *const [32]u8, value: *const [32]u8) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
     
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
+    const key_u256 = std.mem.readInt(u256, key, .big);
+    const value_u256 = std.mem.readInt(u256, value, .big);
     
-    // The Frame doesn't have a direct execute method in the new architecture
-    // We would need to use a Planner and Plan to execute
-    // For now, return error indicating execution is not implemented
-    _ = frame;
-    return @intFromEnum(FrameError.FRAME_ERROR_EXECUTION_FAILED);
-}
-
-/// Get remaining gas in the frame
-/// @param frame_ptr Pointer to frame handle
-/// @return Remaining gas amount
-export fn evm_frame_get_gas_remaining(frame_ptr: ?*anyopaque) u64 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    return @intCast(@max(0, frame.gas_remaining));
-}
-
-/// Get used gas in the frame
-/// @param frame_ptr Pointer to frame handle
-/// @return Used gas amount
-export fn evm_frame_get_gas_used(frame_ptr: ?*anyopaque) u64 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    // Calculate used gas from initial gas and remaining gas
-    const remaining = @max(0, frame.gas_remaining);
-    return handle.initial_gas - @as(u64, @intCast(remaining));
-}
-
-/// Get current program counter
-/// @param frame_ptr Pointer to frame handle
-/// @return Current PC value
-export fn evm_frame_get_pc(frame_ptr: ?*anyopaque) u32 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    // Frame doesn't store PC in the new architecture
-    // PC is managed by the Plan/Planner
-    _ = handle;
-    return 0; // TODO: Need to integrate with Plan for PC tracking
-}
-
-/// Get stack size
-/// @param frame_ptr Pointer to frame handle
-/// @return Number of items on the stack
-export fn evm_frame_stack_size(frame_ptr: ?*anyopaque) u32 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    return @intCast(frame.stack.size());
-}
-
-/// Check if frame execution has stopped
-/// @param frame_ptr Pointer to frame handle
-/// @return 1 if stopped, 0 if running
-export fn evm_frame_is_stopped(frame_ptr: ?*anyopaque) c_int {
-    if (frame_ptr == null) return 1;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    // Frame doesn't have is_stopped field
-    // Would need to track execution state separately
-    _ = handle;
-    return 0; // TODO: Track execution state
-}
-
-/// Get memory size
-/// @param frame_ptr Pointer to frame handle
-/// @return Current memory size in bytes
-export fn evm_frame_get_memory_size(frame_ptr: ?*anyopaque) usize {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    return frame.memory.size();
-}
-
-/// Get bytecode length
-/// @param frame_ptr Pointer to frame handle
-/// @return Bytecode length
-export fn evm_frame_get_bytecode_len(frame_ptr: ?*anyopaque) u32 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    return @intCast(handle.bytecode.len);
-}
-
-/// Get current opcode at PC
-/// @param frame_ptr Pointer to frame handle  
-/// @return Current opcode or 0 if invalid
-export fn evm_frame_get_current_opcode(frame_ptr: ?*anyopaque) u8 {
-    if (frame_ptr == null) return 0;
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    
-    // Frame doesn't track PC, would need Plan integration
-    _ = frame;
-    return 0; // TODO: Integrate with Plan for opcode access
-}
-
-/// Reset frame with new gas
-/// @param frame_ptr Pointer to frame handle
-/// @param new_gas New gas amount
-/// @return Error code (0 = success)
-export fn evm_frame_reset(frame_ptr: ?*anyopaque, new_gas: u64) c_int {
-    if (frame_ptr == null) return @intFromEnum(FrameError.FRAME_ERROR_INVALID_PARAM);
-    
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    
-    // Reset frame state
-    // Reset stack by resetting the pointer to the end of the buffer (stack grows downward)
-    frame.stack.stack_ptr = frame.stack.buf_ptr + @TypeOf(frame.stack).stack_capacity;
-    frame.memory.clear();
-    frame.gas_remaining = @as(DefaultFrame.GasType, @intCast(new_gas));
-    
-    return @intFromEnum(FrameError.FRAME_OK);
-}
-
-/// Push a u64 value onto the stack
-/// @param frame_ptr Pointer to frame handle
-/// @param value Value to push
-/// @return Error code (0 = success)
-export fn evm_frame_push_u64(frame_ptr: ?*anyopaque, value: u64) c_int {
-    if (frame_ptr == null) return @intFromEnum(FrameError.FRAME_ERROR_INVALID_PARAM);
-    
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    
-    frame.stack.push(@intCast(value)) catch {
-        return @intFromEnum(FrameError.FRAME_ERROR_STACK_OVERFLOW);
+    evm_ptr.database.set_storage(address.*, key_u256, value_u256) catch {
+        setError("Failed to set storage", .{});
+        return false;
     };
     
-    return @intFromEnum(FrameError.FRAME_OK);
+    return true;
 }
 
-/// Pop a u64 value from the stack
-/// @param frame_ptr Pointer to frame handle
-/// @param value_out Pointer to store the popped value
-/// @return Error code (0 = success)
-export fn evm_frame_pop_u64(frame_ptr: ?*anyopaque, value_out: ?*u64) c_int {
-    if (frame_ptr == null or value_out == null) return @intFromEnum(FrameError.FRAME_ERROR_INVALID_PARAM);
+// Get storage
+export fn guillotine_get_storage(handle: *EvmHandle, address: *const [20]u8, key: *const [32]u8, value_out: *[32]u8) bool {
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
     
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    
-    const value = frame.stack.pop() catch {
-        return @intFromEnum(FrameError.FRAME_ERROR_STACK_UNDERFLOW);
+    const key_u256 = std.mem.readInt(u256, key, .big);
+    const value = evm_ptr.database.get_storage(address.*, key_u256) catch {
+        setError("Failed to get storage", .{});
+        return false;
     };
     
-    value_out.?.* = @intCast(value);
-    return @intFromEnum(FrameError.FRAME_OK);
+    std.mem.writeInt(u256, value_out, value, .big);
+    return true;
 }
 
-/// Get memory data
-/// @param frame_ptr Pointer to frame handle
-/// @param offset Offset in memory
-/// @param length Number of bytes to read
-/// @param data_out Buffer to write data to
-/// @return Error code (0 = success)
-export fn evm_frame_get_memory(frame_ptr: ?*anyopaque, offset: u32, length: u32, data_out: ?[*]u8) c_int {
-    if (frame_ptr == null or data_out == null) return @intFromEnum(FrameError.FRAME_ERROR_INVALID_PARAM);
-    
-    const handle: *FrameHandle = @ptrCast(@alignCast(frame_ptr.?));
-    const frame = handle.frame;
-    
-    const slice = frame.memory.get_slice(@intCast(offset), @intCast(length)) catch {
-        return @intFromEnum(FrameError.FRAME_ERROR_EXECUTION_FAILED);
-    };
-    
-    const data_out_slice = data_out.?[0..length];
-    @memcpy(data_out_slice, slice);
-    return @intFromEnum(FrameError.FRAME_OK);
+// Free output memory
+export fn guillotine_free_output(output: [*]u8, len: usize) void {
+    const alloc = ffi_allocator orelse return;
+    alloc.free(output[0..len]);
 }
 
-/// Create a debug frame with tracing enabled
-/// @param bytecode_ptr Pointer to bytecode
-/// @param bytecode_len Length of bytecode  
-/// @param initial_gas Initial gas amount
-/// @return Pointer to frame handle or null on error
-export fn evm_debug_frame_create(bytecode_ptr: [*]const u8, bytecode_len: usize, initial_gas: u64) ?*anyopaque {
-    // For now, just create a regular frame
-    // TODO: Add debug/tracing support
-    return evm_frame_create(bytecode_ptr, bytecode_len, initial_gas);
-}
-
-// Helper functions
-fn u256_from_bytes(bytes: *const [32]u8) u256 {
-    // Convert from little-endian bytes to u256
-    var result: u256 = 0;
-    for (bytes, 0..) |byte, i| {
-        result |= @as(u256, byte) << @intCast(i * 8);
+// Free result structure
+export fn guillotine_free_result(result: ?*EvmResult) void {
+    const alloc = ffi_allocator orelse return;
+    if (result) |r| {
+        // Free output
+        if (r.output_len > 0) {
+            alloc.free(r.output[0..r.output_len]);
+        }
+        
+        // Free logs
+        if (r.logs_len > 0) {
+            for (r.logs[0..r.logs_len]) |log| {
+                if (log.topics_len > 0) {
+                    alloc.free(log.topics[0..log.topics_len]);
+                }
+                if (log.data_len > 0) {
+                    alloc.free(log.data[0..log.data_len]);
+                }
+            }
+            alloc.free(r.logs[0..r.logs_len]);
+        }
+        
+        // Free selfdestructs
+        if (r.selfdestructs_len > 0) {
+            alloc.free(r.selfdestructs[0..r.selfdestructs_len]);
+        }
+        
+        // Free accessed addresses
+        if (r.accessed_addresses_len > 0) {
+            alloc.free(r.accessed_addresses[0..r.accessed_addresses_len]);
+        }
+        
+        // Free accessed storage
+        if (r.accessed_storage_len > 0) {
+            alloc.free(r.accessed_storage[0..r.accessed_storage_len]);
+        }
+        
+        // Free trace JSON
+        if (r.trace_json_len > 0) {
+            alloc.free(r.trace_json[0..r.trace_json_len]);
+        }
+        
+        // Free the result structure itself
+        alloc.destroy(r);
     }
-    return result;
+}
+
+// Get last error message
+export fn guillotine_get_last_error() [*:0]const u8 {
+    return @ptrCast(&last_error_z);
+}
+
+// Simulate a call (same as call but doesn't modify state)
+export fn guillotine_simulate(handle: *EvmHandle, params: *const CallParams) ?*EvmResult {
+    // For now, just call the regular call function
+    // TODO: Implement proper simulation that doesn't modify state
+    return guillotine_call(handle, params);
 }

--- a/src/evm_c.zig
+++ b/src/evm_c.zig
@@ -32,19 +32,26 @@ fn log(comptime level: std.log.Level, comptime scope: @TypeOf(.enum_literal), co
 }
 
 const DefaultEvm = evm_root.DefaultEvm;
+const Database = evm_root.Database;
 const MemoryDatabase = evm_root.MemoryDatabase;
 const CallParams = evm_root.CallParams;
 const CallResult = evm_root.CallResult;
-const Address = primitives.Address.Address;
+const Address = primitives.Address;
 const Frame = evm_root.Frame;
 const FrameConfig = evm_root.FrameConfig;
 const NoOpTracer = evm_root.NoOpTracer;
+const BlockInfo = evm_root.BlockInfo;
+const TransactionContext = evm_root.TransactionContext;
+const Hardfork = evm_root.Hardfork;
+const Account = evm_root.Account;
 
 // Define a specific Frame type for C API use
+// Using a void type for DatabaseType since Frame won't have database access
+const VoidDatabase = struct {};
 const DefaultFrameConfig = FrameConfig{
     .stack_size = 1024,
-    .has_database = false,
-    .TracerType = NoOpTracer,
+    .DatabaseType = VoidDatabase,
+    .TracerType = null,
 };
 const DefaultFrame = Frame(DefaultFrameConfig);
 
@@ -87,8 +94,12 @@ export fn evm_init() c_int {
         return @intFromEnum(EvmError.EVM_OK);
     }
 
-    var memory_db = MemoryDatabase.init(allocator);
-    const db_interface = memory_db.to_database_interface();
+    const memory_db = allocator.create(MemoryDatabase) catch {
+        log(.err, .evm_c, "Failed to allocate memory for database", .{});
+        return @intFromEnum(EvmError.EVM_ERROR_MEMORY);
+    };
+    memory_db.* = MemoryDatabase.init(allocator);
+    const db_ptr = @as(*Database, @ptrCast(memory_db));
 
     const vm = allocator.create(DefaultEvm) catch {
         log(.err, .evm_c, "Failed to allocate memory for VM", .{});
@@ -96,17 +107,17 @@ export fn evm_init() c_int {
     };
 
     // Initialize with default configuration
-    const block_info = evm_root.BlockInfo.init();
-    const tx_context = evm_root.TransactionContext{
+    const block_info = BlockInfo.init();
+    const tx_context = TransactionContext{
         .gas_limit = 30_000_000,
         .coinbase = primitives.ZERO_ADDRESS,
         .chain_id = 1,
     };
-    const gas_price = 0;
+    const gas_price: u256 = 0;
     const origin = primitives.ZERO_ADDRESS;
-    const hardfork = evm_root.Hardfork.CANCUN;
+    const hardfork = Hardfork.CANCUN;
     
-    vm.* = DefaultEvm.init(allocator, db_interface, block_info, tx_context, gas_price, origin, hardfork) catch |err| {
+    vm.* = DefaultEvm.init(allocator, db_ptr, block_info, tx_context, gas_price, origin, hardfork) catch |err| {
         log(.err, .evm_c, "Failed to initialize VM: {}", .{err});
         allocator.destroy(vm);
         return @intFromEnum(EvmError.EVM_ERROR_MEMORY);
@@ -160,7 +171,7 @@ export fn evm_execute(
     // Convert inputs
     const bytecode = bytecode_ptr[0..bytecode_len];
     const caller_bytes = caller_ptr[0..20];
-    const caller_address = caller_bytes.*;
+    const caller_address = Address{ .bytes = caller_bytes.* };
 
     // Create a temporary address for the code execution
     const target_address = primitives.ZERO_ADDRESS; // Use zero address for contract execution
@@ -174,9 +185,9 @@ export fn evm_execute(
     };
     
     // Create account with the code
-    var account = evm_root.Account.zero();
+    var account = Account.zero();
     account.code_hash = code_hash;
-    vm.database.set_account(target_address, account) catch |err| {
+    vm.database.set_account(target_address.bytes, account) catch |err| {
         log(.err, .evm_c, "Failed to set account: {}", .{err});
         result_ptr.success = 0;
         result_ptr.error_code = @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
@@ -194,13 +205,8 @@ export fn evm_execute(
         },
     };
 
-    // Execute call
-    const run_result = vm.call(call_params) catch |err| {
-        log(.err, .evm_c, "Execution failed: {}", .{err});
-        result_ptr.success = 0;
-        result_ptr.error_code = @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-        return @intFromEnum(EvmError.EVM_ERROR_EXECUTION_FAILED);
-    };
+    // Execute call - vm.call returns CallResult directly, not an error union
+    const run_result = vm.call(call_params);
 
     // Fill result structure
     result_ptr.success = if (run_result.success) 1 else 0;
@@ -263,6 +269,7 @@ pub const GuillotineExecutionResult = extern struct {
 const VmState = struct {
     vm: *DefaultEvm,
     memory_db: *MemoryDatabase,
+    database: *Database,
     allocator: std.mem.Allocator,
 };
 
@@ -278,7 +285,7 @@ export fn guillotine_vm_create() ?*GuillotineVm {
     };
     state.memory_db.* = MemoryDatabase.init(allocator);
     
-    const db_interface = state.memory_db.to_database_interface();
+    state.database = @as(*Database, @ptrCast(state.memory_db));
     state.vm = allocator.create(DefaultEvm) catch {
         state.memory_db.deinit();
         allocator.destroy(state.memory_db);
@@ -287,17 +294,17 @@ export fn guillotine_vm_create() ?*GuillotineVm {
     };
     
     // Initialize with default configuration
-    const block_info = evm_root.BlockInfo.init();
-    const tx_context = evm_root.TransactionContext{
+    const block_info = BlockInfo.init();
+    const tx_context = TransactionContext{
         .gas_limit = 30_000_000,
         .coinbase = primitives.ZERO_ADDRESS,
         .chain_id = 1,
     };
-    const gas_price = 0;
+    const gas_price: u256 = 0;
     const origin = primitives.ZERO_ADDRESS;
-    const hardfork = evm_root.Hardfork.CANCUN;
+    const hardfork = Hardfork.CANCUN;
     
-    state.vm.* = DefaultEvm.init(allocator, db_interface, block_info, tx_context, gas_price, origin, hardfork) catch {
+    state.vm.* = DefaultEvm.init(allocator, state.database, block_info, tx_context, gas_price, origin, hardfork) catch {
         state.memory_db.deinit();
         allocator.destroy(state.memory_db);
         allocator.destroy(state.vm);
@@ -328,12 +335,12 @@ export fn guillotine_set_balance(vm: ?*GuillotineVm, address: ?*const Guillotine
     const value = u256_from_bytes(&balance.?.bytes);
     
     // Get current account or create new one
-    var account = state.vm.database.get_account(addr) catch return false;
+    var account = state.database.get_account(addr) catch return false;
     if (account == null) {
-        account = evm_root.Account.zero();
+        account = Account.zero();
     }
     account.?.balance = value;
-    state.vm.database.set_account(addr, account.?) catch return false;
+    state.database.set_account(addr, account.?) catch return false;
     return true;
 }
 
@@ -345,15 +352,15 @@ export fn guillotine_set_code(vm: ?*GuillotineVm, address: ?*const GuillotineAdd
     
     const code_slice = if (code) |c| c[0..code_len] else &[_]u8{};
     // Set code and update account
-    const code_hash = state.vm.database.set_code(code_slice) catch return false;
+    const code_hash = state.database.set_code(code_slice) catch return false;
     
     // Get current account or create new one
-    var account = state.vm.database.get_account(addr) catch return false;
+    var account = state.database.get_account(addr) catch return false;
     if (account == null) {
-        account = evm_root.Account.zero();
+        account = Account.zero();
     }
     account.?.code_hash = code_hash;
-    state.vm.database.set_account(addr, account.?) catch return false;
+    state.database.set_account(addr, account.?) catch return false;
     return true;
 }
 
@@ -378,12 +385,12 @@ export fn guillotine_execute(
     if (vm == null or from == null) return result;
     
     const state: *VmState = @ptrCast(@alignCast(vm.?));
-    const from_addr = from.?.bytes;
+    const from_addr = Address{ .bytes = from.?.bytes };
     const value_u256 = if (value) |v| u256_from_bytes(&v.bytes) else 0;
     const input_slice = if (input) |i| i[0..input_len] else &[_]u8{};
     
     // Create call parameters
-    const to_addr = if (to) |t| t.bytes else primitives.ZERO_ADDRESS;
+    const to_addr = if (to) |t| Address{ .bytes = t.bytes } else primitives.ZERO_ADDRESS;
     const call_params = CallParams{
         .call = .{
             .caller = from_addr,
@@ -394,13 +401,8 @@ export fn guillotine_execute(
         },
     };
     
-    // Execute
-    const exec_result = state.vm.call(call_params) catch |err| {
-        const err_msg = @errorName(err);
-        const err_c_str = state.allocator.dupeZ(u8, err_msg) catch return result;
-        result.error_message = err_c_str.ptr;
-        return result;
-    };
+    // Execute - vm.call returns CallResult directly
+    const exec_result = state.vm.call(call_params);
     
     result.success = exec_result.success;
     result.gas_used = gas_limit - exec_result.gas_left;
@@ -479,13 +481,24 @@ export fn evm_frame_create(bytecode_ptr: [*]const u8, bytecode_len: usize, initi
         return null;
     };
     
-    // Initialize frame (Frame doesn't have database when has_database = false)
+    // Initialize frame 
+    // Need to provide all required parameters for Frame.init
+    const default_value: u256 = 0;
+    const default_caller = primitives.ZERO_ADDRESS;
+    const empty_calldata: []const u8 = &[_]u8{};
+    const void_database = VoidDatabase{};
+    // Use a dummy struct as placeholder for evm_ptr
+    var dummy_evm: u8 = 0;
+    const null_evm_ptr: *anyopaque = @ptrCast(&dummy_evm);
+    
     handle.frame.* = DefaultFrame.init(
         allocator,
-        handle.bytecode,
         @intCast(initial_gas),
-        {}, // void when has_database = false
-        null // No host  
+        void_database,
+        default_caller,
+        &default_value,
+        empty_calldata,
+        null_evm_ptr
     ) catch {
         allocator.destroy(handle.frame);
         allocator.free(handle.bytecode);
@@ -626,8 +639,8 @@ export fn evm_frame_reset(frame_ptr: ?*anyopaque, new_gas: u64) c_int {
     const frame = handle.frame;
     
     // Reset frame state
-    // Reset stack by resetting the pointer to the base
-    frame.stack.stack_ptr = frame.stack.stack_base;
+    // Reset stack by resetting the pointer to the end of the buffer (stack grows downward)
+    frame.stack.stack_ptr = frame.stack.buf_ptr + @TypeOf(frame.stack).stack_capacity;
     frame.memory.clear();
     frame.gas_remaining = @as(DefaultFrame.GasType, @intCast(new_gas));
     

--- a/src/evm_c.zig
+++ b/src/evm_c.zig
@@ -91,15 +91,15 @@ pub const CallParams = extern struct {
     salt: [32]u8, // For CREATE2
 };
 
-// Block info for FFI
+// Block info for FFI - all u64 fields first to avoid padding
 pub const BlockInfoFFI = extern struct {
     number: u64,
     timestamp: u64,
     gas_limit: u64,
-    coinbase: [20]u8,
     base_fee: u64,
     chain_id: u64,
     difficulty: u64,
+    coinbase: [20]u8,
     prev_randao: [32]u8,
 };
 

--- a/src/evm_c.zig
+++ b/src/evm_c.zig
@@ -37,13 +37,15 @@ const Account = evm.Account;
 // Opaque handle for EVM instance
 pub const EvmHandle = opaque {};
 
-// Log entry for FFI
+// Log entry for FFI - WASM32 optimized
 pub const LogEntry = extern struct {
     address: [20]u8,
-    topics: [*]const [32]u8,
-    topics_len: usize,
-    data: [*]const u8,
-    data_len: usize,
+    _pad1: [4]u8 = .{0,0,0,0}, // Padding to align pointer
+    topics: [*]const [32]u8,  // 4 bytes (32-bit pointer)
+    topics_len: u32,          // 4 bytes (not usize!)
+    data: [*]const u8,        // 4 bytes
+    data_len: u32,            // 4 bytes
+    // Total: 40 bytes
 };
 
 // Self-destruct record for FFI
@@ -58,49 +60,58 @@ pub const StorageAccessRecord = extern struct {
     slot: [32]u8,
 };
 
-// Result structure for FFI - matches evm_c_api.zig
+// Result structure for FFI - WASM32 optimized with explicit alignment
 pub const EvmResult = extern struct {
-    success: bool align(4), // Align to 4 bytes for C compatibility
-    gas_left: u64,
-    output: [*]const u8,
-    output_len: usize,
-    error_message: [*:0]const u8,
-    logs: [*]const LogEntry,
-    logs_len: usize,
-    selfdestructs: [*]const SelfDestructRecord,
-    selfdestructs_len: usize,
-    accessed_addresses: [*]const [20]u8,
-    accessed_addresses_len: usize,
-    accessed_storage: [*]const StorageAccessRecord,
-    accessed_storage_len: usize,
-    created_address: [20]u8,
-    has_created_address: bool,
-    trace_json: [*]const u8,
-    trace_json_len: usize,
+    success: bool,                       // 1 byte + 3 padding for alignment
+    _pad1: [3]u8 = .{0,0,0},            // Explicit padding
+    gas_left: u64,                       // 8 bytes, must be 8-byte aligned
+    output: [*]const u8,                 // 4 bytes (32-bit pointer)
+    output_len: u32,                     // 4 bytes (use u32 not usize for FFI)
+    error_message: [*:0]const u8,        // 4 bytes
+    _pad2: [4]u8 = .{0,0,0,0},          // Pad to 8-byte boundary
+    logs: [*]const LogEntry,             // 4 bytes
+    logs_len: u32,                       // 4 bytes
+    selfdestructs: [*]const SelfDestructRecord, // 4 bytes
+    selfdestructs_len: u32,              // 4 bytes
+    accessed_addresses: [*]const [20]u8, // 4 bytes
+    accessed_addresses_len: u32,         // 4 bytes
+    accessed_storage: [*]const StorageAccessRecord, // 4 bytes
+    accessed_storage_len: u32,           // 4 bytes
+    created_address: [20]u8,             // 20 bytes
+    has_created_address: bool,           // 1 byte
+    _pad3: [3]u8 = .{0,0,0},            // Padding
+    trace_json: [*]const u8,             // 4 bytes
+    trace_json_len: u32,                 // 4 bytes
 };
 
-// Call parameters for FFI
+// Call parameters for FFI - WASM32 optimized
 pub const CallParams = extern struct {
-    caller: [20]u8,
-    to: [20]u8,
-    value: [32]u8, // u256 as bytes
-    input: [*]const u8,
-    input_len: usize,
-    gas: u64,
-    call_type: u8, // 0=CALL, 1=CALLCODE, 2=DELEGATECALL, 3=STATICCALL, 4=CREATE, 5=CREATE2
-    salt: [32]u8, // For CREATE2
+    caller: [20]u8,         // 20 bytes
+    to: [20]u8,            // 20 bytes  
+    value: [32]u8,         // 32 bytes (u256 as big-endian bytes)
+    input: [*]const u8,    // 4 bytes (32-bit pointer)
+    input_len: u32,        // 4 bytes (not usize!)
+    gas: u64,              // 8 bytes
+    call_type: u8,         // 1 byte
+    _pad: [3]u8 = .{0,0,0}, // Padding for alignment
+    salt: [32]u8,          // 32 bytes (for CREATE2)
+    // Total: Check alignment with offsetof
 };
 
-// Block info for FFI - all u64 fields first to avoid padding
+// Block info for FFI - WASM32 optimized struct layout
 pub const BlockInfoFFI = extern struct {
-    number: u64,
-    timestamp: u64,
-    gas_limit: u64,
-    base_fee: u64,
-    chain_id: u64,
-    difficulty: u64,
-    coinbase: [20]u8,
-    prev_randao: [32]u8,
+    // Group u64 fields first to avoid padding
+    number: u64,         // 8 bytes, offset 0
+    timestamp: u64,      // 8 bytes, offset 8
+    gas_limit: u64,      // 8 bytes, offset 16
+    base_fee: u64,       // 8 bytes, offset 24
+    chain_id: u64,       // 8 bytes, offset 32
+    difficulty: u64,     // 8 bytes, offset 40
+    // Then smaller fields
+    coinbase: [20]u8,    // 20 bytes, offset 48
+    _pad1: [4]u8 = .{0,0,0,0}, // Padding to align next field
+    prev_randao: [32]u8, // 32 bytes, offset 72
+    // Total: 104 bytes
 };
 
 // Use page allocator for WASM (no libc dependency)
@@ -109,12 +120,37 @@ const allocator = if (builtin.target.cpu.arch == .wasm32 and builtin.target.os.t
 else
     std.heap.c_allocator;
 
-// Thread-local allocator for FFI (in WASM this is just global)
+// Global allocator for FFI (WASM is single-threaded)
 var ffi_allocator: ?std.mem.Allocator = null;
 var last_error: [256]u8 = undefined;
 var last_error_z: [257]u8 = undefined;
 const empty_error: [1]u8 = .{0};
 const empty_buffer: [0]u8 = .{};
+
+// Instance pooling for performance (WASM-optimized, no threading)
+const EvmInstance = struct {
+    evm: *DefaultEvm,
+    database: *Database,
+    block_info: BlockInfoFFI,
+    in_use: bool,
+    needs_reset: bool,
+};
+
+const TracingEvmInstance = struct {
+    evm: *TracerEvm,
+    database: *Database,
+    block_info: BlockInfoFFI,
+    in_use: bool,
+    needs_reset: bool,
+};
+
+// Instance pools - maintain reusable EVM instances (no mutex needed in WASM)
+var instance_pool: ?std.ArrayList(*EvmInstance) = null;
+var tracing_instance_pool: ?std.ArrayList(*TracingEvmInstance) = null;
+
+// Map handles to instances
+var handle_map: ?std.AutoHashMap(*EvmHandle, *EvmInstance) = null;
+var tracing_handle_map: ?std.AutoHashMap(*EvmHandle, *TracingEvmInstance) = null;
 
 fn setError(comptime fmt: []const u8, args: anytype) void {
     const slice = std.fmt.bufPrint(&last_error, fmt, args) catch "Unknown error";
@@ -122,31 +158,126 @@ fn setError(comptime fmt: []const u8, args: anytype) void {
     last_error_z[slice.len] = 0;
 }
 
-// Initialize FFI
+// Initialize FFI and instance pools
 export fn guillotine_init() void {
     if (ffi_allocator == null) {
         ffi_allocator = allocator;
     }
+    
+    const alloc = ffi_allocator.?;
+    
+    if (instance_pool == null) {
+        instance_pool = std.ArrayList(*EvmInstance).initCapacity(alloc, 4) catch return;
+        tracing_instance_pool = std.ArrayList(*TracingEvmInstance).initCapacity(alloc, 4) catch return;
+        handle_map = std.AutoHashMap(*EvmHandle, *EvmInstance).init(alloc);
+        tracing_handle_map = std.AutoHashMap(*EvmHandle, *TracingEvmInstance).init(alloc);
+    }
 }
 
-// Cleanup FFI
+// Cleanup FFI and instance pools
 export fn guillotine_cleanup() void {
+    if (ffi_allocator) |alloc| {
+        // Clean up instance pools
+        if (instance_pool) |*pool| {
+            for (pool.items) |instance| {
+                instance.evm.deinit();
+                instance.database.deinit();
+                alloc.destroy(instance.database);
+                alloc.destroy(instance.evm);
+                alloc.destroy(instance);
+            }
+            pool.deinit(alloc);
+            instance_pool = null;
+        }
+        
+        if (tracing_instance_pool) |*pool| {
+            for (pool.items) |instance| {
+                instance.evm.deinit();
+                instance.database.deinit();
+                alloc.destroy(instance.database);
+                alloc.destroy(instance.evm);
+                alloc.destroy(instance);
+            }
+            pool.deinit(alloc);
+            tracing_instance_pool = null;
+        }
+        
+        if (handle_map) |*map| {
+            map.deinit();
+            handle_map = null;
+        }
+        
+        if (tracing_handle_map) |*map| {
+            map.deinit();
+            tracing_handle_map = null;
+        }
+    }
+    
     ffi_allocator = null;
 }
 
-// Create EVM instance
+// Create EVM instance (or reuse from pool)
 export fn guillotine_evm_create(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle {
     const alloc = ffi_allocator orelse {
         setError("FFI not initialized. Call guillotine_init() first", .{});
         return null;
     };
-
-    // Create database
-    const db = alloc.create(evm.Database) catch {
-        setError("Failed to allocate database", .{});
+    
+    // Try to find a free instance in the pool
+    if (instance_pool) |*pool| {
+        for (pool.items) |instance| {
+            if (!instance.in_use) {
+                // Found a free instance - reset and reuse it
+                if (instance.needs_reset) {
+                    // Reset the database by reinitializing it
+                    instance.database.deinit();
+                    instance.database.* = Database.init(alloc);
+                    instance.needs_reset = false;
+                }
+                
+                // Update block info
+                instance.block_info = block_info_ptr.*;
+                const block_info = BlockInfo{
+                    .number = block_info_ptr.number,
+                    .timestamp = block_info_ptr.timestamp,
+                    .gas_limit = block_info_ptr.gas_limit,
+                    .coinbase = primitives.Address{ .bytes = block_info_ptr.coinbase },
+                    .base_fee = block_info_ptr.base_fee,
+                    .chain_id = block_info_ptr.chain_id,
+                    .difficulty = block_info_ptr.difficulty,
+                    .prev_randao = block_info_ptr.prev_randao,
+                    .blob_base_fee = 0,
+                    .blob_versioned_hashes = &.{},
+                };
+                instance.evm.block_info = block_info;
+                instance.in_use = true;
+                
+                // Create handle and register it
+                const handle = @as(*EvmHandle, @ptrCast(instance.evm));
+                handle_map.?.put(handle, instance) catch {
+                    instance.in_use = false;
+                    setError("Failed to register handle", .{});
+                    return null;
+                };
+                
+                return handle;
+            }
+        }
+    }
+    
+    // No free instance found, create a new one
+    const instance = alloc.create(EvmInstance) catch {
+        setError("Failed to allocate instance", .{});
         return null;
     };
-    db.* = evm.Database.init(alloc);
+    
+    // Create database
+    const db = alloc.create(Database) catch {
+        setError("Failed to allocate database", .{});
+        alloc.destroy(instance);
+        return null;
+    };
+    db.* = Database.init(alloc);
 
     // Set up block info
     const block_info = BlockInfo{
@@ -158,6 +289,8 @@ export fn guillotine_evm_create(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle
         .chain_id = block_info_ptr.chain_id,
         .difficulty = block_info_ptr.difficulty,
         .prev_randao = block_info_ptr.prev_randao,
+        .blob_base_fee = 0,
+        .blob_versioned_hashes = &.{},
     };
 
     // Create transaction context
@@ -166,11 +299,14 @@ export fn guillotine_evm_create(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle
         .coinbase = block_info.coinbase,
         .chain_id = @intCast(block_info.chain_id),
         .blob_versioned_hashes = &.{},
+        .blob_base_fee = 0,
     };
 
     // Create EVM instance
     const evm_ptr = alloc.create(DefaultEvm) catch {
+        db.deinit();
         alloc.destroy(db);
+        alloc.destroy(instance);
         setError("Failed to allocate EVM instance", .{});
         return null;
     };
@@ -181,31 +317,108 @@ export fn guillotine_evm_create(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle
         block_info,
         tx_context,
         0, // gas_price
-        primitives.Address.zero(), // origin
-        Hardfork.DEFAULT,
+        primitives.Address.ZERO_ADDRESS, // origin
+        .CANCUN, // Latest hardfork
     ) catch {
+        db.deinit();
         alloc.destroy(db);
         alloc.destroy(evm_ptr);
+        alloc.destroy(instance);
         setError("Failed to initialize EVM", .{});
         return null;
     };
+    
+    // Initialize instance struct
+    instance.* = .{
+        .evm = evm_ptr,
+        .database = db,
+        .block_info = block_info_ptr.*,
+        .in_use = true,
+        .needs_reset = false,
+    };
+    
+    // Add to pool
+    instance_pool.?.append(alloc, instance) catch {
+        setError("Failed to add to pool", .{});
+        evm_ptr.deinit();
+        db.deinit();
+        alloc.destroy(db);
+        alloc.destroy(evm_ptr);
+        alloc.destroy(instance);
+        return null;
+    };
+    
+    // Create handle and register it
+    const handle = @as(*EvmHandle, @ptrCast(evm_ptr));
+    handle_map.?.put(handle, instance) catch {
+        setError("Failed to register handle", .{});
+        return null;
+    };
 
-    return @ptrCast(evm_ptr);
+    return handle;
 }
 
-// Create tracing EVM instance
+// Create tracing EVM instance (with pooling support)
 export fn guillotine_evm_create_tracing(block_info_ptr: *const BlockInfoFFI) ?*EvmHandle {
     const alloc = ffi_allocator orelse {
         setError("FFI not initialized. Call guillotine_init() first", .{});
         return null;
     };
-
-    // Create database
-    const db = alloc.create(evm.Database) catch {
-        setError("Failed to allocate database", .{});
+    
+    // Try to find a free tracing instance in the pool
+    if (tracing_instance_pool) |*pool| {
+        for (pool.items) |instance| {
+            if (!instance.in_use) {
+                // Found a free instance - reset and reuse it
+                if (instance.needs_reset) {
+                    instance.database.deinit();
+                    instance.database.* = Database.init(alloc);
+                    instance.needs_reset = false;
+                }
+                
+                // Update block info
+                instance.block_info = block_info_ptr.*;
+                const block_info = BlockInfo{
+                    .number = block_info_ptr.number,
+                    .timestamp = block_info_ptr.timestamp,
+                    .gas_limit = block_info_ptr.gas_limit,
+                    .coinbase = primitives.Address{ .bytes = block_info_ptr.coinbase },
+                    .base_fee = block_info_ptr.base_fee,
+                    .chain_id = block_info_ptr.chain_id,
+                    .difficulty = block_info_ptr.difficulty,
+                    .prev_randao = block_info_ptr.prev_randao,
+                    .blob_base_fee = 0,
+                    .blob_versioned_hashes = &.{},
+                };
+                instance.evm.block_info = block_info;
+                instance.in_use = true;
+                
+                // Create handle and register it
+                const handle = @as(*EvmHandle, @ptrCast(instance.evm));
+                tracing_handle_map.?.put(handle, instance) catch {
+                    instance.in_use = false;
+                    setError("Failed to register handle", .{});
+                    return null;
+                };
+                
+                return handle;
+            }
+        }
+    }
+    
+    // No free instance found, create a new one
+    const instance = alloc.create(TracingEvmInstance) catch {
+        setError("Failed to allocate tracing instance", .{});
         return null;
     };
-    db.* = evm.Database.init(alloc);
+
+    // Create database
+    const db = alloc.create(Database) catch {
+        setError("Failed to allocate database", .{});
+        alloc.destroy(instance);
+        return null;
+    };
+    db.* = Database.init(alloc);
 
     // Set up block info
     const block_info = BlockInfo{
@@ -217,6 +430,8 @@ export fn guillotine_evm_create_tracing(block_info_ptr: *const BlockInfoFFI) ?*E
         .chain_id = block_info_ptr.chain_id,
         .difficulty = block_info_ptr.difficulty,
         .prev_randao = block_info_ptr.prev_randao,
+        .blob_base_fee = 0,
+        .blob_versioned_hashes = &.{},
     };
 
     // Create transaction context
@@ -225,6 +440,7 @@ export fn guillotine_evm_create_tracing(block_info_ptr: *const BlockInfoFFI) ?*E
         .coinbase = block_info.coinbase,
         .chain_id = @intCast(block_info.chain_id),
         .blob_versioned_hashes = &.{},
+        .blob_base_fee = 0,
     };
 
     // Create tracing EVM instance
@@ -240,46 +456,73 @@ export fn guillotine_evm_create_tracing(block_info_ptr: *const BlockInfoFFI) ?*E
         block_info,
         tx_context,
         0, // gas_price
-        primitives.Address.zero(), // origin
-        Hardfork.DEFAULT,
+        primitives.Address.ZERO_ADDRESS, // origin
+        .CANCUN, // Latest hardfork
     ) catch {
+        db.deinit();
         alloc.destroy(db);
         alloc.destroy(evm_ptr);
+        alloc.destroy(instance);
         setError("Failed to initialize tracing EVM", .{});
         return null;
     };
+    
+    // Initialize instance struct
+    instance.* = .{
+        .evm = evm_ptr,
+        .database = db,
+        .block_info = block_info_ptr.*,
+        .in_use = true,
+        .needs_reset = false,
+    };
+    
+    // Add to pool
+    tracing_instance_pool.?.append(alloc, instance) catch {
+        setError("Failed to add to pool", .{});
+        evm_ptr.deinit();
+        db.deinit();
+        alloc.destroy(db);
+        alloc.destroy(evm_ptr);
+        alloc.destroy(instance);
+        return null;
+    };
+    
+    // Create handle and register it
+    const handle = @as(*EvmHandle, @ptrCast(evm_ptr));
+    tracing_handle_map.?.put(handle, instance) catch {
+        setError("Failed to register handle", .{});
+        return null;
+    };
 
-    return @ptrCast(evm_ptr);
+    return handle;
 }
 
-// Destroy EVM instance
+// Destroy EVM instance (actually returns it to the pool)
 export fn guillotine_evm_destroy(handle: *EvmHandle) void {
-    const alloc = ffi_allocator orelse return;
-    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
-    
-    // Deinit database
-    const db_ptr: *evm.Database = @ptrCast(@alignCast(evm_ptr.database));
-    db_ptr.deinit();
-    alloc.destroy(db_ptr);
-    
-    // Destroy EVM
-    evm_ptr.deinit();
-    alloc.destroy(evm_ptr);
+    // Find the instance in the handle map
+    if (handle_map) |*map| {
+        if (map.fetchRemove(handle)) |entry| {
+            const instance = entry.value;
+            // Mark as not in use and needs reset
+            instance.in_use = false;
+            instance.needs_reset = true;
+            // Instance stays in the pool for reuse
+        }
+    }
 }
 
-// Destroy tracing EVM instance
+// Destroy tracing EVM instance (actually returns it to the pool)
 export fn guillotine_evm_destroy_tracing(handle: *EvmHandle) void {
-    const alloc = ffi_allocator orelse return;
-    const evm_ptr: *TracerEvm = @ptrCast(@alignCast(handle));
-
-    // Deinit database
-    const db_ptr: *evm.Database = @ptrCast(@alignCast(evm_ptr.database));
-    db_ptr.deinit();
-    alloc.destroy(db_ptr);
-
-    // Destroy EVM
-    evm_ptr.deinit();
-    alloc.destroy(evm_ptr);
+    // Find the instance in the tracing handle map
+    if (tracing_handle_map) |*map| {
+        if (map.fetchRemove(handle)) |entry| {
+            const instance = entry.value;
+            // Mark as not in use and needs reset
+            instance.in_use = false;
+            instance.needs_reset = true;
+            // Instance stays in the pool for reuse
+        }
+    }
 }
 
 // Set balance
@@ -386,7 +629,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         };
         @memcpy(output_copy, result.output);
         evm_result.output = output_copy.ptr;
-        evm_result.output_len = output_copy.len;
+        evm_result.output_len = @intCast(output_copy.len);
     } else {
         evm_result.output = @as([*]const u8, @ptrCast(&empty_error));
         evm_result.output_len = 0;
@@ -422,7 +665,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
                     std.mem.writeInt(u256, &topics_copy[j], topic, .big);
                 }
                 logs_copy[i].topics = topics_copy.ptr;
-                logs_copy[i].topics_len = topics_copy.len;
+                logs_copy[i].topics_len = @intCast(topics_copy.len);
             } else {
                 logs_copy[i].topics = @as([*]const [32]u8, @ptrCast(&empty_buffer));
                 logs_copy[i].topics_len = 0;
@@ -445,7 +688,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
                 };
                 @memcpy(data_copy, log.data);
                 logs_copy[i].data = data_copy.ptr;
-                logs_copy[i].data_len = data_copy.len;
+                logs_copy[i].data_len = @intCast(data_copy.len);
             } else {
                 logs_copy[i].data = @as([*]const u8, @ptrCast(&empty_buffer));
                 logs_copy[i].data_len = 0;
@@ -453,7 +696,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         }
         
         evm_result.logs = logs_copy.ptr;
-        evm_result.logs_len = logs_copy.len;
+        evm_result.logs_len = @intCast(logs_copy.len);
     } else {
         evm_result.logs = @as([*]const LogEntry, @ptrCast(@alignCast(&empty_buffer)));
         evm_result.logs_len = 0;
@@ -482,7 +725,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         }
         
         evm_result.selfdestructs = selfdestructs_copy.ptr;
-        evm_result.selfdestructs_len = selfdestructs_copy.len;
+        evm_result.selfdestructs_len = @intCast(selfdestructs_copy.len);
     } else {
         evm_result.selfdestructs = @as([*]const SelfDestructRecord, @ptrCast(&empty_buffer));
         evm_result.selfdestructs_len = 0;
@@ -511,7 +754,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         }
         
         evm_result.accessed_addresses = addresses_copy.ptr;
-        evm_result.accessed_addresses_len = addresses_copy.len;
+        evm_result.accessed_addresses_len = @intCast(addresses_copy.len);
     } else {
         evm_result.accessed_addresses = @as([*]const [20]u8, @ptrCast(&empty_buffer));
         evm_result.accessed_addresses_len = 0;
@@ -542,7 +785,7 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         }
         
         evm_result.accessed_storage = storage_copy.ptr;
-        evm_result.accessed_storage_len = storage_copy.len;
+        evm_result.accessed_storage_len = @intCast(storage_copy.len);
     } else {
         evm_result.accessed_storage = @as([*]const StorageAccessRecord, @ptrCast(&empty_buffer));
         evm_result.accessed_storage_len = 0;
@@ -553,13 +796,53 @@ fn convertCallResultToEvmResult(result: anytype, alloc: std.mem.Allocator) ?*Evm
         evm_result.created_address = addr.bytes;
         evm_result.has_created_address = true;
     } else {
-        evm_result.created_address = [_]u8{0} ** 20;
+        evm_result.created_address = primitives.Address.ZERO_ADDRESS.bytes;
         evm_result.has_created_address = false;
     }
     
-    // TODO: Add trace JSON support if available
+    // If we have an execution trace, serialize to JSON-RPC format
     evm_result.trace_json = @as([*]const u8, @ptrCast(&empty_buffer));
     evm_result.trace_json_len = 0;
+    if (result.trace) |*trace| {
+        // WASM32: Use heap allocation to avoid stack overflow
+        var buf = std.array_list.AlignedManaged(u8, null).init(alloc);
+        defer buf.deinit();
+        
+        // Build JSON with proper escaping
+        buf.appendSlice("{\"structLogs\":[") catch {
+            setError("Failed to start trace JSON", .{});
+            alloc.destroy(evm_result);
+            return null;
+        };
+        
+        for (trace.steps, 0..) |step, i| {
+            if (i > 0) buf.append(',') catch {};
+            // WASM32: Be careful with stack values (u256 = 32 bytes each)
+            buf.writer().print(
+                "{{\"pc\":{d},\"op\":\"{s}\",\"gas\":{d},\"gasCost\":{d},\"depth\":{d},\"stack\":[",
+                .{step.pc, step.opcode_name, step.gas, step.gas_cost, step.depth}
+            ) catch {};
+            
+            for (step.stack, 0..) |val, j| {
+                if (j > 0) buf.append(',') catch {};
+                // WASM32: u256 values must be formatted as hex strings
+                buf.writer().print("\"0x{x}\"", .{val}) catch {};
+            }
+            
+            buf.writer().print("],\"memSize\":{d}}}", .{step.mem_size}) catch {};
+        }
+        
+        buf.appendSlice("]}") catch {};
+        
+        // WASM32: Allocate final buffer with page_allocator
+        const bytes = alloc.dupe(u8, buf.items) catch {
+            setError("Failed to allocate trace JSON", .{});
+            alloc.destroy(evm_result);
+            return null;
+        };
+        evm_result.trace_json = bytes.ptr;
+        evm_result.trace_json_len = @intCast(bytes.len);
+    }
     
     return evm_result;
 }
@@ -690,10 +973,10 @@ export fn guillotine_call_tracing(handle: *EvmHandle, params: *const CallParams)
         },
     };
     
-    // Execute the call
+    // Execute the call with tracing
     const result = evm_ptr.call(call_params);
     
-    // TODO: Include trace JSON in result
+    // The trace is already included in result and will be serialized by convertCallResultToEvmResult
     return convertCallResultToEvmResult(result, alloc);
 }
 
@@ -710,44 +993,45 @@ export fn guillotine_get_balance(handle: *EvmHandle, address: *const [20]u8, bal
     return true;
 }
 
-// Get code
-export fn guillotine_get_code(handle: *EvmHandle, address: *const [20]u8, code_out: *[*]u8, len_out: *usize) bool {
+// Get code - returns code bytes and length, caller must free with guillotine_free_code
+export fn guillotine_get_code(handle: *EvmHandle, address: *const [20]u8, code_out: *[*]u8, len_out: *u32) bool {
     const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
     const alloc = ffi_allocator orelse {
         setError("FFI not initialized", .{});
         return false;
     };
     
-    const account = evm_ptr.database.get_account(address.*) catch {
-        setError("Failed to get account", .{});
-        return false;
-    } orelse Account{ .balance = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32, .nonce = 0, .delegated_address = null };
-    
-    if (std.mem.eql(u8, &account.code_hash, &primitives.EMPTY_CODE_HASH)) {
-        code_out.* = @constCast(@ptrCast(@alignCast(&empty_buffer)));
-        len_out.* = 0;
-        return true;
-    }
-    
-    const code = evm_ptr.database.get_code(account.code_hash) catch {
-        setError("Failed to get code", .{});
-        return false;
+    const code = evm_ptr.database.get_code_by_address(address.*) catch |err| {
+        if (err == Database.Error.AccountNotFound) {
+            // For non-existent accounts, return empty code (success with len=0)
+            code_out.* = @as([*]u8, @ptrCast(@constCast(&empty_buffer)));
+            len_out.* = 0;
+            return true;
+        } else if (err == Database.Error.CodeNotFound) {
+            // For accounts with no code, return empty code (success with len=0)
+            code_out.* = @as([*]u8, @ptrCast(@constCast(&empty_buffer)));
+            len_out.* = 0;
+            return true;
+        } else {
+            setError("Failed to get code: {}", .{err});
+            return false;
+        }
     };
     
-    if (code.len == 0) {
-        code_out.* = @constCast(@ptrCast(@alignCast(&empty_buffer)));
+    // Copy code if present
+    if (code.len > 0) {
+        const code_copy = alloc.alloc(u8, code.len) catch {
+            setError("Failed to allocate code buffer", .{});
+            return false;
+        };
+        @memcpy(code_copy, code);
+        code_out.* = code_copy.ptr;
+        len_out.* = @intCast(code_copy.len);
+    } else {
+        code_out.* = @as([*]u8, @ptrCast(@constCast(&empty_buffer)));
         len_out.* = 0;
-        return true;
     }
     
-    const code_copy = alloc.alloc(u8, code.len) catch {
-        setError("Failed to allocate code buffer", .{});
-        return false;
-    };
-    @memcpy(code_copy, code);
-    
-    code_out.* = code_copy.ptr;
-    len_out.* = code_copy.len;
     return true;
 }
 
@@ -846,9 +1130,69 @@ export fn guillotine_get_last_error() [*:0]const u8 {
     return @ptrCast(&last_error_z);
 }
 
-// Simulate a call (same as call but doesn't modify state)
+// Simulate a call (doesn't commit state)
 export fn guillotine_simulate(handle: *EvmHandle, params: *const CallParams) ?*EvmResult {
-    // For now, just call the regular call function
-    // TODO: Implement proper simulation that doesn't modify state
-    return guillotine_call(handle, params);
+    const evm_ptr: *DefaultEvm = @ptrCast(@alignCast(handle));
+    const alloc = ffi_allocator orelse {
+        setError("FFI not initialized", .{});
+        return null;
+    };
+    
+    // Convert parameters
+    const value = std.mem.readInt(u256, &params.value, .big);
+    const salt = std.mem.readInt(u256, &params.salt, .big);
+    const input = if (params.input_len > 0) params.input[0..params.input_len] else &[_]u8{};
+    
+    // Create appropriate call params based on type
+    const call_params = switch (params.call_type) {
+        0 => evm.CallParams{ .call = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        1 => evm.CallParams{ .callcode = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .value = value,
+            .input = input,
+            .gas = params.gas,
+        }},
+        2 => evm.CallParams{ .delegatecall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        3 => evm.CallParams{ .staticcall = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .to = primitives.Address{ .bytes = params.to },
+            .input = input,
+            .gas = params.gas,
+        }},
+        4 => evm.CallParams{ .create = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .value = value,
+            .init_code = input,
+            .gas = params.gas,
+        }},
+        5 => evm.CallParams{ .create2 = .{
+            .caller = primitives.Address{ .bytes = params.caller },
+            .value = value,
+            .init_code = input,
+            .salt = salt,
+            .gas = params.gas,
+        }},
+        else => {
+            setError("Invalid call type: {}", .{params.call_type});
+            return null;
+        },
+    };
+    
+    // Simulate the call (doesn't modify state)
+    const result = evm_ptr.simulate(call_params);
+    
+    // Convert result to FFI format
+    return convertCallResultToEvmResult(result, alloc);
 }


### PR DESCRIPTION
## Description
Refactor WASM build system to simplify the module structure and improve the C API for WebAssembly. This PR:

1. Restructures the WASM build to use a single output file (`guillotine.wasm`) instead of multiple modules
2. Updates the C API in `evm_c.zig` to be WASM-compatible with proper FFI support; it mirrors all functionality in `evm_c_api.zig`, including pooling, only exceptions are:
  - no mutex or thread-local storage since WASM is single-threaded
  - uses page_allocator instead of c_allocator
4. Adds stubs for KZG operations in WASM builds since they're not supported
5. Updates `.gitignore` to only ignore build directories within SDKs
6. Fixes string escaping in WASM size reporting script

The new WASM API provides a more comprehensive interface with proper memory management and error handling for JavaScript/TypeScript bindings.

## Type of Change
- ♻️ Code refactoring
- 🔧 Build/CI/tooling changes

## Testing
- [x] `zig build wasm` completes successfully
- [x] WASM output can be properly imported in JavaScript

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I understand and take responsibility for all code in this PR