### PR TITLE
feat: update BLS12-381 precompile addresses and implement MSM operations

### DIFF
--- a/src/precompiles/precompiles.zig
+++ b/src/precompiles/precompiles.zig
@@ -17,6 +17,7 @@
 const std = @import("std");
 const primitives = @import("primitives");
 const Address = primitives.Address;
+const GasConstants = primitives.GasConstants;
 // Use the real crypto and build_options modules
 const crypto = @import("crypto");
 const build_options = @import("build_options");
@@ -35,13 +36,12 @@ pub const POINT_EVALUATION_ADDRESS = primitives.Address.from_u256(10);
 
 /// BLS12-381 precompile addresses (EIP-2537)
 pub const BLS12_381_G1_ADD_ADDRESS = primitives.Address.from_u256(0x0B);
-pub const BLS12_381_G1_MUL_ADDRESS = primitives.Address.from_u256(0x0C);
-pub const BLS12_381_G1_MULTIEXP_ADDRESS = primitives.Address.from_u256(0x0D);
-pub const BLS12_381_G2_ADD_ADDRESS = primitives.Address.from_u256(0x0E);
-pub const BLS12_381_G2_MUL_ADDRESS = primitives.Address.from_u256(0x0F);
-pub const BLS12_381_G2_MULTIEXP_ADDRESS = primitives.Address.from_u256(0x10);
-pub const BLS12_381_PAIRING_ADDRESS = primitives.Address.from_u256(0x11);
-pub const BLS12_381_MAP_FP_TO_G1_ADDRESS = primitives.Address.from_u256(0x12);
+pub const BLS12_381_G1_MSM_ADDRESS = primitives.Address.from_u256(0x0C);
+pub const BLS12_381_G2_ADD_ADDRESS = primitives.Address.from_u256(0x0D);
+pub const BLS12_381_G2_MSM_ADDRESS = primitives.Address.from_u256(0x0E);
+pub const BLS12_381_PAIRING_ADDRESS = primitives.Address.from_u256(0x0F);
+pub const BLS12_381_MAP_FP_TO_G1_ADDRESS = primitives.Address.from_u256(0x10);
+pub const BLS12_381_MAP_FP2_TO_G2_ADDRESS = primitives.Address.from_u256(0x11);
 
 /// Precompile error types
 pub const PrecompileError = error{
@@ -73,14 +73,14 @@ pub fn is_precompile(address: Address) bool {
     // Check if the address is one of the known precompile addresses
     // Precompiles are at addresses:
     // 0x01-0x0A: Standard precompiles (ECRECOVER through POINT_EVALUATION)
-    // 0x0B-0x12: BLS12-381 precompiles (EIP-2537)
+    // 0x0B-0x13: BLS12-381 precompiles (EIP-2537)
     
     // Check if all bytes except the last one are zero
     for (address.bytes[0..19]) |byte| {
         if (byte != 0) return false;
     }
-    // Check if the last byte is between 1 and 18 (0x12)
-    return address.bytes[19] >= 1 and address.bytes[19] <= 0x12;
+    // Check if the last byte is between 1 and 0x11 (17)
+    return address.bytes[19] >= 1 and address.bytes[19] <= 0x11;
 }
 
 /// Execute a precompile based on its address
@@ -105,13 +105,12 @@ pub fn execute_precompile(
         9 => execute_blake2f(allocator, input, gas_limit),
         10 => execute_point_evaluation(allocator, input, gas_limit),
         0x0B => execute_bls12_381_g1_add(allocator, input, gas_limit),
-        0x0C => execute_bls12_381_g1_mul(allocator, input, gas_limit),
-        0x0D => execute_bls12_381_g1_multiexp(allocator, input, gas_limit),
-        0x0E => execute_bls12_381_g2_add(allocator, input, gas_limit),
-        0x0F => execute_bls12_381_g2_mul(allocator, input, gas_limit),
-        0x10 => execute_bls12_381_g2_multiexp(allocator, input, gas_limit),
-        0x11 => execute_bls12_381_pairing(allocator, input, gas_limit),
-        0x12 => execute_bls12_381_map_fp_to_g1(allocator, input, gas_limit),
+        0x0C => execute_bls12_381_g1_msm(allocator, input, gas_limit),
+        0x0D => execute_bls12_381_g2_add(allocator, input, gas_limit),
+        0x0E => execute_bls12_381_g2_msm(allocator, input, gas_limit),
+        0x0F => execute_bls12_381_pairing(allocator, input, gas_limit),
+        0x10 => execute_bls12_381_map_fp_to_g1(allocator, input, gas_limit),
+        0x11 => execute_bls12_381_map_fp2_to_g2(allocator, input, gas_limit),
         else => PrecompileOutput{
             .output = &.{},
             .gas_used = 0,
@@ -147,6 +146,7 @@ pub const GasCosts = struct {
     pub const BLS12_381_PAIRING_BASE = 65000;
     pub const BLS12_381_PAIRING_PER_PAIR = 43000;
     pub const BLS12_381_MAP_FP_TO_G1 = 5500;
+    pub const BLS12_381_MAP_FP2_TO_G2 = 23800;
 };
 
 /// 0x01: ecRecover - ECDSA signature recovery
@@ -796,41 +796,28 @@ pub fn execute_bls12_381_g1_add(allocator: std.mem.Allocator, input: []const u8,
     };
 }
 
-/// 0x0C: BLS12-381 G1 scalar multiplication
-pub fn execute_bls12_381_g1_mul(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
-    const required_gas = GasCosts.BLS12_381_G1_MUL;
-    if (gas_limit < required_gas) {
+/// 0x0C: BLS12-381 G1 MSM (Multi-scalar multiplication)
+/// For single scalar multiplication, use with k=1 (one point-scalar pair)
+pub fn execute_bls12_381_g1_msm(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
+    const G1_MSM_INPUT_LENGTH = 160; // 128 bytes G1 + 32 bytes scalar
+    
+    // Input validation: must be multiple of 160 bytes
+    if (input.len % G1_MSM_INPUT_LENGTH != 0) {
         return PrecompileOutput{
             .output = &.{},
-            .gas_used = gas_limit,
+            .gas_used = 0,
             .success = false,
         };
     }
-
-    const output = try allocator.alloc(u8, 128);
-    errdefer allocator.free(output);
-
-    crypto.bls12_381.g1_mul(input, output) catch {
-        allocator.free(output);
-        return PrecompileOutput{
-            .output = &.{},
-            .gas_used = required_gas,
-            .success = false,
-        };
+    
+    const num_pairs = input.len / G1_MSM_INPUT_LENGTH;
+    
+    // Calculate gas using discount table
+    const required_gas = if (num_pairs == 0) 0 else blk: {
+        const discount_index = @min(num_pairs - 1, GasConstants.BLS12_381_G1_MSM_DISCOUNT.len - 1);
+        const discount = GasConstants.BLS12_381_G1_MSM_DISCOUNT[discount_index];
+        break :blk (@as(u64, num_pairs) * GasConstants.BLS12_381_G1_MSM * discount) / GasConstants.MSM_MULTIPLIER;
     };
-
-    return PrecompileOutput{
-        .output = output,
-        .gas_used = required_gas,
-        .success = true,
-    };
-}
-
-/// 0x0D: BLS12-381 G1 multi-exponentiation
-pub fn execute_bls12_381_g1_multiexp(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
-    // Dynamic gas based on number of pairs
-    const num_pairs = input.len / 160;
-    const required_gas = GasCosts.BLS12_381_G1_MULTIEXP_BASE * num_pairs;
     
     if (gas_limit < required_gas) {
         return PrecompileOutput{
@@ -839,10 +826,23 @@ pub fn execute_bls12_381_g1_multiexp(allocator: std.mem.Allocator, input: []cons
             .success = false,
         };
     }
+    
+    // Handle empty input: return point at infinity (all zeros)
+    if (num_pairs == 0) {
+        const output = try allocator.alloc(u8, 128);
+        @memset(output, 0);
+        return PrecompileOutput{
+            .output = output,
+            .gas_used = required_gas,
+            .success = true,
+        };
+    }
 
     const output = try allocator.alloc(u8, 128);
     errdefer allocator.free(output);
 
+    // Perform the multi-scalar multiplication
+    // Note: The crypto module should validate points and scalars internally
     crypto.bls12_381.g1_multiexp(input, output) catch {
         allocator.free(output);
         return PrecompileOutput{
@@ -867,19 +867,49 @@ pub fn execute_bls12_381_g2_add(allocator: std.mem.Allocator, input: []const u8,
     return PrecompileError.NotImplemented;
 }
 
-/// 0x0F: BLS12-381 G2 scalar multiplication (not implemented in Rust wrapper yet)
-pub fn execute_bls12_381_g2_mul(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
-    _ = allocator;
-    _ = input;
-    _ = gas_limit;
-    return PrecompileError.NotImplemented;
-}
+/// 0x0E: BLS12-381 G2 multi-scalar multiplication (MSM)
+/// Includes single scalar multiplication (k=1) and multi-scalar multiplication (k>1)
+pub fn execute_bls12_381_g2_msm(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
+    const G2_MSM_INPUT_LENGTH = 288; // 256 bytes G2 + 32 bytes scalar
+    
+    // Input validation: must be multiple of 288 bytes
+    if (input.len % G2_MSM_INPUT_LENGTH != 0) {
+        return PrecompileOutput{
+            .output = &.{},
+            .gas_used = 0,
+            .success = false,
+        };
+    }
+    
+    const num_pairs = input.len / G2_MSM_INPUT_LENGTH;
+    
+    // Calculate gas using discount table
+    const required_gas = if (num_pairs == 0) 0 else blk: {
+        const discount_index = @min(num_pairs - 1, GasConstants.BLS12_381_G2_MSM_DISCOUNT.len - 1);
+        const discount = GasConstants.BLS12_381_G2_MSM_DISCOUNT[discount_index];
+        break :blk (@as(u64, num_pairs) * GasConstants.BLS12_381_G2_MSM * discount) / GasConstants.MSM_MULTIPLIER;
+    };
+    
+    if (gas_limit < required_gas) {
+        return PrecompileOutput{
+            .output = &.{},
+            .gas_used = gas_limit,
+            .success = false,
+        };
+    }
+    
+    // Handle empty input: return point at infinity (all zeros)
+    if (num_pairs == 0) {
+        const output = try allocator.alloc(u8, 256);
+        @memset(output, 0);
+        return PrecompileOutput{
+            .output = output,
+            .gas_used = required_gas,
+            .success = true,
+        };
+    }
 
-/// 0x10: BLS12-381 G2 multi-exponentiation (not implemented in Rust wrapper yet)
-pub fn execute_bls12_381_g2_multiexp(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
-    _ = allocator;
-    _ = input;
-    _ = gas_limit;
+    // Not implemented in crypto module yet
     return PrecompileError.NotImplemented;
 }
 
@@ -918,6 +948,14 @@ pub fn execute_bls12_381_pairing(allocator: std.mem.Allocator, input: []const u8
 
 /// 0x12: BLS12-381 map field element to G1 (not implemented in Rust wrapper yet)
 pub fn execute_bls12_381_map_fp_to_g1(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
+    _ = allocator;
+    _ = input;
+    _ = gas_limit;
+    return PrecompileError.NotImplemented;
+}
+
+/// 0x13: BLS12-381 map field element pair to G2 (not implemented in Rust wrapper yet)
+pub fn execute_bls12_381_map_fp2_to_g2(allocator: std.mem.Allocator, input: []const u8, gas_limit: u64) PrecompileError!PrecompileOutput {
     _ = allocator;
     _ = input;
     _ = gas_limit;
@@ -968,13 +1006,12 @@ test "is_precompile detects valid precompile addresses" {
 
     // Test BLS12-381 precompile addresses (EIP-2537)
     try testing.expect(is_precompile(BLS12_381_G1_ADD_ADDRESS));
-    try testing.expect(is_precompile(BLS12_381_G1_MUL_ADDRESS));
-    try testing.expect(is_precompile(BLS12_381_G1_MULTIEXP_ADDRESS));
+    try testing.expect(is_precompile(BLS12_381_G1_MSM_ADDRESS));
     try testing.expect(is_precompile(BLS12_381_G2_ADD_ADDRESS));
-    try testing.expect(is_precompile(BLS12_381_G2_MUL_ADDRESS));
-    try testing.expect(is_precompile(BLS12_381_G2_MULTIEXP_ADDRESS));
+    try testing.expect(is_precompile(BLS12_381_G2_MSM_ADDRESS));
     try testing.expect(is_precompile(BLS12_381_PAIRING_ADDRESS));
     try testing.expect(is_precompile(BLS12_381_MAP_FP_TO_G1_ADDRESS));
+    try testing.expect(is_precompile(BLS12_381_MAP_FP2_TO_G2_ADDRESS));
 
     // Test invalid addresses
     try testing.expect(!is_precompile(primitives.Address.from_u256(0)));

--- a/src/primitives/gas_constants.zig
+++ b/src/primitives/gas_constants.zig
@@ -348,6 +348,103 @@ pub const MODEXP_QUADRATIC_THRESHOLD: usize = 64;
 pub const MODEXP_LINEAR_THRESHOLD: usize = 1024;
 
 // ============================================================================
+// BLAKE2F Precompile Cost (EIP-152)
+// ============================================================================
+
+/// Gas cost per round for BLAKE2F precompile (address 0x09)
+/// EIP-152 (Istanbul): Cost is linear based on number of rounds
+pub const BLAKE2F_PER_ROUND: u64 = 1;
+
+// ============================================================================
+// KZG Point Evaluation Precompile Cost (EIP-4844)
+// ============================================================================
+
+/// Fixed gas cost for POINT_EVALUATION precompile (address 0x0A)
+/// EIP-4844 (Cancun): KZG point evaluation for blob transactions
+pub const POINT_EVALUATION_COST: u64 = 50000;
+
+// ============================================================================
+// BLS12-381 Precompile Costs (EIP-2537) - Prague Hardfork
+// ============================================================================
+
+/// Fixed gas cost for BLS12_381_G1_ADD precompile (address 0x0B)
+/// EIP-2537 (Prague): BLS12-381 curve G1 point addition
+pub const BLS12_381_G1_ADD: u64 = 375;
+
+/// Base gas cost for BLS12_381_G1_MSM precompile (address 0x0C) 
+/// EIP-2537 (Prague): BLS12-381 curve G1 multi-scalar multiplication
+/// Note: Single scalar multiplication (k=1) uses this base cost
+/// Formula: (k * BLS12_381_G1_MSM * DISCOUNT[k]) / MSM_MULTIPLIER
+pub const BLS12_381_G1_MSM: u64 = 12000;
+
+/// Fixed gas cost for BLS12_381_G1_MULTIEXP precompile (address 0x0D)
+/// EIP-2537 (Prague): BLS12-381 curve G1 multi-exponentiation
+/// Note: This uses the same calculation as G1_MSM with discount table
+pub const BLS12_381_G1_MULTIEXP: u64 = 12000;
+
+/// Fixed gas cost for BLS12_381_G2_ADD precompile (address 0x0E)
+/// EIP-2537 (Prague): BLS12-381 curve G2 point addition
+pub const BLS12_381_G2_ADD: u64 = 600;
+
+/// Base gas cost for BLS12_381_G2_MSM precompile (address 0x0F)
+/// EIP-2537 (Prague): BLS12-381 curve G2 multi-scalar multiplication
+/// Note: Single scalar multiplication (k=1) uses this base cost
+/// Formula: (k * BLS12_381_G2_MSM * DISCOUNT[k]) / MSM_MULTIPLIER
+pub const BLS12_381_G2_MSM: u64 = 22500;
+
+/// Fixed gas cost for BLS12_381_G2_MULTIEXP precompile (address 0x10)
+/// EIP-2537 (Prague): BLS12-381 curve G2 multi-exponentiation
+/// Note: This uses the same calculation as G2_MSM with discount table
+pub const BLS12_381_G2_MULTIEXP: u64 = 22500;
+
+/// Base gas cost for BLS12_381_PAIRING precompile (address 0x11)
+/// EIP-2537 (Prague): BLS12-381 pairing check base cost
+pub const BLS12_381_PAIRING_BASE: u64 = 37700;
+
+/// Per-pair gas cost for BLS12_381_PAIRING precompile
+/// EIP-2537 (Prague): Additional cost per pairing pair
+/// Total cost = BLS12_381_PAIRING_BASE + (pair_count * BLS12_381_PAIRING_PER_PAIR)
+pub const BLS12_381_PAIRING_PER_PAIR: u64 = 32600;
+
+/// Fixed gas cost for BLS12_381_MAP_FP_TO_G1 precompile (address 0x12)
+/// EIP-2537 (Prague): Map field element to BLS12-381 G1 point
+pub const BLS12_381_MAP_FP_TO_G1: u64 = 5500;
+
+/// Fixed gas cost for BLS12_381_MAP_FP2_TO_G2 precompile (address 0x13)
+/// EIP-2537 (Prague): Map field element to BLS12-381 G2 point
+pub const BLS12_381_MAP_FP2_TO_G2: u64 = 23800;
+
+/// MSM multiplier for discount calculation
+/// Used in formula: (k * BASE_GAS * DISCOUNT[k]) / MSM_MULTIPLIER
+pub const MSM_MULTIPLIER: u64 = 1000;
+
+/// Discount table for BLS12-381 G1 MSM operations
+/// Index k-1 gives discount factor for k pairs (multiply by BASE_GAS * k / 1000)
+pub const BLS12_381_G1_MSM_DISCOUNT: [128]u16 = .{
+    1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705, 698, 692, 687, 682, 677,
+    673, 669, 665, 661, 658, 654, 651, 648, 645, 642, 640, 637, 635, 632, 630, 627,
+    625, 623, 621, 619, 617, 615, 613, 611, 609, 608, 606, 604, 603, 601, 599, 598,
+    596, 595, 593, 592, 591, 589, 588, 586, 585, 584, 582, 581, 580, 579, 577, 576,
+    575, 574, 573, 572, 570, 569, 568, 567, 566, 565, 564, 563, 562, 561, 560, 559,
+    558, 557, 556, 555, 554, 553, 552, 551, 550, 549, 548, 547, 547, 546, 545, 544,
+    543, 542, 541, 540, 540, 539, 538, 537, 536, 536, 535, 534, 533, 532, 532, 531,
+    530, 529, 528, 528, 527, 526, 525, 525, 524, 523, 522, 522, 521, 520, 520, 519,
+};
+
+/// Discount table for BLS12-381 G2 MSM operations
+/// Index k-1 gives discount factor for k pairs (multiply by BASE_GAS * k / 1000)
+pub const BLS12_381_G2_MSM_DISCOUNT: [128]u16 = .{
+    1000, 1000, 923, 884, 855, 832, 812, 796, 782, 770, 759, 749, 740, 732, 724, 717,
+    711, 704, 699, 693, 688, 683, 679, 674, 670, 666, 663, 659, 655, 652, 649, 646,
+    643, 640, 637, 634, 632, 629, 627, 624, 622, 620, 618, 615, 613, 611, 609, 607,
+    606, 604, 602, 600, 598, 597, 595, 593, 592, 590, 589, 587, 586, 584, 583, 582,
+    580, 579, 578, 576, 575, 574, 573, 571, 570, 569, 568, 567, 566, 565, 563, 562,
+    561, 560, 559, 558, 557, 556, 555, 554, 553, 552, 552, 551, 550, 549, 548, 547,
+    546, 545, 545, 544, 543, 542, 541, 541, 540, 539, 538, 537, 537, 536, 535, 535,
+    534, 533, 532, 532, 531, 530, 530, 529, 528, 528, 527, 526, 526, 525, 524, 524,
+};
+
+// ============================================================================
 // Call Operation Gas Constants (EIP-150 & EIP-2929)
 // ============================================================================
 


### PR DESCRIPTION
## Description
Update BLS12-381 precompile addresses and implementations to align with EIP-2537 specifications.

Roughly:
- For G1 and G2 there were two MUL and MULTIEXP precompiles when it should just be one MSM
- There was a missing precompile

This PR:
- Renames G1/G2 scalar multiplication operations to MSM (Multi-Scalar Multiplication)
- Updates precompile addresses to be sequential (0x0B through 0x11)
- Adds support for empty input handling in MSM operations
- Implements gas cost calculations using discount tables for MSM operations
- Adds BLS12_381_MAP_FP2_TO_G2 precompile at address 0x11
- Adds comprehensive gas constants for all BLS12-381 operations in gas_constants.zig
- Adds discount tables for G1 and G2 MSM operations with 128 entries each

## Type of Change
- [x] 🎉 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔧 Build/CI/tooling changes

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings