### PR TITLE
[MinimalEvm] feat: add accessed addresses/storage to CallResult

### DIFF
--- a/src/tracer/minimal_evm.zig
+++ b/src/tracer/minimal_evm.zig
@@ -330,7 +330,7 @@ pub const MinimalEvm = struct {
     pub fn call(
         self: *Self,
         params: CallParams,
-    ) CallResult {        
+    ) CallResult {
         const to = params.get_to() orelse Address.ZERO_ADDRESS;
         const gas = params.getGas();
 
@@ -416,6 +416,22 @@ pub const MinimalEvm = struct {
                 result.gas_left = gas - floor_gas;
             }
         }
+        // Extract accessed addresses and storage before clearing
+        result.accessed_addresses = self.allocator.dupe(Address, self.warm_addresses.keys()) catch |err| {
+            log.err("Failed to allocate accessed addresses: {s}", .{@errorName(err)});
+            return CallResult.failure_with_error(result.gas_left, @errorName(err));
+        };
+
+        // Convert StorageSlotKey to StorageAccess
+        const storage_keys = self.warm_storage_slots.keys();
+        const storage_access = self.allocator.alloc(call_result_mod.StorageAccess, storage_keys.len) catch |err| {
+            log.err("Failed to allocate accessed storage: {s}", .{@errorName(err)});
+            return CallResult.failure_with_error(result.gas_left, @errorName(err));
+        };
+        for (storage_keys, 0..) |key, i| {
+            storage_access[i] = .{ .address = key.address, .slot = key.slot };
+        }
+        result.accessed_storage = storage_access;
 
         return result;
     }


### PR DESCRIPTION
## Description
Add tracking of accessed addresses and storage in MinimalEVM call results

This PR enhances the `call` method in `MinimalEVM` to extract and store accessed addresses and storage slots before clearing them. It captures warm addresses and storage slots from the EVM execution context and properly formats them in the call result, allowing callers to analyze which addresses and storage slots were accessed during execution.

## Type of Change
- [x] 🎉 New feature (non-breaking change which adds functionality)
- [x] ♻️ Code refactoring

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings