### PR TITLE
fix bn254 and foundry build error on mac

### DIFF
--- a/lib/ark/Cargo.toml
+++ b/lib/ark/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "bn254_wrapper"
-crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 [dependencies]
 # Using arkworks for BN254 elliptic curve operations - from workspace

--- a/lib/foundry-compilers/Cargo.toml
+++ b/lib/foundry-compilers/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]  # Build as a static library for Zig to link
+crate-type = ["staticlib"]  # Build as a static library for Zig to link
 
 [dependencies]
 foundry-compilers = { version = "0.10.1", features = ["svm-solc"] }


### PR DESCRIPTION
## Description
fix bn254 and foundry build error：
```
cannot find libfoundry_wrapper.a and bn254_wrapper.a
```

## AI Disclosure
<!-- 
If you used AI tools to generate any part of this code, you MUST:
1. Check the box below
2. List all prompts used
3. Provide a human-written explanation

If no AI was used, you can leave this section blank.
-->

- [ ] This PR contains AI-generated code

### AI Tools Used

### Human Explanation


## Related Issues
<!-- Link any related issues using #issue-number -->
Fixes #

## Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🎉 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ✅ Test additions or updates
- [ ] 🔧 Build/CI/tooling changes

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] `zig build test` passes
- [ ] `zig build` completes successfully
- [ ] All existing tests pass
- [ ] Added new tests for changes (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I understand and take responsibility for all code in this PR (including AI-generated code)