### PR TITLE
⚡ perf: bn254 g2 subgroup check

### DIFF
--- a/src/crypto/bn254/Fp12Mont.zig
+++ b/src/crypto/bn254/Fp12Mont.zig
@@ -85,6 +85,15 @@ pub fn mulAssign(self: *Fp12Mont, other: *const Fp12Mont) void {
     self.* = self.mul(other);
 }
 
+pub fn div(self: *const Fp12Mont, other: *const Fp12Mont) !Fp12Mont {
+    var inverse = try other.inv();
+    return self.mul(&inverse);
+}
+
+pub fn divAssign(self: *Fp12Mont, other: *const Fp12Mont) !void {
+    self.* = try self.div(other);
+}
+
 //we use double and add to multiply by a small integer
 pub fn mulBySmallInt(self: *const Fp12Mont, other: u8) Fp12Mont {
     var result = ZERO;

--- a/src/crypto/bn254/Fp2Mont.zig
+++ b/src/crypto/bn254/Fp2Mont.zig
@@ -85,6 +85,15 @@ pub fn mulAssign(self: *Fp2Mont, other: *const Fp2Mont) void {
     self.* = self.mul(other);
 }
 
+pub fn div(self: *const Fp2Mont, other: *const Fp2Mont) !Fp2Mont {
+    var inverse = try other.inv();
+    return self.mul(&inverse);
+}
+
+pub fn divAssign(self: *Fp2Mont, other: *const Fp2Mont) !void {
+    self.* = try self.div(other);
+}
+
 //we use double and add to multiply by a small integer
 pub fn mulBySmallInt(self: *const Fp2Mont, other: u8) Fp2Mont {
     var result = ZERO;

--- a/src/crypto/bn254/Fp6Mont.zig
+++ b/src/crypto/bn254/Fp6Mont.zig
@@ -114,6 +114,15 @@ pub fn mulAssign(self: *Fp6Mont, other: *const Fp6Mont) void {
     self.* = self.mul(other);
 }
 
+pub fn div(self: *const Fp6Mont, other: *const Fp6Mont) !Fp6Mont {
+    var inverse = try other.inv();
+    return self.mul(&inverse);
+}
+
+pub fn divAssign(self: *Fp6Mont, other: *const Fp6Mont) !void {
+    self.* = try self.div(other);
+}
+
 //we use double and add to multiply by a small integer
 pub fn mulBySmallInt(self: *const Fp6Mont, other: u8) Fp6Mont {
     var result = ZERO;

--- a/src/crypto/bn254/FpMont.zig
+++ b/src/crypto/bn254/FpMont.zig
@@ -93,6 +93,15 @@ pub fn mulAssign(self: *FpMont, other: *const FpMont) void {
     self.* = self.mul(other);
 }
 
+pub fn div(self: *const FpMont, other: *const FpMont) !FpMont {
+    var inverse = try other.inv();
+    return self.mul(&inverse);
+}
+
+pub fn divAssign(self: *FpMont, other: *const FpMont) !void {
+    self.* = try self.div(other);
+}
+
 // we use double and add to multiply by a small integer, this is faster than Montgomery multiplication for very small hamming weights
 pub fn mulBySmallInt(self: *const FpMont, other: u8) FpMont {
     var result = ZERO;

--- a/src/crypto/bn254/G2.zig
+++ b/src/crypto/bn254/G2.zig
@@ -72,12 +72,25 @@ pub fn isInSubgroup(self: *const G2) bool {
         return true;
     }
 
+    if (!self.isOnCurve()) {
+        return false;
+    }
+
     // Create Fr element from curve order
-    const r = Fr{ .value = curve_parameters.FR_MOD };
+    //const r = Fr{ .value = curve_parameters.FR_MOD };
 
     // Check if [r]P = O (infinity)
-    const r_times_p = self.mul(&r);
-    return r_times_p.isInfinity();
+    var exp = @as(u256, @intCast(curve_parameters.FR_MOD));
+    var result = INFINITY;
+    var base = self.*;
+    while (exp > 0) : (exp >>= 1) {
+        if (exp & 1 == 1) {
+            result.addAssign(&base);
+        }
+        base.doubleAssign();
+    }
+
+    return result.isInfinity();
 }
 
 pub fn neg(self: *const G2) G2 {
@@ -376,6 +389,15 @@ test "G2.isInSubgroup generator multiples" {
         const point = G2.GENERATOR.mul(&scalar);
         try std.testing.expect(point.isInSubgroup());
     }
+}
+
+test "G2.isInSubgroup non subgroup point" {
+    const x = Fp2Mont{ .u0 = FpMont{ .value = 122 }, .u1 = FpMont{ .value = 3333 } };
+    const y = Fp2Mont{ .u0 = FpMont{ .value = 4562906498667794019468448659772613644715180855375958127421599247974276735405 }, .u1 = FpMont{ .value = 11306249705311604911826567979787687424320829738512421461876664403170710609448 } };
+    const z = Fp2Mont.ONE;
+    const point = G2.initUnchecked(&x, &y, &z);
+    try std.testing.expect(point.isOnCurve());
+    try std.testing.expect(!point.isInSubgroup());
 }
 
 test "G2.equal different representations same point" {

--- a/src/crypto/bn254/G2.zig
+++ b/src/crypto/bn254/G2.zig
@@ -66,6 +66,8 @@ pub fn isOnCurve(self: *const G2) bool {
 pub fn isInSubgroup(self: *const G2) bool {
     // For BN254, G2 points are in the correct subgroup if [r]P = O
     // where r is the order of the scalar field (FR_MOD) and O is infinity
+    // you can reduce this to a smaller exponent check by using the frobenius map
+    // we use the shortest vector as given by https://eprint.iacr.org/2022/348.pdf
 
     // If point is infinity, it's in the subgroup
     if (self.isInfinity()) {
@@ -76,21 +78,16 @@ pub fn isInSubgroup(self: *const G2) bool {
         return false;
     }
 
-    // Create Fr element from curve order
-    //const r = Fr{ .value = curve_parameters.FR_MOD };
+    const point_times_t = self.mul_by_int(curve_parameters.CURVE_PARAM_T);
+    const point_times_2t = point_times_t.double();
+    const point_times_tp1 = point_times_t.add(self);
 
-    // Check if [r]P = O (infinity)
-    var exp = @as(u256, @intCast(curve_parameters.FR_MOD));
-    var result = INFINITY;
-    var base = self.*;
-    while (exp > 0) : (exp >>= 1) {
-        if (exp & 1 == 1) {
-            result.addAssign(&base);
-        }
-        base.doubleAssign();
-    }
+    const lhs = point_times_tp1
+        .add(&point_times_t.frobenius())
+        .add(&point_times_t.frobenius().frobenius());
+    const rhs = point_times_2t.frobenius().frobenius().frobenius();
 
-    return result.isInfinity();
+    return lhs.equal(&rhs);
 }
 
 pub fn neg(self: *const G2) G2 {

--- a/src/crypto/bn254/G2.zig
+++ b/src/crypto/bn254/G2.zig
@@ -63,6 +63,22 @@ pub fn isOnCurve(self: *const G2) bool {
     return y_squared.equal(&rhs);
 }
 
+pub fn mulByCurveParamT(self: *const G2) G2 {
+    var result = INFINITY;
+    var base = self.*;
+    //var exp: u64 = curve_parameters.CURVE_PARAM_T;
+    const exp = curve_parameters.CURVE_PARAM_T_NAF;
+    for (exp) |bit| {
+        if (bit == 1) {
+            result.addAssign(&base);
+        } else if (bit == -1) {
+            result.addAssign(&base.neg());
+        }
+        base.doubleAssign();
+    }
+    return result;
+}
+
 pub fn isInSubgroup(self: *const G2) bool {
     // For BN254, G2 points are in the correct subgroup if [r]P = O
     // where r is the order of the scalar field (FR_MOD) and O is infinity
@@ -78,7 +94,7 @@ pub fn isInSubgroup(self: *const G2) bool {
         return false;
     }
 
-    const point_times_t = self.mul_by_int(curve_parameters.CURVE_PARAM_T);
+    const point_times_t = self.mulByCurveParamT();
     const point_times_2t = point_times_t.double();
     const point_times_tp1 = point_times_t.add(self);
 

--- a/src/crypto/bn254/G2.zig
+++ b/src/crypto/bn254/G2.zig
@@ -338,3 +338,260 @@ pub fn gamma_endomorphism(self: *const G2) G2 {
 pub fn gamma_lambda_endomorphism(self: *const G2) G2 {
     return self.gamma_endomorphism().lambda_endomorphism();
 }
+
+const std = @import("std");
+
+test "G2.isOnCurve generator" {
+    try std.testing.expect(G2.GENERATOR.isOnCurve());
+}
+
+test "G2.isOnCurve identity" {
+    try std.testing.expect(G2.INFINITY.isOnCurve());
+}
+
+test "G2.isOnCurve multiples" {
+    const scalars = [_]u256{ 2, 3, 7, 13, 27 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        try std.testing.expect(point.isOnCurve());
+    }
+}
+
+test "G2.curve order annihilates subgroup points" {
+    const order = curve_parameters.FR_MOD;
+    const scalars = [_]u256{ 1, 5, 9, 33, 101 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        const multiple = point.mul_by_int(order);
+        try std.testing.expect(multiple.isInfinity());
+    }
+}
+
+test "G2.isInSubgroup generator multiples" {
+    const scalars = [_]u256{ 1, 7, 19, 123, 98765 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        try std.testing.expect(point.isInSubgroup());
+    }
+}
+
+test "G2.equal different representations same point" {
+    var scalar = Fr.init(11);
+    const point = G2.GENERATOR.mul(&scalar);
+    const scale = Fp2Mont.init_from_int(5, 0);
+    const scale_sq = scale.mul(&scale);
+    const scale_cu = scale_sq.mul(&scale);
+    const scaled = G2{
+        .x = point.x.mul(&scale_sq),
+        .y = point.y.mul(&scale_cu),
+        .z = point.z.mul(&scale),
+    };
+    try std.testing.expect(point.equal(&scaled));
+}
+
+test "G2.toAffine normalizes coordinates" {
+    var scalar = Fr.init(19);
+    const projective = G2.GENERATOR.mul(&scalar);
+    const affine = projective.toAffine();
+    try std.testing.expect(affine.z.equal(&Fp2Mont.ONE));
+    try std.testing.expect(projective.equal(&affine));
+    try std.testing.expect(affine.isOnCurve());
+}
+
+test "G2.add inverse gives infinity" {
+    var scalar = Fr.init(23);
+    const point = G2.GENERATOR.mul(&scalar);
+    const inverse = point.neg();
+    const sum = point.add(&inverse);
+    try std.testing.expect(sum.isInfinity());
+}
+
+test "G2.add commutativity" {
+    var s1 = Fr.init(9);
+    var s2 = Fr.init(17);
+    const p1 = G2.GENERATOR.mul(&s1);
+    const p2 = G2.GENERATOR.mul(&s2);
+    const left = p1.add(&p2);
+    const right = p2.add(&p1);
+    try std.testing.expect(left.equal(&right));
+}
+
+test "G2.add associativity" {
+    var s1 = Fr.init(5);
+    var s2 = Fr.init(11);
+    var s3 = Fr.init(19);
+    const p1 = G2.GENERATOR.mul(&s1);
+    const p2 = G2.GENERATOR.mul(&s2);
+    const p3 = G2.GENERATOR.mul(&s3);
+
+    var left = p1.add(&p2);
+    left.addAssign(&p3);
+    var right = p2.add(&p3);
+    right.addAssign(&p1);
+    try std.testing.expect(left.equal(&right));
+}
+
+test "G2.double matches add self" {
+    var scalar = Fr.init(29);
+    const point = G2.GENERATOR.mul(&scalar);
+    const doubled = point.double();
+    const sum = point.add(&point);
+    try std.testing.expect(doubled.equal(&sum));
+}
+
+test "G2.assignment helpers" {
+    var s1 = Fr.init(7);
+    var s2 = Fr.init(13);
+    var p = G2.GENERATOR.mul(&s1);
+    const q = G2.GENERATOR.mul(&s2);
+
+    const add_expected = p.add(&q);
+    p.addAssign(&q);
+    try std.testing.expect(p.equal(&add_expected));
+
+    p = G2.GENERATOR.mul(&s1);
+    const double_expected = p.double();
+    p.doubleAssign();
+    try std.testing.expect(p.equal(&double_expected));
+
+    p = G2.GENERATOR.mul(&s1);
+    const neg_expected = p.neg();
+    p.negAssign();
+    try std.testing.expect(p.equal(&neg_expected));
+
+    p = G2.GENERATOR.mul(&s1);
+    var scalar = Fr.init(21);
+    const mul_expected = p.mul(&scalar);
+    p.mulAssign(&scalar);
+    try std.testing.expect(p.equal(&mul_expected));
+}
+
+test "G2.mul matches naive ladder" {
+    const scalars = [_]u256{ 0, 1, 2, 3, 5, 9, 15, 37 };
+    for (scalars) |k| {
+        var expected = INFINITY;
+        var addend = G2.GENERATOR;
+        var tmp = k;
+        while (tmp != 0) : (tmp >>= 1) {
+            if ((tmp & 1) == 1) {
+                expected = expected.add(&addend);
+            }
+            addend = addend.double();
+        }
+        const actual = G2.GENERATOR.mul_by_int(k);
+        try std.testing.expect(expected.equal(&actual));
+    }
+}
+
+test "G2.mul edge cases" {
+    const zero = G2.GENERATOR.mul_by_int(0);
+    try std.testing.expect(zero.isInfinity());
+
+    const one = G2.GENERATOR.mul_by_int(1);
+    try std.testing.expect(one.equal(&G2.GENERATOR));
+
+    const near_order = curve_parameters.FR_MOD - 1;
+    const neg_point = G2.GENERATOR.neg();
+    const result = G2.GENERATOR.mul_by_int(near_order);
+    try std.testing.expect(result.equal(&neg_point));
+}
+
+test "G2.distributivity over addition" {
+    var s1 = Fr.init(8);
+    var s2 = Fr.init(21);
+    const scalar = Fr.init(17);
+    const p = G2.GENERATOR.mul(&s1);
+    const q = G2.GENERATOR.mul(&s2);
+
+    const lhs = p.mul(&scalar).add(&q.mul(&scalar));
+    const rhs = p.add(&q).mul(&scalar);
+    try std.testing.expect(lhs.equal(&rhs));
+}
+
+test "G2.lambda endomorphism equals multiplication by lambda" {
+    const lambda = Fr{ .value = curve_parameters.G2_SCALAR.lambda };
+    const scalars = [_]u256{ 1, 3, 17, 55, 1234 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        const by_lambda = point.mul(&lambda);
+        const endo = point.lambda_endomorphism();
+        try std.testing.expect(by_lambda.equal(&endo));
+    }
+}
+
+test "G2.gamma endomorphism equals multiplication by gamma" {
+    const gamma = Fr{ .value = curve_parameters.G2_SCALAR.gamma };
+    const scalars = [_]u256{ 2, 9, 27, 91 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        const by_gamma = point.mul(&gamma);
+        const endo = point.gamma_endomorphism();
+        try std.testing.expect(by_gamma.equal(&endo));
+    }
+}
+
+test "G2.gamma lambda endomorphism equals multiplication by gamma lambda" {
+    const gamma_lambda = Fr{ .value = curve_parameters.G2_SCALAR.gamma_lambda };
+    const scalars = [_]u256{ 4, 13, 29, 123 };
+    for (scalars) |k| {
+        var scalar = Fr.init(k);
+        const point = G2.GENERATOR.mul(&scalar);
+        const composed = point.gamma_endomorphism().lambda_endomorphism();
+        const by_gamma_lambda = point.mul(&gamma_lambda);
+        const direct = point.gamma_lambda_endomorphism();
+        try std.testing.expect(by_gamma_lambda.equal(&direct));
+        try std.testing.expect(composed.equal(&direct));
+    }
+}
+
+test "G2.frobenius has order 12" {
+    var scalar = Fr.init(15);
+    const point = G2.GENERATOR.mul(&scalar);
+    var iter = point;
+    var i: usize = 0;
+    while (i < 12) : (i += 1) {
+        iter = iter.frobenius();
+        try std.testing.expect(iter.isOnCurve());
+    }
+    try std.testing.expect(iter.equal(&point));
+}
+
+test "G2.decomposeScalar recomposes original" {
+    const scalars = [_]Fr{
+        Fr.init(1),
+        Fr.init(56789),
+        Fr.init(9876543210),
+        Fr.init(curve_parameters.FR_MOD - 5),
+        Fr.init(curve_parameters.FR_MOD / 2 + 12345),
+    };
+
+    const lambda = @as(i512, @intCast(curve_parameters.G2_SCALAR.lambda));
+    const gamma = @as(i512, @intCast(curve_parameters.G2_SCALAR.gamma));
+    const gamma_lambda = @as(i512, @intCast(curve_parameters.G2_SCALAR.gamma_lambda));
+    const modulus = @as(i512, @intCast(curve_parameters.FR_MOD));
+
+    for (scalars) |scalar_val| {
+        const decomposition = G2.decomposeScalar(scalar_val.value);
+        const k1 = @as(i512, decomposition.k1);
+        const k2 = @as(i512, decomposition.k2);
+        const k3 = @as(i512, decomposition.k3);
+        const k4 = @as(i512, decomposition.k4);
+
+        var acc = k1;
+        acc += lambda * k2;
+        acc += gamma * k3;
+        acc += gamma_lambda * k4;
+
+        var reconstructed = @mod(acc, modulus);
+        if (reconstructed < 0) {
+            reconstructed += modulus;
+        }
+        const expected = @as(i512, @intCast(scalar_val.value));
+        try std.testing.expect(reconstructed == expected);
+    }
+}

--- a/src/crypto/bn254/benchmarks.zig
+++ b/src/crypto/bn254/benchmarks.zig
@@ -64,6 +64,7 @@ const OperationSampleSizes = struct {
 
     g2_add: usize = 5,
     g2_double: usize = 5,
+    g2_is_in_subgroup: usize = 5,
     g2_scalar_mul: usize = 1,
 
     // Pairing operations - always single
@@ -809,6 +810,15 @@ fn benchG2Double(sample_size: usize) void {
     }
 }
 
+fn benchG2IsInSubgroup(sample_size: usize) void {
+    const test_inputs = getInputs();
+    const i = nextInputIndex();
+    for (0..sample_size) |j| {
+        const result = test_inputs.g2_points[(i + j) % 1000].isInSubgroup();
+        std.mem.doNotOptimizeAway(result);
+    }
+}
+
 fn benchG2ScalarMul(sample_size: usize) void {
     const test_inputs = getInputs();
     const i = nextInputIndex();
@@ -899,6 +909,7 @@ pub fn runComprehensiveBenchmarks(allocator: std.mem.Allocator) !void {
 
         .{ .name = "G2 Addition", .func = benchG2Add, .sample_size = operation_sample_sizes.g2_add, .is_slow = false },
         .{ .name = "G2 Doubling", .func = benchG2Double, .sample_size = operation_sample_sizes.g2_double, .is_slow = false },
+        .{ .name = "G2 Subgroup Check", .func = benchG2IsInSubgroup, .sample_size = operation_sample_sizes.g2_is_in_subgroup, .is_slow = true },
         .{ .name = "G2 Scalar Multiplication", .func = benchG2ScalarMul, .sample_size = operation_sample_sizes.g2_scalar_mul, .is_slow = true },
 
         // Pairing operations (slow)


### PR DESCRIPTION
## Description
Faster Subgroup check using the frobenius endomorphism.
Also added tests for G2

## AI Disclosure
Codex was used to write the new G2 tests and to add isInSubgroup to the benchmarks

- [x] This PR contains AI-generated code

### AI Tools Used
Codex

### Prompts Used
<!-- List all prompts used to generate the code -->
```
- "Add test to G2"
- "add benchmarks for isInSubgroup"
```

### Human Explanation
<!-- Explain in your own words why this change is needed and what it does -->
We can make the subgroup check faster by using the fact that the frobenius endomorphism acts as multiplication by p only for G2 points.
We use a small polynomial with p as a root in Fr, and check that the point zeroes out. the specific poly is taken from https://eprint.iacr.org/2022/348.pdf

### Performance
237μs -> 66μs For subgroup check

## Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🎉 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [x] ✅ Test additions or updates
- [ ] 🔧 Build/CI/tooling changes
- [x] ⚡️Performance improvements

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] `zig build test` passes
- [x] `zig build` completes successfully
- [x] All existing tests pass
- [x] Added new tests for changes (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I understand and take responsibility for all code in this PR (including AI-generated code)