### PR TITLE
[MinimalEvm] feat: implement EIP-1153 transient storage

### DIFF
--- a/src/tracer/minimal_evm.zig
+++ b/src/tracer/minimal_evm.zig
@@ -97,6 +97,8 @@ pub const MinimalEvm = struct {
     frames: std.ArrayList(*MinimalFrame),
     storage: std.AutoHashMap(StorageSlotKey, u256),
     original_storage: std.AutoHashMap(StorageSlotKey, u256),
+    // EIP-1153 transient storage (cleared after each transaction)
+    transient_storage: std.AutoHashMap(StorageSlotKey, u256),
     balances: std.AutoHashMap(Address, u256),
     code: std.AutoHashMap(Address, []const u8),
     nonces: std.AutoHashMap(Address, u64),
@@ -131,6 +133,7 @@ pub const MinimalEvm = struct {
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
         const storage_map = std.AutoHashMap(StorageSlotKey, u256).init(arena_allocator);
+        const transient_storage_map = std.AutoHashMap(StorageSlotKey, u256).init(arena_allocator);
         const balances_map = std.AutoHashMap(Address, u256).init(arena_allocator);
         const code_map = std.AutoHashMap(Address, []const u8).init(arena_allocator);
         const nonces_map = std.AutoHashMap(Address, u64).init(arena_allocator);
@@ -145,6 +148,7 @@ pub const MinimalEvm = struct {
             .frames = frames_list,
             .storage = storage_map,
             .original_storage = original_storage_map,
+            .transient_storage = transient_storage_map,
             .balances = balances_map,
             .code = code_map,
             .nonces = nonces_map,
@@ -183,6 +187,7 @@ pub const MinimalEvm = struct {
         self.frames = std.ArrayList(*MinimalFrame){}; // Unmanaged ArrayList, default init
         self.storage = std.AutoHashMap(StorageSlotKey, u256).init(arena_allocator);
         self.original_storage = std.AutoHashMap(StorageSlotKey, u256).init(arena_allocator);
+        self.transient_storage = std.AutoHashMap(StorageSlotKey, u256).init(arena_allocator);
         self.balances = std.AutoHashMap(Address, u256).init(arena_allocator);
         self.code = std.AutoHashMap(Address, []const u8).init(arena_allocator);
         self.nonces = std.AutoHashMap(Address, u64).init(arena_allocator);
@@ -339,6 +344,8 @@ pub const MinimalEvm = struct {
             self.gas_refund = 0;
             self.warm_addresses.clearRetainingCapacity();
             self.warm_storage_slots.clearRetainingCapacity();
+            // EIP-1153: Clear transient storage after transaction
+            self.transient_storage.clearRetainingCapacity();
         }
 
         // Pre-warm transaction, including precompiles depending on hardfork
@@ -916,9 +923,8 @@ pub const MinimalEvm = struct {
 
     /// Get storage value (called by frame)
     pub fn get_storage(self: *Self, address: Address, slot: u256) u256 {
-        if (self.host) |host| {
-            return host.getStorage(address, slot);
-        }
+        if (self.host) |host| return host.getStorage(address, slot);
+
         const key = StorageSlotKey{ .address = address, .slot = slot };
         return self.storage.get(key) orelse 0;
     }
@@ -931,6 +937,7 @@ pub const MinimalEvm = struct {
             host.setStorage(address, slot, value);
             return;
         }
+
         const key = StorageSlotKey{ .address = address, .slot = slot };
 
         // Track original value on first write in transaction
@@ -951,6 +958,32 @@ pub const MinimalEvm = struct {
         }
         // Otherwise return current value (unchanged in this transaction)
         return self.storage.get(key) orelse 0;
+    }
+
+    /// Get transient storage value (EIP-1153)
+    pub fn get_transient_storage(self: *Self, address: Address, slot: u256) u256 {
+        if (self.host) |host| return host.getTransientStorage(address, slot);
+
+        const key = StorageSlotKey{ .address = address, .slot = slot };
+        return self.transient_storage.get(key) orelse 0;
+    }
+
+    /// Set transient storage value (EIP-1153)
+    pub fn set_transient_storage(self: *Self, address: Address, slot: u256, value: u256) !void {
+        if (self.is_static_context()) return error.StaticCallViolation;
+
+        if (self.host) |host| {
+            host.setTransientStorage(address, slot, value);
+            return;
+        }
+
+        const key = StorageSlotKey{ .address = address, .slot = slot };
+        if (value == 0) {
+            // Remove entry when storing zero (storage optimization)
+            _ = self.transient_storage.remove(key);
+        } else {
+            try self.transient_storage.put(key, value);
+        }
     }
 
     /// Add gas refund

--- a/src/tracer/minimal_frame.zig
+++ b/src/tracer/minimal_frame.zig
@@ -1146,9 +1146,7 @@ pub const MinimalFrame = struct {
 
                 try self.consumeGas(GasConstants.WarmStorageReadCost);
                 const key = try self.popStack();
-                // For MinimalEvm tracer, we use regular storage for transient storage
-                // In a real implementation, this would be separate
-                const value = evm.get_storage(self.address, key);
+                const value = evm.get_transient_storage(self.address, key);
                 try self.pushStack(value);
                 self.pc += 1;
             },
@@ -1158,12 +1156,10 @@ pub const MinimalFrame = struct {
                 // EIP-1153: TSTORE was introduced in Cancun hardfork
                 if (evm.hardfork.isBefore(.CANCUN)) return error.InvalidOpcode;
 
-                try self.consumeGas(GasConstants.WarmStorageReadCost); // Use same as TLOAD for now
+                try self.consumeGas(GasConstants.WarmStorageReadCost);
                 const key = try self.popStack();
                 const value = try self.popStack();
-                // For MinimalEvm tracer, we can just track transient storage in the EVM
-                // Transient storage behaves like regular storage but is cleared after tx
-                try evm.set_storage(self.address, key, value);
+                try evm.set_transient_storage(self.address, key, value);
                 self.pc += 1;
             },
 

--- a/src/tracer/minimal_host.zig
+++ b/src/tracer/minimal_host.zig
@@ -23,6 +23,8 @@ pub const HostInterface = struct {
         set_code: *const fn (ptr: *anyopaque, address: Address, code: []const u8) void,
         get_storage: *const fn (ptr: *anyopaque, address: Address, slot: u256) u256,
         set_storage: *const fn (ptr: *anyopaque, address: Address, slot: u256, value: u256) void,
+        get_transient_storage: *const fn (ptr: *anyopaque, address: Address, slot: u256) u256,
+        set_transient_storage: *const fn (ptr: *anyopaque, address: Address, slot: u256, value: u256) void,
     };
 
     pub fn innerCall(self: HostInterface, params: CallParams) CallResult {
@@ -60,6 +62,14 @@ pub const HostInterface = struct {
     pub fn setStorage(self: HostInterface, address: Address, slot: u256, value: u256) void {
         self.vtable.set_storage(self.ptr, address, slot, value);
     }
+
+    pub fn getTransientStorage(self: HostInterface, address: Address, slot: u256) u256 {
+        return self.vtable.get_transient_storage(self.ptr, address, slot);
+    }
+
+    pub fn setTransientStorage(self: HostInterface, address: Address, slot: u256, value: u256) void {
+        self.vtable.set_transient_storage(self.ptr, address, slot, value);
+    }
 };
 
 /// Host implementation that reads from real EVM
@@ -89,6 +99,8 @@ pub const Host = struct {
                 .set_code = setCode,
                 .get_storage = getStorage,
                 .set_storage = setStorage,
+                .get_transient_storage = getTransientStorage,
+                .set_transient_storage = setTransientStorage,
             },
         };
     }
@@ -203,6 +215,22 @@ pub const Host = struct {
         // 1. Host would need to hold a reference to the EVM instance
         // 2. Access the database through: evm.database
         // 3. Store value: evm.database.storage.put(StorageKey{address.bytes, slot}, value)
+        _ = address;
+        _ = slot;
+        _ = value;
+    }
+
+    fn getTransientStorage(ptr: *anyopaque, address: Address, slot: u256) u256 {
+        const self = @as(*Self, @ptrCast(@alignCast(ptr)));
+        _ = self;
+        _ = address;
+        _ = slot;
+        return 0;
+    }
+
+    fn setTransientStorage(ptr: *anyopaque, address: Address, slot: u256, value: u256) void {
+        const self = @as(*Self, @ptrCast(@alignCast(ptr)));
+        _ = self;
         _ = address;
         _ = slot;
         _ = value;


### PR DESCRIPTION
## Description
Implemented EIP-1153 transient storage in the minimal EVM tracer. This adds proper support for the TLOAD and TSTORE opcodes introduced in the Cancun hardfork. Transient storage behaves like regular storage but is cleared after each transaction completes.

Key changes:
- Added a dedicated `transient_storage` hash map in `MinimalEvm`
- Implemented `get_transient_storage` and `set_transient_storage` methods
- Updated TLOAD and TSTORE opcodes to use the new transient storage methods
- Added transient storage clearing after transaction completion
- Extended the host interface with transient storage methods

## Type of Change
- [x] 🎉 New feature (non-breaking change which adds functionality)

## Testing
- [x] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings