### PR TITLE
fix: correct stack operand order in EXP, LT, GT, SLT, SGT opcodes

### DIFF
--- a/src/instructions/handlers_arithmetic.zig
+++ b/src/instructions/handlers_arithmetic.zig
@@ -288,11 +288,10 @@ pub fn Handlers(comptime FrameType: type) type {
 
         /// EXP opcode (0x0a) - Exponential operation.
         pub fn exp(self: *FrameType, cursor: [*]const Dispatch.Item) Error!noreturn {
-            // EVM stack ordering: first pop is exponent, second pop is base
-            // Computing base^exponent where base is second on stack
+            // Pop base (top), then exponent (second); compute base^exponent
             self.beforeInstruction(.EXP, cursor);
-            const exponent = self.stack.pop_unsafe(); // Top of stack (exponent)
-            const base = self.stack.peek_unsafe(); // Below top (base)
+            const base = self.stack.pop_unsafe(); // Top of stack (base)
+            const exponent = self.stack.peek_unsafe(); // Below top (exponent)
 
             // EIP-160: Dynamic gas cost for EXP
             // Gas cost = 10 + 50 * (number of non-zero bytes in exponent)

--- a/src/instructions/handlers_comparison.zig
+++ b/src/instructions/handlers_comparison.zig
@@ -21,10 +21,10 @@ pub fn Handlers(comptime FrameType: type) type {
         /// LT opcode (0x10) - Less than comparison.
         pub fn lt(self: *FrameType, cursor: [*]const Dispatch.Item) Error!noreturn {
             self.beforeInstruction(.LT, cursor);
-            // EVM: pops top, then second; pushes (second < top)
+            // EVM: pops a (top), then b (second); pushes (a < b)
             self.stack.binary_op_unsafe(struct {
                 fn op(top: WordType, second: WordType) WordType {
-                    return @intFromBool(second < top);
+                    return @intFromBool(top < second);
                 }
             }.op);
             return next_instruction(self, cursor, .LT);
@@ -33,10 +33,10 @@ pub fn Handlers(comptime FrameType: type) type {
         /// GT opcode (0x11) - Greater than comparison.
         pub fn gt(self: *FrameType, cursor: [*]const Dispatch.Item) Error!noreturn {
             self.beforeInstruction(.GT, cursor);
-            // EVM: pops top, then second; pushes (second > top)
+            // EVM: pops a (top), then b (second); pushes (a > b)
             self.stack.binary_op_unsafe(struct {
                 fn op(top: WordType, second: WordType) WordType {
-                    return @intFromBool(second > top);
+                    return @intFromBool(top > second);
                 }
             }.op);
             return next_instruction(self, cursor, .GT);
@@ -49,8 +49,8 @@ pub fn Handlers(comptime FrameType: type) type {
             const b = self.stack.peek_unsafe(); // Second from top (first pushed value)
             const a_signed = @as(std.meta.Int(.signed, @bitSizeOf(WordType)), @bitCast(a));
             const b_signed = @as(std.meta.Int(.signed, @bitSizeOf(WordType)), @bitCast(b));
-            // EVM: pops a (top), then b; pushes (b < a) with signed comparison
-            const result: WordType = @intFromBool(b_signed < a_signed);
+            // EVM: pops a (top), then b; pushes (a < b) with signed comparison
+            const result: WordType = @intFromBool(a_signed < b_signed);
             self.stack.set_top_unsafe(result);
             return next_instruction(self, cursor, .SLT);
         }
@@ -62,8 +62,8 @@ pub fn Handlers(comptime FrameType: type) type {
             const b = self.stack.peek_unsafe(); // Second from top (first pushed value)
             const a_signed = @as(std.meta.Int(.signed, @bitSizeOf(WordType)), @bitCast(a));
             const b_signed = @as(std.meta.Int(.signed, @bitSizeOf(WordType)), @bitCast(b));
-            // EVM: pops a (top), then b; pushes (b > a) with signed comparison
-            const result: WordType = @intFromBool(b_signed > a_signed);
+            // EVM: pops a (top), then b; pushes (a > b) with signed comparison
+            const result: WordType = @intFromBool(a_signed > b_signed);
             self.stack.set_top_unsafe(result);
             return next_instruction(self, cursor, .SGT);
         }

--- a/test/evm/opcodes/0a_test.zig
+++ b/test/evm/opcodes/0a_test.zig
@@ -4,20 +4,20 @@ const primitives = @import("primitives");
 const common = @import("common.zig");
 
 test "EXP: basic (2 ^ 3 = 8)" {
-    try run_exp_test(std.testing.allocator, 2, 3);
+    try run_exp_test(std.testing.allocator, 2, 3, 8); // 2 ^ 3 = 8
 }
 
-fn run_exp_test(allocator: std.mem.Allocator, base: u256, exponent: u256) !void {
+fn run_exp_test(allocator: std.mem.Allocator, base: u256, exponent: u256, expected: u256) !void {
     // Build custom bytecode for EXP test
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     
-    // Push base
-    if (base == 0) {
+    // Push exponent first (will be second from top)
+    if (exponent == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, base, .big);
+        std.mem.writeInt(u256, &tmp, exponent, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -27,12 +27,12 @@ fn run_exp_test(allocator: std.mem.Allocator, base: u256, exponent: u256) !void 
         }
     }
     
-    // Push exponent
-    if (exponent == 0) {
+    // Push base second (will be on top)
+    if (base == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, exponent, .big);
+        std.mem.writeInt(u256, &tmp, base, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -123,137 +123,172 @@ fn run_exp_test(allocator: std.mem.Allocator, base: u256, exponent: u256) !void 
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // Verify the result
+    // The bytecode pushes exponent, then base, so stack is [base, exponent] with base on top
+    // EXP pops base (first), then exponent (second), and computes base ^ exponent
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 test "EXP: zero to any power (0 ^ 100 = 0)" {
-    try run_exp_test(std.testing.allocator, 0, 100);
+    try run_exp_test(std.testing.allocator, 0, 100, 0); // 0 ^ 100 = 0
 }
 
 test "EXP: zero to zero power (0 ^ 0 = 1)" {
-    try run_exp_test(std.testing.allocator, 0, 0);
+    try run_exp_test(std.testing.allocator, 0, 0, 1); // 0 ^ 0 = 1
 }
 
 test "EXP: any to zero power (100 ^ 0 = 1)" {
-    try run_exp_test(std.testing.allocator, 100, 0);
+    try run_exp_test(std.testing.allocator, 100, 0, 1); // 100 ^ 0 = 1
 }
 
 test "EXP: one to any power (1 ^ 100 = 1)" {
-    try run_exp_test(std.testing.allocator, 1, 100);
+    try run_exp_test(std.testing.allocator, 1, 100, 1); // 1 ^ 100 = 1
 }
 
 test "EXP: any to one power (123 ^ 1 = 123)" {
-    try run_exp_test(std.testing.allocator, 123, 1);
+    try run_exp_test(std.testing.allocator, 123, 1, 123); // 123 ^ 1 = 123
 }
 
 test "EXP: powers of two (2 ^ 8 = 256)" {
-    try run_exp_test(std.testing.allocator, 2, 8);
+    try run_exp_test(std.testing.allocator, 2, 8, 256); // 2 ^ 8 = 256
 }
 
 test "EXP: square (10 ^ 2 = 100)" {
-    try run_exp_test(std.testing.allocator, 10, 2);
+    try run_exp_test(std.testing.allocator, 10, 2, 100); // 10 ^ 2 = 100
 }
 
 test "EXP: cube (5 ^ 3 = 125)" {
-    try run_exp_test(std.testing.allocator, 5, 3);
+    try run_exp_test(std.testing.allocator, 5, 3, 125); // 5 ^ 3 = 125
 }
 
 test "EXP: large base small exp (1000 ^ 2 = 1000000)" {
-    try run_exp_test(std.testing.allocator, 1000, 2);
+    try run_exp_test(std.testing.allocator, 1000, 2, 1000000); // 1000 ^ 2 = 1000000
 }
 
 test "EXP: power of 2 base (256 ^ 2 = 65536)" {
-    try run_exp_test(std.testing.allocator, 256, 2);
+    try run_exp_test(std.testing.allocator, 256, 2, 65536); // 256 ^ 2 = 65536
 }
 
 test "EXP: 2 to the 16 (2 ^ 16 = 65536)" {
-    try run_exp_test(std.testing.allocator, 2, 16);
+    try run_exp_test(std.testing.allocator, 2, 16, 65536); // 2 ^ 16 = 65536
 }
 
 test "EXP: 2 to the 32" {
-    try run_exp_test(std.testing.allocator, 2, 32);
+    try run_exp_test(std.testing.allocator, 2, 32, 4294967296); // 2 ^ 32 = 4294967296
 }
 
 test "EXP: 2 to the 64" {
-    try run_exp_test(std.testing.allocator, 2, 64);
+    try run_exp_test(std.testing.allocator, 2, 64, 18446744073709551616); // 2 ^ 64
 }
 
 test "EXP: 2 to the 128" {
-    try run_exp_test(std.testing.allocator, 2, 128);
+    try run_exp_test(std.testing.allocator, 2, 128, 340282366920938463463374607431768211456); // 2 ^ 128
 }
 
 test "EXP: 2 to the 255 (near max bit position)" {
-    try run_exp_test(std.testing.allocator, 2, 255);
+    try run_exp_test(std.testing.allocator, 2, 255, 57896044618658097711785492504343953926634992332820282019728792003956564819968); // 2 ^ 255
 }
 
 test "EXP: 2 to the 256 (overflows to 0)" {
-    try run_exp_test(std.testing.allocator, 2, 256);
+    try run_exp_test(std.testing.allocator, 2, 256, 0); // 2 ^ 256 overflows to 0
 }
 
 test "EXP: 3 to small powers" {
-    try run_exp_test(std.testing.allocator, 3, 5);
+    try run_exp_test(std.testing.allocator, 3, 5, 243); // 3 ^ 5 = 243
 }
 
 test "EXP: 10 to the 10" {
-    try run_exp_test(std.testing.allocator, 10, 10);
+    try run_exp_test(std.testing.allocator, 10, 10, 10000000000); // 10 ^ 10
 }
 
 test "EXP: 10 to the 18 (wei to ether)" {
-    try run_exp_test(std.testing.allocator, 10, 18);
+    try run_exp_test(std.testing.allocator, 10, 18, 1000000000000000000); // 10 ^ 18
 }
 
 test "EXP: overflow with large base and exp" {
-    try run_exp_test(std.testing.allocator, 999, 999);
+    // 999^999 overflows, resulting in wrapped value
+    // The exact result depends on overflow behavior, use computed value 
+    const expected = comptime blk: {
+        var result: u256 = 1;
+        var b: u256 = 999;
+        var e: u256 = 999;
+        while (e > 0) : (e >>= 1) {
+            if (e & 1 == 1) {
+                result *%= b;
+            }
+            b *%= b;
+        }
+        break :blk result;
+    };
+    try run_exp_test(std.testing.allocator, 999, 999, expected);
 }
 
 test "EXP: near u64 max base" {
     const near_u64 = @as(u256, std.math.maxInt(u64)) - 10;
-    try run_exp_test(std.testing.allocator, near_u64, 2);
+    // (2^64 - 11)^2 = overflows
+    const expected = near_u64 *% near_u64;
+    try run_exp_test(std.testing.allocator, near_u64, 2, expected);
 }
 
 test "EXP: MAX base with exp 1" {
-    try run_exp_test(std.testing.allocator, std.math.maxInt(u256), 1);
+    try run_exp_test(std.testing.allocator, std.math.maxInt(u256), 1, std.math.maxInt(u256)); // MAX ^ 1 = MAX
 }
 
 test "EXP: MAX base with exp 2 (overflow)" {
-    try run_exp_test(std.testing.allocator, std.math.maxInt(u256), 2);
+    // MAX_U256^2 overflows, result wraps to 1
+    const max_val = std.math.maxInt(u256);
+    const expected: u256 = 1; // MAX^2 wraps to 1 in modular arithmetic
+    try run_exp_test(std.testing.allocator, max_val, 2, expected);
 }
 
 test "EXP: alternating bit pattern" {
     const pattern = 0xAAAAAAAAAAAAAAAA;
-    try run_exp_test(std.testing.allocator, pattern, 2);
+    const expected = pattern *% pattern;
+    try run_exp_test(std.testing.allocator, pattern, 2, expected);
 }
 
 test "EXP: prime number powers" {
-    try run_exp_test(std.testing.allocator, 13, 7);
+    try run_exp_test(std.testing.allocator, 13, 7, 62748517); // 13 ^ 7 = 62748517
 }
 
 test "EXP: fibonacci base and exp" {
-    try run_exp_test(std.testing.allocator, 13, 8);
+    try run_exp_test(std.testing.allocator, 13, 8, 815730721); // 13 ^ 8 = 815730721
 }
 
 test "EXP: large exponent causing overflow" {
-    try run_exp_test(std.testing.allocator, 2, 257);
+    try run_exp_test(std.testing.allocator, 2, 257, 0); // 2 ^ 257 overflows to 0
 }
 
 test "EXP: edge case 255 ^ 2" {
-    try run_exp_test(std.testing.allocator, 255, 2);
+    try run_exp_test(std.testing.allocator, 255, 2, 65025); // 255 ^ 2 = 65025
 }
 
 test "EXP: edge case 256 ^ 3" {
-    try run_exp_test(std.testing.allocator, 256, 3);
+    try run_exp_test(std.testing.allocator, 256, 3, 16777216); // 256 ^ 3 = 16777216
 }
 
-fn run_exp_test_with_jump(allocator: std.mem.Allocator, base: u256, exponent: u256) !void {
+fn run_exp_test_with_jump(allocator: std.mem.Allocator, base: u256, exponent: u256, expected: u256) !void {
     // Build custom bytecode for EXP test with jump to prevent fusion
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     
-    // Push base
-    if (base == 0) {
+    // Push exponent first (will be second from top)
+    if (exponent == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, base, .big);
+        std.mem.writeInt(u256, &tmp, exponent, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -263,12 +298,12 @@ fn run_exp_test_with_jump(allocator: std.mem.Allocator, base: u256, exponent: u2
         }
     }
     
-    // Push exponent
-    if (exponent == 0) {
+    // Push base second (will be on top)
+    if (base == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, exponent, .big);
+        std.mem.writeInt(u256, &tmp, base, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -368,24 +403,38 @@ fn run_exp_test_with_jump(allocator: std.mem.Allocator, base: u256, exponent: u2
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 test "EXP with JUMP: basic (2 ^ 3 = 8)" {
-    try run_exp_test_with_jump(std.testing.allocator, 2, 3);
+    try run_exp_test_with_jump(std.testing.allocator, 2, 3, 8); // 2 ^ 3 = 8
 }
 
 test "EXP with JUMP: zero to zero (0 ^ 0 = 1)" {
-    try run_exp_test_with_jump(std.testing.allocator, 0, 0);
+    try run_exp_test_with_jump(std.testing.allocator, 0, 0, 1); // 0 ^ 0 = 1
 }
 
 test "EXP with JUMP: large power of 2" {
-    try run_exp_test_with_jump(std.testing.allocator, 2, 100);
+    try run_exp_test_with_jump(std.testing.allocator, 2, 100, 1267650600228229401496703205376); // 2 ^ 100
 }
 
 test "EXP with JUMP: overflow case" {
-    try run_exp_test_with_jump(std.testing.allocator, std.math.maxInt(u256), 3);
+    // MAX_U256^3 overflows, wraps to MAX
+    const max = std.math.maxInt(u256);
+    const expected: u256 = max; // MAX^3 = MAX^2 * MAX = 1 * MAX = MAX
+    try run_exp_test_with_jump(std.testing.allocator, max, 3, expected);
 }
 
 test "EXP with JUMP: 10 to the 18" {
-    try run_exp_test_with_jump(std.testing.allocator, 10, 18);
+    try run_exp_test_with_jump(std.testing.allocator, 10, 18, 1000000000000000000); // 10 ^ 18
 }

--- a/test/evm/opcodes/11_test.zig
+++ b/test/evm/opcodes/11_test.zig
@@ -4,20 +4,20 @@ const primitives = @import("primitives");
 const common = @import("common.zig");
 
 test "GT: basic (10 > 5 = 1)" {
-    try run_gt_test(std.testing.allocator, 10, 5);
+    try run_gt_test(std.testing.allocator, 10, 5, 1);
 }
 
-fn run_gt_test(allocator: std.mem.Allocator, a: u256, b: u256) !void {
+fn run_gt_test(allocator: std.mem.Allocator, a: u256, b: u256, expected: u256) !void {
     // Build custom bytecode for GT test
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     
-    // Push a
-    if (a == 0) {
+    // Push b first (will be second from top)
+    if (b == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, a, .big);
+        std.mem.writeInt(u256, &tmp, b, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -27,12 +27,12 @@ fn run_gt_test(allocator: std.mem.Allocator, a: u256, b: u256) !void {
         }
     }
     
-    // Push b
-    if (b == 0) {
+    // Push a second (will be on top)
+    if (a == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, b, .big);
+        std.mem.writeInt(u256, &tmp, a, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -123,119 +123,134 @@ fn run_gt_test(allocator: std.mem.Allocator, a: u256, b: u256) !void {
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // Verify the result
+    // The bytecode pushes b, then a, so stack is [a, b] with a on top
+    // GT pops a (first), then b (second), and computes a > b
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 test "GT: equal values (10 > 10 = 0)" {
-    try run_gt_test(std.testing.allocator, 10, 10);
+    try run_gt_test(std.testing.allocator, 10, 10, 0);
 }
 
 test "GT: less than (5 > 10 = 0)" {
-    try run_gt_test(std.testing.allocator, 5, 10);
+    try run_gt_test(std.testing.allocator, 5, 10, 0);
 }
 
 test "GT: zero comparison (1 > 0 = 1)" {
-    try run_gt_test(std.testing.allocator, 1, 0);
+    try run_gt_test(std.testing.allocator, 1, 0, 1);
 }
 
 test "GT: zero comparison reversed (0 > 1 = 0)" {
-    try run_gt_test(std.testing.allocator, 0, 1);
+    try run_gt_test(std.testing.allocator, 0, 1, 0);
 }
 
 test "GT: both zero (0 > 0 = 0)" {
-    try run_gt_test(std.testing.allocator, 0, 0);
+    try run_gt_test(std.testing.allocator, 0, 0, 0);
 }
 
 test "GT: large numbers" {
-    try run_gt_test(std.testing.allocator, 1000000, 999999);
+    try run_gt_test(std.testing.allocator, 1000000, 999999, 1);
 }
 
 test "GT: near u64 boundary" {
     const u64_max = @as(u256, std.math.maxInt(u64));
-    try run_gt_test(std.testing.allocator, u64_max, u64_max - 10);
+    try run_gt_test(std.testing.allocator, u64_max, u64_max - 10, 1);
 }
 
 test "GT: exactly u64 max" {
     const u64_max = @as(u256, std.math.maxInt(u64));
-    try run_gt_test(std.testing.allocator, u64_max + 1, u64_max);
+    try run_gt_test(std.testing.allocator, u64_max + 1, u64_max, 1);
 }
 
 test "GT: large 128-bit numbers" {
     const large_128 = @as(u256, 1) << 120;
-    try run_gt_test(std.testing.allocator, large_128 + 1, large_128);
+    try run_gt_test(std.testing.allocator, large_128 + 1, large_128, 1);
 }
 
 test "GT: MAX_U256 comparisons" {
-    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1);
+    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1, 1);
 }
 
 test "GT: MAX_U256 with self" {
-    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256));
+    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256), 0);
 }
 
 test "GT: MAX and zero" {
-    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), 0);
+    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), 0, 1);
 }
 
 test "GT: zero and MAX" {
-    try run_gt_test(std.testing.allocator, 0, std.math.maxInt(u256));
+    try run_gt_test(std.testing.allocator, 0, std.math.maxInt(u256), 0);
 }
 
 test "GT: consecutive numbers" {
-    try run_gt_test(std.testing.allocator, 12346, 12345);
+    try run_gt_test(std.testing.allocator, 12346, 12345, 1);
 }
 
 test "GT: powers of 2" {
-    try run_gt_test(std.testing.allocator, 512, 256);
+    try run_gt_test(std.testing.allocator, 512, 256, 1);
 }
 
 test "GT: near 256-bit boundary" {
-    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1000);
+    try run_gt_test(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1000, 1);
 }
 
 test "GT: alternating bit patterns" {
     const pattern1 = 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
     const pattern2 = 0x5555555555555555555555555555555555555555555555555555555555555555;
-    try run_gt_test(std.testing.allocator, pattern1, pattern2);
+    try run_gt_test(std.testing.allocator, pattern1, pattern2, 1);
 }
 
 test "GT: all ones pattern" {
     const all_ones_128 = (@as(u256, 1) << 128) - 1;
-    try run_gt_test(std.testing.allocator, (@as(u256, 1) << 128), all_ones_128);
+    try run_gt_test(std.testing.allocator, (@as(u256, 1) << 128), all_ones_128, 1);
 }
 
 test "GT: fibonacci numbers" {
-    try run_gt_test(std.testing.allocator, 21, 13);
+    try run_gt_test(std.testing.allocator, 21, 13, 1);
 }
 
 test "GT: prime numbers" {
-    try run_gt_test(std.testing.allocator, 1009, 997);
+    try run_gt_test(std.testing.allocator, 1009, 997, 1);
 }
 
 test "GT: edge case near middle" {
     const mid = @as(u256, 1) << 128;
-    try run_gt_test(std.testing.allocator, mid, mid - 1);
+    try run_gt_test(std.testing.allocator, mid, mid - 1, 1);
 }
 
 test "GT: very large difference" {
-    try run_gt_test(std.testing.allocator, @as(u256, 1) << 255, 1);
+    try run_gt_test(std.testing.allocator, @as(u256, 1) << 255, 1, 1);
 }
 
 test "GT: one apart at boundary" {
     const boundary = @as(u256, 1) << 64;
-    try run_gt_test(std.testing.allocator, boundary, boundary - 1);
+    try run_gt_test(std.testing.allocator, boundary, boundary - 1, 1);
 }
 
-fn run_gt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256) !void {
+fn run_gt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256, expected: u256) !void {
     // Build custom bytecode for GT test with jump to prevent fusion
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     
-    // Push a
-    if (a == 0) {
+    // Push b first (will be second from top)
+    if (b == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, a, .big);
+        std.mem.writeInt(u256, &tmp, b, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -245,12 +260,12 @@ fn run_gt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256) !void {
         }
     }
     
-    // Push b
-    if (b == 0) {
+    // Push a second (will be on top)
+    if (a == 0) {
         try buf.append(allocator, 0x5f); // PUSH0
     } else {
         var tmp: [32]u8 = [_]u8{0} ** 32;
-        std.mem.writeInt(u256, &tmp, b, .big);
+        std.mem.writeInt(u256, &tmp, a, .big);
         const first_non_zero = std.mem.indexOfNonePos(u8, &tmp, 0, &[_]u8{0}) orelse 32;
         const slice = tmp[first_non_zero..];
         if (slice.len > 0 and slice.len <= 32) {
@@ -350,25 +365,40 @@ fn run_gt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256) !void {
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // Verify the result
+    // The bytecode pushes b, then a, so stack is [a, b] with a on top
+    // GT pops a (first), then b (second), and computes a > b
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 test "GT with JUMP: basic (10 > 5 = 1)" {
-    try run_gt_test_with_jump(std.testing.allocator, 10, 5);
+    try run_gt_test_with_jump(std.testing.allocator, 10, 5, 1); // 10 > 5 = true
 }
 
 test "GT with JUMP: equal values (100 > 100 = 0)" {
-    try run_gt_test_with_jump(std.testing.allocator, 100, 100);
+    try run_gt_test_with_jump(std.testing.allocator, 100, 100, 0); // 100 > 100 = false
 }
 
 test "GT with JUMP: large numbers" {
-    try run_gt_test_with_jump(std.testing.allocator, 2000000, 1000000);
+    try run_gt_test_with_jump(std.testing.allocator, 2000000, 1000000, 1); // 2000000 > 1000000 = true
 }
 
 test "GT with JUMP: MAX comparison" {
-    try run_gt_test_with_jump(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1);
+    try run_gt_test_with_jump(std.testing.allocator, std.math.maxInt(u256), std.math.maxInt(u256) - 1, 1); // MAX > (MAX - 1) = true
 }
 
 test "GT with JUMP: near u64 boundary" {
     const u64_max = @as(u256, std.math.maxInt(u64));
-    try run_gt_test_with_jump(std.testing.allocator, u64_max, u64_max - 10);
+    try run_gt_test_with_jump(std.testing.allocator, u64_max, u64_max - 10, 1); // u64_max > (u64_max - 10) = true
 }

--- a/test/evm/opcodes/13_test.zig
+++ b/test/evm/opcodes/13_test.zig
@@ -4,25 +4,34 @@ const primitives = @import("primitives");
 const common = @import("common.zig");
 
 fn run_sgt_test(allocator: std.mem.Allocator, a: u256, b: u256, expected: u256) !void {
-    _ = expected; // TODO: Use when stack comparison is re-enabled
-    // Build bytecode: PUSH a, PUSH b, SGT
+    // Build bytecode: PUSH b, PUSH a, SGT
     var bytecode = try std.ArrayList(u8).initCapacity(allocator, 0);
     defer bytecode.deinit(allocator);
     
-    // PUSH a
-    try bytecode.append(allocator, 0x7f); // PUSH32
-    var a_bytes: [32]u8 = undefined;
-    std.mem.writeInt(u256, &a_bytes, a, .big);
-    try bytecode.appendSlice(allocator, &a_bytes);
-    
-    // PUSH b
+    // PUSH b first (will be second from top)
     try bytecode.append(allocator, 0x7f); // PUSH32
     var b_bytes: [32]u8 = undefined;
     std.mem.writeInt(u256, &b_bytes, b, .big);
     try bytecode.appendSlice(allocator, &b_bytes);
     
+    // PUSH a second (will be on top)
+    try bytecode.append(allocator, 0x7f); // PUSH32
+    var a_bytes: [32]u8 = undefined;
+    std.mem.writeInt(u256, &a_bytes, a, .big);
+    try bytecode.appendSlice(allocator, &a_bytes);
+    
     // SGT
     try bytecode.append(allocator, 0x13);
+    
+    // Store result and return
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x00); // 0 (memory offset)
+    try bytecode.append(allocator, 0x52); // MSTORE
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x20); // 32 (length)
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x00); // 0 (offset)
+    try bytecode.append(allocator, 0xf3); // RETURN
     
     // Setup Guillotine EVM
     var database = evm.Database.init(allocator);
@@ -89,25 +98,39 @@ fn run_sgt_test(allocator: std.mem.Allocator, a: u256, b: u256, expected: u256) 
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // Verify the result
+    // The bytecode pushes b, then a, so stack is [a, b] with a on top
+    // SGT pops a (first), then b (second), and computes a > b (signed comparison)
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 fn run_sgt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256, expected: u256) !void {
-    _ = expected; // TODO: Use when stack comparison is re-enabled
-    // Build bytecode with JUMP to prevent opcode fusion: PUSH a, PUSH b, PUSH dest, JUMP, JUMPDEST, SGT
+    // Build bytecode with JUMP to prevent opcode fusion: PUSH b, PUSH a, PUSH dest, JUMP, JUMPDEST, SGT
     var bytecode = try std.ArrayList(u8).initCapacity(allocator, 0);
     defer bytecode.deinit(allocator);
     
-    // PUSH a
-    try bytecode.append(allocator, 0x7f); // PUSH32
-    var a_bytes: [32]u8 = undefined;
-    std.mem.writeInt(u256, &a_bytes, a, .big);
-    try bytecode.appendSlice(allocator, &a_bytes);
-    
-    // PUSH b
+    // PUSH b first (will be second from top)
     try bytecode.append(allocator, 0x7f); // PUSH32
     var b_bytes: [32]u8 = undefined;
     std.mem.writeInt(u256, &b_bytes, b, .big);
     try bytecode.appendSlice(allocator, &b_bytes);
+    
+    // PUSH a second (will be on top)
+    try bytecode.append(allocator, 0x7f); // PUSH32
+    var a_bytes: [32]u8 = undefined;
+    std.mem.writeInt(u256, &a_bytes, a, .big);
+    try bytecode.appendSlice(allocator, &a_bytes);
     
     // PUSH destination (position after JUMP: 32 + 1 + 32 + 1 + 1 + 1 + 1 = 69)
     try bytecode.append(allocator, 0x60); // PUSH1
@@ -121,6 +144,16 @@ fn run_sgt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256, expect
     
     // SGT
     try bytecode.append(allocator, 0x13);
+    
+    // Store result and return
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x00); // 0 (memory offset)
+    try bytecode.append(allocator, 0x52); // MSTORE
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x20); // 32 (length)
+    try bytecode.append(allocator, 0x60); // PUSH1
+    try bytecode.append(allocator, 0x00); // 0 (offset)
+    try bytecode.append(allocator, 0xf3); // RETURN
     
     // Setup and execute (same as regular test)
     var database = evm.Database.init(allocator);
@@ -187,6 +220,21 @@ fn run_sgt_test_with_jump(allocator: std.mem.Allocator, a: u256, b: u256, expect
     
     var guillotine_result = guillotine_evm.call(call_params);
     defer guillotine_result.deinit(allocator);
+    
+    // Verify the result
+    // The bytecode pushes b, then a, so stack is [a, b] with a on top
+    // SGT pops a (first), then b (second), and computes a > b (signed comparison)
+    
+    // The result should be 32 bytes with the value at the end
+    try std.testing.expect(guillotine_result.output.len == 32);
+    
+    // Convert output bytes to u256 (big-endian)
+    var result_value: u256 = 0;
+    for (guillotine_result.output) |byte| {
+        result_value = (result_value << 8) | byte;
+    }
+    
+    try std.testing.expectEqual(expected, result_value);
 }
 
 test "SGT: basic positive numbers" {


### PR DESCRIPTION
## Description
- Fix stack operand ordering in these opcode handlers, which was reversed 3-4 days ago
- Fix test assumptions for these handlers to push `b`, then `a` so we can expect `a <op> b`
- Actually test assumptions (we were never asserting)

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test additions or updates

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass
- [x] Added new tests for changes (if applicable)

## Related Issues
Fixes #