### PR TITLE
feat(python): productionize Python SDK for PyPI publishing

### DIFF
--- a/sdks/python/.bumpversion.cfg
+++ b/sdks/python/.bumpversion.cfg
@@ -1,0 +1,14 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+tag_name = python-v{new_version}
+message = chore(python): bump version to {new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:guillotine_evm/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/sdks/python/MANIFEST.in
+++ b/sdks/python/MANIFEST.in
@@ -1,0 +1,29 @@
+# Include package metadata
+include LICENSE
+include README.md
+include pyproject.toml
+include setup.py
+
+# Include type stubs
+include guillotine_evm/py.typed
+
+# Include C extension source files if any
+recursive-include guillotine_evm *.c *.h *.pyx
+
+# Include compiled libraries
+recursive-include guillotine_evm *.so *.dll *.dylib *.pyd
+
+# Include test files
+recursive-include tests *.py
+
+# Include examples
+include examples.py
+include examples_comprehensive.py
+
+# Exclude build artifacts
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude .DS_Store
+global-exclude *.egg-info
+recursive-exclude build *
+recursive-exclude dist *

--- a/sdks/python/PUBLISHING.md
+++ b/sdks/python/PUBLISHING.md
@@ -1,0 +1,247 @@
+# Publishing test-guillotine-publish to PyPI
+
+This guide explains how to publish the `test-guillotine-publish` Python package to PyPI.
+
+## Prerequisites
+
+1. **PyPI Account**: Register at [pypi.org](https://pypi.org) and [test.pypi.org](https://test.pypi.org)
+2. **API Tokens**: Generate tokens from your PyPI account settings
+3. **Build Tools**: Install required Python packages:
+   ```bash
+   pip install build twine bump2version wheel setuptools cffi
+   ```
+4. **Zig Compiler**: Ensure Zig 0.15.1 is installed
+
+## Package Structure
+
+```
+sdks/python/
+├── guillotine_evm/      # Main package code
+│   ├── __init__.py       # Package initialization
+│   ├── py.typed          # Type hints marker
+│   └── *.py              # Module files
+├── tests/                # Test files
+├── pyproject.toml        # Package configuration
+├── setup.py              # Backwards compatibility
+├── MANIFEST.in           # Source distribution files
+├── .bumpversion.cfg      # Version management config
+├── release.py            # Release helper script
+└── publish-to-pypi.yml   # GitHub Action workflow
+```
+
+## Local Development Publishing
+
+### Quick Release (Using Helper Script)
+
+```bash
+# Test release (to TestPyPI)
+python release.py patch --test
+
+# Production release
+python release.py minor
+```
+
+### Manual Release Process
+
+1. **Build the Zig library**:
+   ```bash
+   cd ../..  # Go to project root
+   zig build python
+   cd sdks/python
+   ```
+
+2. **Bump version** (optional):
+   ```bash
+   # Patch version (0.1.0 -> 0.1.1)
+   bump2version patch
+
+   # Minor version (0.1.0 -> 0.2.0)
+   bump2version minor
+
+   # Major version (0.1.0 -> 1.0.0)
+   bump2version major
+   ```
+
+3. **Build distributions**:
+   ```bash
+   # Clean previous builds
+   rm -rf dist/ build/ *.egg-info
+
+   # Build source and wheel distributions
+   python -m build --sdist --wheel
+   ```
+
+4. **Check distributions**:
+   ```bash
+   twine check dist/*
+   ```
+
+5. **Upload to TestPyPI** (recommended first):
+   ```bash
+   twine upload --repository testpypi dist/*
+
+   # Test installation
+   pip install --index-url https://test.pypi.org/simple/ test-guillotine-publish
+   ```
+
+6. **Upload to PyPI**:
+   ```bash
+   twine upload dist/*
+   ```
+
+## GitHub Actions Publishing
+
+The included workflow (`publish-to-pypi.yml`) automates the entire process.
+
+**IMPORTANT**: Move `publish-to-pypi.yml` to `.github/workflows/publish-python.yml` in your repository root to enable the GitHub Action.
+
+### Setup GitHub Secrets
+
+1. Go to Repository Settings → Secrets → Actions
+2. Add these secrets:
+   - `TEST_PYPI_API_TOKEN`: Your TestPyPI token
+   - `PYPI_API_TOKEN`: Your PyPI token
+
+### Trigger the Workflow
+
+1. Go to Actions tab → "Publish Python Package to PyPI"
+2. Click "Run workflow"
+3. Select options:
+   - **Release type**: `test` or `production`
+   - **Version bump**: `patch`, `minor`, or `major` (optional)
+
+### What the Workflow Does
+
+1. **Builds** the Zig library
+2. **Bumps** version (if specified)
+3. **Creates** source and wheel distributions
+4. **Publishes** to TestPyPI or PyPI
+5. **Creates** GitHub release (for production)
+6. **Builds** platform-specific wheels (production only)
+
+## Authentication
+
+### Configure PyPI Credentials
+
+Create `~/.pypirc`:
+
+```ini
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[pypi]
+username = __token__
+password = pypi-AgEIcHl...your-token-here
+
+[testpypi]
+username = __token__
+password = pypi-AgEIcHl...your-test-token-here
+```
+
+### Using Environment Variables
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=pypi-AgEIcHl...your-token-here
+twine upload dist/*
+```
+
+## Platform-Specific Wheels
+
+For maximum compatibility, build wheels for multiple platforms:
+
+### Using cibuildwheel
+
+```bash
+pip install cibuildwheel
+
+# Build for current platform
+cibuildwheel --output-dir dist
+
+# Build for specific Python versions
+CIBW_BUILD="cp39-* cp310-* cp311-*" cibuildwheel --output-dir dist
+```
+
+### Manual Cross-Platform Building
+
+```bash
+# Linux wheels
+docker run -v $(pwd):/io python:3.11 bash -c "cd /io && pip install build && python -m build"
+
+# macOS wheels (on macOS)
+python -m build --wheel
+
+# Windows wheels (on Windows)
+python -m build --wheel
+```
+
+## Version Management
+
+Version is tracked in multiple places:
+- `pyproject.toml`: Main version source
+- `guillotine_evm/__init__.py`: Runtime version
+- Git tags: `python-v0.1.0` format
+
+The `.bumpversion.cfg` keeps these synchronized.
+
+## Testing the Published Package
+
+### From TestPyPI
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple test-guillotine-publish
+```
+
+### From PyPI
+
+```bash
+pip install test-guillotine-publish
+
+# Verify installation
+python -c "import guillotine_evm; print(guillotine_evm.__version__)"
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing compiled library**: Ensure `zig build python` was run
+2. **Version conflict**: Package name already exists with that version
+3. **Authentication failed**: Check API token and `.pypirc` configuration
+4. **Missing dependencies**: Install all build requirements
+5. **Platform compatibility**: Use cibuildwheel for cross-platform wheels
+
+### Checking Package Contents
+
+```bash
+# List files in source distribution
+tar -tzf dist/*.tar.gz
+
+# Inspect wheel contents
+unzip -l dist/*.whl
+
+# Extract and examine
+cd /tmp
+pip download --no-deps test-guillotine-publish
+unzip test_guillotine_publish-*.whl
+```
+
+## Best Practices
+
+1. **Always test on TestPyPI first**
+2. **Use semantic versioning** (MAJOR.MINOR.PATCH)
+3. **Include comprehensive metadata** in pyproject.toml
+4. **Build platform-specific wheels** for better performance
+5. **Tag releases in Git** for traceability
+6. **Document breaking changes** in release notes
+7. **Test installation** in clean virtual environment
+
+## Package URLs
+
+Once published:
+- **PyPI**: https://pypi.org/project/test-guillotine-publish/
+- **TestPyPI**: https://test.pypi.org/project/test-guillotine-publish/
+- **Documentation**: Link to your docs
+- **Repository**: https://github.com/evmts/guillotine

--- a/sdks/python/publish-to-pypi.yml
+++ b/sdks/python/publish-to-pypi.yml
@@ -1,0 +1,182 @@
+name: Publish Python Package to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - test
+          - production
+      version_bump:
+        description: 'Version bump type'
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python package
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write  # Required for PyPI trusted publishing
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for version tagging
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.15.1
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine wheel setuptools cffi typing-extensions
+          pip install bump2version  # For version management
+
+      - name: Bump version (if specified)
+        if: ${{ github.event.inputs.version_bump != '' }}
+        working-directory: sdks/python
+        run: |
+          # Read current version
+          current_version=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          echo "Current version: $current_version"
+
+          # Bump version using bump2version
+          bump2version ${{ github.event.inputs.version_bump }} --current-version $current_version --no-tag
+
+          # Read new version
+          new_version=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          echo "New version: $new_version"
+          echo "VERSION=$new_version" >> $GITHUB_ENV
+
+      - name: Build Guillotine shared library
+        run: |
+          zig build python
+
+      - name: Build Python distribution
+        working-directory: sdks/python
+        run: |
+          python -m build --sdist --wheel
+
+          # Display built distributions
+          echo "Built distributions:"
+          ls -lh dist/
+
+      - name: Check distribution
+        working-directory: sdks/python
+        run: |
+          # Check the built distributions
+          twine check dist/*
+
+          # Show package contents
+          echo "Package contents:"
+          tar -tzf dist/*.tar.gz | head -20
+
+      - name: Publish to TestPyPI
+        if: ${{ github.event.inputs.release_type == 'test' }}
+        working-directory: sdks/python
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload --repository testpypi dist/*
+          echo "Package published to TestPyPI!"
+          echo "Install with: pip install --index-url https://test.pypi.org/simple/ test-guillotine-publish"
+
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.release_type == 'production' }}
+        working-directory: sdks/python
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload dist/*
+          echo "Package published to PyPI!"
+          echo "Install with: pip install test-guillotine-publish"
+
+      - name: Create GitHub Release (production only)
+        if: ${{ github.event.inputs.release_type == 'production' && github.event.inputs.version_bump != '' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: python-v${{ env.VERSION }}
+          name: Python SDK v${{ env.VERSION }}
+          body: |
+            ## Python SDK Release v${{ env.VERSION }}
+
+            ### Installation
+            ```bash
+            pip install test-guillotine-publish==${{ env.VERSION }}
+            ```
+
+            ### What's Changed
+            - Version bump: ${{ github.event.inputs.version_bump }}
+            - Published to PyPI
+
+            ### Links
+            - [PyPI Package](https://pypi.org/project/test-guillotine-publish/${{ env.VERSION }}/)
+            - [Documentation](https://github.com/evmts/guillotine/tree/main/sdks/python)
+          files: |
+            sdks/python/dist/*
+          draft: false
+          prerelease: ${{ contains(env.VERSION, 'rc') || contains(env.VERSION, 'beta') || contains(env.VERSION, 'alpha') }}
+
+  build-wheels:
+    name: Build wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event.inputs.release_type == 'production' }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.15.1
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.2
+
+      - name: Build wheels
+        working-directory: sdks/python
+        env:
+          CIBW_BUILD: cp${{ matrix.python-version }}-*
+          CIBW_SKIP: "*-musllinux_*"  # Skip musl builds for now
+          CIBW_BEFORE_BUILD: |
+            pip install cffi setuptools wheel
+            cd ../.. && zig build python
+        run: |
+          python -m cibuildwheel --output-dir dist
+
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: sdks/python/dist/*.whl

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "wheel", "cffi>=1.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "guillotine-evm"
+name = "test-guillotine-publish"
 version = "0.1.0"
 description = "Python bindings for Guillotine EVM - A high-performance Ethereum Virtual Machine implementation"
 readme = "README.md"
@@ -11,19 +11,26 @@ license = {text = "MIT"}
 authors = [
     {name = "EVMts Contributors", email = "noreply@evmts.dev"}
 ]
-keywords = ["ethereum", "evm", "blockchain", "smart-contracts", "virtual-machine"]
+maintainers = [
+    {name = "Will Cory", email = "roninjin10@users.noreply.github.com"}
+]
+keywords = ["ethereum", "evm", "blockchain", "smart-contracts", "virtual-machine", "web3"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",
+    "Topic :: Software Development :: Compilers",
+    "Typing :: Typed",
 ]
 requires-python = ">=3.8"
 dependencies = [

--- a/sdks/python/release.py
+++ b/sdks/python/release.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Release helper script for test-guillotine-publish package.
+
+Usage:
+    python release.py [patch|minor|major] [--test]
+
+Examples:
+    python release.py patch --test  # Release patch version to TestPyPI
+    python release.py minor          # Release minor version to PyPI
+"""
+
+import argparse
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+def run_command(cmd, cwd=None):
+    """Run a shell command and return the result."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        sys.exit(1)
+    return result.stdout.strip()
+
+def main():
+    parser = argparse.ArgumentParser(description="Release helper for test-guillotine-publish")
+    parser.add_argument("bump_type", choices=["patch", "minor", "major"],
+                        help="Type of version bump")
+    parser.add_argument("--test", action="store_true",
+                        help="Upload to TestPyPI instead of PyPI")
+    parser.add_argument("--skip-build", action="store_true",
+                        help="Skip building the Zig library")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Skip running tests")
+
+    args = parser.parse_args()
+
+    # Change to the script's directory
+    script_dir = Path(__file__).parent
+    os.chdir(script_dir)
+
+    # Step 1: Build the Zig library
+    if not args.skip_build:
+        print("\n=== Building Zig library ===")
+        run_command(["zig", "build", "python"], cwd=script_dir.parent.parent)
+
+    # Step 2: Run tests
+    if not args.skip_tests and (script_dir / "tests").exists():
+        print("\n=== Running tests ===")
+        run_command(["python", "-m", "pytest", "tests/"])
+
+    # Step 3: Bump version
+    print(f"\n=== Bumping {args.bump_type} version ===")
+    run_command(["bump2version", args.bump_type])
+
+    # Step 4: Clean previous builds
+    print("\n=== Cleaning previous builds ===")
+    for dir_name in ["dist", "build", "*.egg-info"]:
+        run_command(["rm", "-rf", dir_name])
+
+    # Step 5: Build distributions
+    print("\n=== Building distributions ===")
+    run_command(["python", "-m", "build", "--sdist", "--wheel"])
+
+    # Step 6: Check distributions
+    print("\n=== Checking distributions ===")
+    run_command(["twine", "check", "dist/*"])
+
+    # Step 7: Upload to PyPI or TestPyPI
+    if args.test:
+        print("\n=== Uploading to TestPyPI ===")
+        run_command(["twine", "upload", "--repository", "testpypi", "dist/*"])
+        print("\n✅ Package uploaded to TestPyPI!")
+        print("Install with: pip install --index-url https://test.pypi.org/simple/ test-guillotine-publish")
+    else:
+        print("\n=== Uploading to PyPI ===")
+        response = input("Are you sure you want to upload to production PyPI? (yes/no): ")
+        if response.lower() == "yes":
+            run_command(["twine", "upload", "dist/*"])
+            print("\n✅ Package uploaded to PyPI!")
+            print("Install with: pip install test-guillotine-publish")
+        else:
+            print("Upload cancelled.")
+
+    print("\n=== Release complete! ===")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Productionize Python SDK for publishing to PyPI as `test-guillotine-publish`

## Changes
- Updated package metadata for PyPI publishing
- Added MANIFEST.in for proper source distribution
- Created GitHub Action workflow for automated publishing
- Added version management configuration
- Included comprehensive publishing documentation

Closes #818

Generated with [Claude Code](https://claude.ai/code)