### PR TITLE
fix: update zbench dependency hash from 0.11.1 to 0.11.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,7 +42,7 @@
         // },
         .zbench = .{
             .url = "https://github.com/hendriknielaender/zBench/archive/refs/heads/main.tar.gz",
-            .hash = "zbench-0.11.1-YTdc7zgmAQDtDcHPFwsLeawui27WjMLWmUwrfz7pIlB2",
+            .hash = "zbench-0.11.2-YTdc7zolAQDlBF9i0ywXIvDjafL3Kg27S-aFUq6dU5zy",
         },
         .clap = .{
             .url = "https://github.com/Hejsil/zig-clap/archive/refs/heads/master.tar.gz",

--- a/src/frame/frame.zig
+++ b/src/frame/frame.zig
@@ -301,12 +301,14 @@ pub fn Frame(comptime config: FrameConfig) type {
         pub const vector_length = config.vector_length;
 
         /// Returns the appropriate tail call modifier based on the target architecture.
-        /// WebAssembly doesn't support tail calls by default, so we use .auto for wasm targets.
+        /// WebAssembly and x86_64 stage2 backend don't support tail calls, so we use .auto for those targets.
         pub inline fn getTailCallModifier() std.builtin.CallModifier {
-            return if (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64)
+            return if (builtin.target.cpu.arch == .wasm32 or 
+                      builtin.target.cpu.arch == .wasm64 or
+                      builtin.target.cpu.arch == .x86_64)
                 .auto
             else
-                .always_tail; // Must use always_tail for performance
+                .always_tail; // Must use always_tail for performance on supported architectures
         }
         /// The "word" type used by the evm. Defaults to u256. "Word" is the type used by Stack and throughout the Evm
         /// If set to something else the EVM will update to that new word size. e.g. run kekkak128 instead of kekkak256


### PR DESCRIPTION
## Summary
• Fix CI build failures caused by zbench dependency hash mismatch
• Fix x86_64 tail call compilation errors in stage2 backend
• Update zbench hash from 0.11.1 to 0.11.2 in build.zig.zon
• Update getTailCallModifier() to handle x86_64 architecture limitations

## Test plan
- [x] Verify `zig build` completes successfully on ARM64
- [x] Verify `zig build test-opcodes` runs without initial errors
- [x] Confirm all required dependencies are properly resolved
- [x] Test tail call fix handles x86_64 stage2 backend limitations

## Changes
1. **zbench hash update**: Updated zbench dependency hash in `build.zig.zon` line 45
   - Resolves: `hash mismatch: manifest declares 'zbench-0.11.1-...' but the fetched package has 'zbench-0.11.2-...'`

2. **x86_64 tail call fix**: Updated `getTailCallModifier()` in `src/frame/frame.zig`
   - Resolves: `unable to perform tail call: compiler backend 'stage2_x86_64' does not support tail calls`
   - Uses `.auto` for x86_64 targets while preserving `.always_tail` for ARM64 performance

## Technical Details
The Zig stage2_x86_64 compiler backend doesn't support tail calls, which was causing CI failures on GitHub's x86_64 runners. The fix maintains optimal performance on ARM64/AArch64 while ensuring compatibility on x86_64.

🤖 Generated with [Claude Code](https://claude.ai/code)