### PR TITLE
feat: add missing static context validation to MinimalEvm

### DIFF
--- a/src/tracer/minimal_evm.zig
+++ b/src/tracer/minimal_evm.zig
@@ -117,8 +117,10 @@ pub const MinimalEvm = struct {
     origin: Address,
     gas_price: u256,
     host: ?HostInterface,
+    is_static: bool,
     arena: std.heap.ArenaAllocator,
     allocator: std.mem.Allocator,
+    
     pub fn init(allocator: std.mem.Allocator) !Self {
         var arena = std.heap.ArenaAllocator.init(allocator);
         errdefer arena.deinit();
@@ -149,6 +151,7 @@ pub const MinimalEvm = struct {
             .origin = ZERO_ADDRESS,
             .gas_price = 0,
             .host = null,
+            .is_static = false,
             .arena = arena,
             .allocator = arena_allocator,
         };
@@ -182,6 +185,7 @@ pub const MinimalEvm = struct {
         self.origin = ZERO_ADDRESS;
         self.gas_price = 0;
         self.host = null;
+        self.is_static = false;
         self.allocator = arena_allocator;
 
         return self;
@@ -230,6 +234,16 @@ pub const MinimalEvm = struct {
     pub fn setTransactionContext(self: *Self, origin: Address, gas_price: u256) void {
         self.origin = origin;
         self.gas_price = gas_price;
+    }
+
+    /// Set the static context flag
+    pub fn set_is_static(self: *Self, is_static: bool) void {
+        self.is_static = is_static;
+    }
+
+    /// Check if current context is static (EIP-214)
+    pub fn is_static_context(self: *Self) bool {
+        return self.is_static;
     }
 
     pub fn setCode(self: *Self, address: Address, code: []const u8) !void {

--- a/src/tracer/minimal_frame.zig
+++ b/src/tracer/minimal_frame.zig
@@ -880,6 +880,9 @@ pub const MinimalFrame = struct {
                 const key = try self.popStack();
                 const value = try self.popStack();
 
+                // Check static context (EIP-214)
+                if (evm.is_static_context()) return error.StaticCallViolation;
+
                 // Simplified gas cost (actual is complex with refunds)
                 // TODO: Implement full EIP-2200/EIP-3529 metering using
                 // original value tracking and refund logic, reusing warm/cold state.
@@ -1029,6 +1032,9 @@ pub const MinimalFrame = struct {
                 const offset = try self.popStack();
                 const length = try self.popStack();
 
+                // Check static context (EIP-214)
+                if (evm.is_static_context()) return error.StaticCallViolation;
+
                 // Pop topics
                 var i: u8 = 0;
                 while (i < topic_count) : (i += 1) {
@@ -1050,6 +1056,9 @@ pub const MinimalFrame = struct {
                 const value = try self.popStack();
                 const offset = try self.popStack();
                 const length = try self.popStack();
+
+                // Check static context (EIP-214)
+                if (evm.is_static_context()) return error.StaticCallViolation;
 
                 // Gas cost
                 try self.consumeGas(32000);
@@ -1084,6 +1093,9 @@ pub const MinimalFrame = struct {
                 // Base gas cost
                 var gas_cost: u64 = GasConstants.CallGas;
                 if (value_arg > 0) {
+                    // Check static context for value transfer (EIP-214)
+                    if (evm.is_static_context()) return error.StaticCallViolation;
+
                     gas_cost += GasConstants.CallValueTransferGas;
                 }
                 // EIP-2929: access target account (warm/cold)
@@ -1165,6 +1177,9 @@ pub const MinimalFrame = struct {
                 // Base gas cost
                 var gas_cost: u64 = GasConstants.CallGas;
                 if (value_arg > 0) {
+                    // Check static context for value transfer (EIP-214)
+                    if (evm.is_static_context()) return error.StaticCallViolation;
+
                     gas_cost += GasConstants.CallValueTransferGas;
                 }
                 // EIP-2929: access target account (warm/cold)
@@ -1326,6 +1341,9 @@ pub const MinimalFrame = struct {
                 const offset = try self.popStack();
                 const length = try self.popStack();
                 const salt = try self.popStack();
+
+                // Check static context (EIP-214)
+                if (evm.is_static_context()) return error.StaticCallViolation;
 
                 // Gas cost
                 const word_count = @as(u64, @intCast((length + 31) / 32));
@@ -1704,6 +1722,10 @@ pub const MinimalFrame = struct {
             // SELFDESTRUCT
             0xff => {
                 const beneficiary = try self.popStack();
+
+                // Check static context (EIP-214)
+                if (evm.is_static_context()) return error.StaticCallViolation;
+
                 _ = beneficiary;
                 try self.consumeGas(5000);
                 self.stopped = true;

--- a/src/tracer/tracer.zig
+++ b/src/tracer/tracer.zig
@@ -176,6 +176,7 @@ pub const Tracer = struct {
                 const block_info = evm_instance.get_block_info();
                 evm.setBlockchainContext(evm_instance.get_chain_id(), block_info.number, block_info.timestamp, block_info.difficulty, block_info.coinbase, block_info.gas_limit, block_info.base_fee, block_info.blob_base_fee);
                 evm.setTransactionContext(evm_instance.get_tx_origin(), evm_instance.gas_price);
+                evm.set_is_static(evm_instance.is_static_context());
                 var caller = primitives.ZERO_ADDRESS;
                 var address = primitives.ZERO_ADDRESS;
                 var value: u256 = 0;
@@ -186,7 +187,7 @@ pub const Tracer = struct {
                 if (@hasField(@TypeOf(frame.*), "value")) value = frame.value;
                 if (@hasField(@TypeOf(frame.*), "calldata_slice")) calldata = frame.calldata_slice;
 
-                if (!std.mem.eql(u8, &address.bytes, &primitives.ZERO_ADDRESS.bytes)) evm.setCode(address, bytecode) catch {};
+                if (!address.equals(primitives.ZERO_ADDRESS)) evm.setCode(address, bytecode) catch {};
 
                 const frame_gas_remaining = frame.gas_remaining;
 


### PR DESCRIPTION
## Description
Implement EIP-214 (STATICCALL) by adding static context support to the minimal EVM implementation. This adds an `is_static` flag to track when execution is in a static context, and adds checks in state-modifying operations to prevent them from executing in static contexts. The affected operations include SSTORE, LOG, CREATE, CREATE2, SELFDESTRUCT, and value-transferring CALL/DELEGATECALL operations.

## Type of Change
- [x] 🎉 New feature (non-breaking change which adds functionality)

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings