### PR TITLE
fix: remove redundant self-transfer check in balance transfers

### DIFF
--- a/src/evm.zig
+++ b/src/evm.zig
@@ -245,8 +245,6 @@ pub fn Evm(comptime config: EvmConfig) type {
             try self.journal.record_balance_change(snapshot_id, from, from_account.balance);
             try self.journal.record_balance_change(snapshot_id, to, to_account.balance);
 
-            if (std.mem.eql(u8, &from.bytes, &to.bytes)) return;
-
             from_account.balance -= value;
             to_account.balance += value;
             try self.database.set_account(from.bytes, from_account);


### PR DESCRIPTION
## Description
Remove redundant early return when transferring value between the same account.

```zig
        fn transferWithBalanceChecks(self: *Self, from: primitives.Address, to: primitives.Address, value: u256, snapshot_id: Journal.SnapshotIdType) !void {
            var from_account = try self.database.get_account(from.bytes) orelse Account.zero();
            if (comptime !config.disable_balance_checks) {
                if (from_account.balance < value) return error.InsufficientBalance;
            }
            if (from.equals(to)) return; // here
            var to_account = try self.database.get_account(to.bytes) orelse Account.zero();
            try self.journal.record_balance_change(snapshot_id, from, from_account.balance);
            try self.journal.record_balance_change(snapshot_id, to, to_account.balance);

            if (std.mem.eql(u8, &from.bytes, &to.bytes)) return; // here again

            from_account.balance -= value;
            to_account.balance += value;
            try self.database.set_account(from.bytes, from_account);
            try self.database.set_account(to.bytes, to_account);
        }
```