### PR TITLE
feat: implement EIP-4844 blob gas pricing and validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["lib/foundry-compilers", "lib/ark"]
-exclude = ["bench/evm-bench", "benchmarks"]
+exclude = ["bench/evm-bench", "benchmarks", "lib/voltaire"]
 
 [workspace.package]
 version = "0.1.0"

--- a/lib/voltaire/src/primitives/blob.zig
+++ b/lib/voltaire/src/primitives/blob.zig
@@ -12,6 +12,12 @@ pub const BYTES_PER_BLOB = FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT; //
 pub const MAX_BLOBS_PER_TRANSACTION = 6;
 pub const BLOB_COMMITMENT_VERSION_KZG = 0x01;
 pub const BLOB_BASE_FEE_UPDATE_FRACTION = 3338477;
+pub const TARGET_BLOB_GAS_PER_BLOCK_CANCUN = 393216;
+pub const MAX_BLOB_GAS_PER_BLOCK_CANCUN = 786432;
+pub const BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN = 3338477;
+pub const TARGET_BLOB_GAS_PER_BLOCK_PRAGUE = 786432;
+pub const MAX_BLOB_GAS_PER_BLOCK_PRAGUE = 1179648;
+pub const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE = 5007716;
 pub const MIN_BLOB_BASE_FEE = 1;
 pub const BLOB_GAS_PER_BLOB = 131072; // 2^17
 
@@ -53,8 +59,12 @@ pub fn isValidVersionedHash(h: VersionedHash) bool {
 
 // Calculate blob gas price
 pub fn calculateBlobGasPrice(excess_blob_gas: u64) u64 {
-    // fakeExponential(MIN_BLOB_BASE_FEE, excess_blob_gas, BLOB_BASE_FEE_UPDATE_FRACTION)
-    return fakeExponential(MIN_BLOB_BASE_FEE, excess_blob_gas, BLOB_BASE_FEE_UPDATE_FRACTION);
+    return calculateBlobGasPriceWithFraction(excess_blob_gas, BLOB_BASE_FEE_UPDATE_FRACTION);
+}
+
+/// Calculate the blob gas price using the hardfork-specific update fraction.
+pub fn calculateBlobGasPriceWithFraction(excess_blob_gas: u64, update_fraction: u64) u64 {
+    return fakeExponential(MIN_BLOB_BASE_FEE, excess_blob_gas, update_fraction);
 }
 
 // Fake exponential from EIP-4844
@@ -77,13 +87,19 @@ fn fakeExponential(factor: u64, numerator: u64, denominator: u64) u64 {
 
 // Calculate excess blob gas for next block
 pub fn calculateExcessBlobGas(parent_excess_blob_gas: u64, parent_blob_gas_used: u64) u64 {
-    const target_blob_gas_per_block = 393216; // 3 * BLOB_GAS_PER_BLOB
+    return calculateExcessBlobGasWithTarget(
+        parent_excess_blob_gas,
+        parent_blob_gas_used,
+        TARGET_BLOB_GAS_PER_BLOCK_CANCUN,
+    );
+}
 
+/// Calculate excess blob gas using the hardfork-specific per-block target.
+pub fn calculateExcessBlobGasWithTarget(parent_excess_blob_gas: u64, parent_blob_gas_used: u64, target_blob_gas_per_block: u64) u64 {
     if (parent_excess_blob_gas + parent_blob_gas_used < target_blob_gas_per_block) {
         return 0;
-    } else {
-        return parent_excess_blob_gas + parent_blob_gas_used - target_blob_gas_per_block;
     }
+    return parent_excess_blob_gas + parent_blob_gas_used - target_blob_gas_per_block;
 }
 
 // Blob transaction validation
@@ -203,6 +219,14 @@ test "blob gas price calculation" {
     try testing.expect(price_high > price_low);
 }
 
+test "hardfork-specific blob gas price calculation" {
+    const excess = 10 * BLOB_GAS_PER_BLOB;
+    const cancun = calculateBlobGasPriceWithFraction(excess, BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN);
+    const prague = calculateBlobGasPriceWithFraction(excess, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
+
+    try testing.expect(cancun > prague);
+}
+
 test "excess blob gas calculation" {
     const target = 393216; // 3 blobs
 
@@ -221,6 +245,18 @@ test "excess blob gas calculation" {
     // With existing excess
     excess = calculateExcessBlobGas(BLOB_GAS_PER_BLOB, target);
     try testing.expectEqual(BLOB_GAS_PER_BLOB, excess);
+}
+
+test "hardfork-specific excess blob gas calculation" {
+    const used = 4 * BLOB_GAS_PER_BLOB;
+    try testing.expectEqual(
+        BLOB_GAS_PER_BLOB,
+        calculateExcessBlobGasWithTarget(0, used, TARGET_BLOB_GAS_PER_BLOCK_CANCUN),
+    );
+    try testing.expectEqual(
+        @as(u64, 0),
+        calculateExcessBlobGasWithTarget(0, used, TARGET_BLOB_GAS_PER_BLOCK_PRAGUE),
+    );
 }
 
 test "blob transaction validation" {

--- a/specs/runner.zig
+++ b/specs/runner.zig
@@ -48,6 +48,28 @@ pub fn runJsonTest(allocator: std.mem.Allocator, test_case: std.json.Value) !voi
 
     // Parse environment
     const env = test_case.object.get("env");
+    const hardfork = blk: {
+        if (test_case.object.get("network")) |network| {
+            if (network == .string) break :blk parseHardfork(network.string);
+        }
+        if (test_case.object.get("expect")) |expect_list| {
+            if (expect_list == .array and expect_list.array.items.len > 0) {
+                const first_expect = expect_list.array.items[0];
+                if (first_expect.object.get("network")) |networks| {
+                    if (networks == .array and networks.array.items.len > 0) {
+                        const net = networks.array.items[0].string;
+                        if (std.mem.startsWith(u8, net, ">=")) break :blk parseHardfork(net[2..]);
+                        break :blk parseHardfork(net);
+                    }
+                }
+            }
+        }
+        break :blk evm.Hardfork.CANCUN;
+    };
+    const fixture_eips = evm.Eips{ .hardfork = hardfork };
+    const excess_blob_gas = if (env != null and env.?.object.get("currentExcessBlobGas") != null)
+        try parseIntFromJson(env.?.object.get("currentExcessBlobGas").?)
+    else 0;
     const block_info = evm.BlockInfo{
         .number = if (env != null and env.?.object.get("currentNumber") != null)
             try parseIntFromJson(env.?.object.get("currentNumber").?)
@@ -73,17 +95,8 @@ pub fn runJsonTest(allocator: std.mem.Allocator, test_case: std.json.Value) !voi
             try std.fmt.parseInt(u256, env.?.object.get("currentBaseFee").?.string, 0)
         else 10,
 
-        .blob_base_fee = if (env != null and env.?.object.get("currentBlobBaseFee") != null)
-            try std.fmt.parseInt(u256, env.?.object.get("currentBlobBaseFee").?.string, 0)
-        else 0,
-
-        .blob_versioned_hashes = blk: {
-            if (env) |e| if (e.object.get("currentBlobVersionedHashes")) |hashes| {
-                const bytes = try primitives.Hex.hexToBytes(allocator, hashes.string);
-                break :blk std.mem.bytesAsSlice([32]u8, bytes);
-            };
-            break :blk &.{};
-        },
+        .excess_blob_gas = excess_blob_gas,
+        .blob_base_fee = fixture_eips.blob_gas_price(excess_blob_gas),
         
         .prev_randao = blk: {
             if (env) |e| if (e.object.get("currentRandom")) |rand| {
@@ -214,26 +227,6 @@ pub fn runJsonTest(allocator: std.mem.Allocator, test_case: std.json.Value) !voi
         }
     }
     
-    // Determine hardfork (currently not used, but would be useful for configuring EVM)
-    _ = blk: {
-        // Check for network field in expect
-        if (test_case.object.get("expect")) |expect_list| {
-            if (expect_list == .array and expect_list.array.items.len > 0) {
-                const first_expect = expect_list.array.items[0];
-                if (first_expect.object.get("network")) |networks| {
-                    if (networks == .array and networks.array.items.len > 0) {
-                        const net = networks.array.items[0].string;
-                        if (std.mem.startsWith(u8, net, ">=")) {
-                            break :blk parseHardfork(net[2..]);
-                        }
-                        break :blk parseHardfork(net);
-                    }
-                }
-            }
-        }
-        break :blk evm.Hardfork.CANCUN;
-    };
-    
     // Execute transaction(s)
     const has_transactions = test_case.object.get("transactions") != null;
     const has_transaction = test_case.object.get("transaction") != null;
@@ -267,16 +260,49 @@ pub fn runJsonTest(allocator: std.mem.Allocator, test_case: std.json.Value) !voi
             else
                 Address.zero();
 
-            // Determine gas price
-            const gas_price = if (tx.object.get("gasPrice")) |g| blk: {
-                break :blk try parseIntFromJson(g);
-            } else 10;
+            const max_fee_per_gas: ?u256 = if (tx.object.get("maxFeePerGas")) |fee|
+                try parseIntFromJson(fee)
+            else null;
+            const max_priority_fee_per_gas: u256 = if (tx.object.get("maxPriorityFeePerGas")) |fee|
+                try parseIntFromJson(fee)
+            else 0;
+            const gas_price: u256 = if (tx.object.get("gasPrice")) |g|
+                try parseIntFromJson(g)
+            else if (max_fee_per_gas) |max_fee|
+                @min(max_fee, block_info.base_fee + max_priority_fee_per_gas)
+            else 0;
+
+            const max_fee_per_blob_gas: u256 = if (tx.object.get("maxFeePerBlobGas")) |fee|
+                try parseIntFromJson(fee)
+            else 0;
+            const is_blob_transaction = tx.object.get("blobVersionedHashes") != null or blk: {
+                const tx_type = tx.object.get("type") orelse break :blk false;
+                break :blk try parseIntFromJson(tx_type) == 3;
+            };
+            const blob_versioned_hashes = blk: {
+                const hashes = tx.object.get("blobVersionedHashes") orelse break :blk &.{};
+                if (hashes != .array) break :blk &.{};
+                const list = try allocator.alloc([32]u8, hashes.array.items.len);
+                errdefer allocator.free(list);
+                for (hashes.array.items, 0..) |item, i| {
+                    const bytes = try primitives.Hex.hexToBytes(allocator, item.string);
+                    defer allocator.free(bytes);
+                    if (bytes.len != 32) return error.InvalidBlobVersionedHashLength;
+                    @memcpy(&list[i], bytes);
+                }
+                break :blk list;
+            };
+            defer if (blob_versioned_hashes.len > 0) allocator.free(blob_versioned_hashes);
 
             // Create EVM with transaction context (create per transaction to set correct origin)
             const tx_context = evm.TransactionContext{
                 .gas_limit = 10000000,
                 .coinbase = block_info.coinbase,
                 .chain_id = 1,
+                .blob_versioned_hashes = blob_versioned_hashes,
+                .is_blob_transaction = is_blob_transaction,
+                .max_fee_per_gas = max_fee_per_gas,
+                .max_fee_per_blob_gas = max_fee_per_blob_gas,
             };
 
             var evm_instance = try evm.DefaultEvm.init(
@@ -523,6 +549,7 @@ pub const TestEnv = struct {
     currentTimestamp: ?[]const u8 = null,
     currentRandom: ?[]const u8 = null,
     currentBaseFee: ?[]const u8 = null,
+    currentExcessBlobGas: ?[]const u8 = null,
 };
 
 pub const AccountState = struct {
@@ -542,6 +569,11 @@ pub const Transaction = struct {
     data: ?[]const u8 = null,
     gasLimit: ?[]const u8 = null,
     gasPrice: ?[]const u8 = null,
+    maxFeePerGas: ?[]const u8 = null,
+    maxPriorityFeePerGas: ?[]const u8 = null,
+    maxFeePerBlobGas: ?[]const u8 = null,
+    blobVersionedHashes: ?[]const []const u8 = null,
+    type: ?[]const u8 = null,
     nonce: ?[]const u8 = null,
     to: ?[]const u8 = null,
     value: ?[]const u8 = null,
@@ -853,6 +885,8 @@ fn isAssemblyCode(code: []const u8) bool {
 fn parseHardfork(network: []const u8) evm.Hardfork {
     if (std.mem.eql(u8, network, "Shanghai")) return .SHANGHAI;
     if (std.mem.eql(u8, network, "Cancun")) return .CANCUN;
+    if (std.mem.eql(u8, network, "Prague")) return .PRAGUE;
+    if (std.mem.eql(u8, network, "Osaka")) return .OSAKA;
     if (std.mem.eql(u8, network, "Paris")) return .SHANGHAI; // Map Paris to Shanghai
     if (std.mem.eql(u8, network, "London")) return .LONDON;
     if (std.mem.eql(u8, network, "Berlin")) return .BERLIN;

--- a/src/block/block_info.zig
+++ b/src/block/block_info.zig
@@ -47,10 +47,13 @@ pub fn BlockInfo(comptime config: BlockInfoConfig) type {
         /// Blob base fee for EIP-4844 (cold data)
         /// Set to 0 for non-Cancun hardforks
         blob_base_fee: BaseFeeType = 0,
-        /// Blob versioned hashes for EIP-4844 blob transactions (cold data)
-        /// Empty slice for non-blob transactions
-        /// TODO: this is a transaction-level setting (should be in TransactionContext)
+        /// Deprecated compatibility field. BLOBHASH reads versioned hashes from
+        /// TransactionContext; new callers must leave this empty.
         blob_versioned_hashes: []const [32]u8 = &.{},
+        /// Excess blob gas carried by the block header (EIP-4844).
+        excess_blob_gas: u64 = 0,
+        /// Blob gas consumed by all transactions in this block.
+        blob_gas_used: u64 = 0,
         /// Beacon block root for EIP-4788 (Dencun)
         /// Contains the parent beacon block root for trust-minimized access to consensus layer
         beacon_root: ?[32]u8 = null,
@@ -102,6 +105,8 @@ test "block info initialization" {
     try std.testing.expectEqual([_]u8{0} ** 32, block.prev_randao);
     try std.testing.expectEqual(@as(u256, 0), block.blob_base_fee);
     try std.testing.expectEqual(@as(usize, 0), block.blob_versioned_hashes.len);
+    try std.testing.expectEqual(@as(u64, 0), block.excess_blob_gas);
+    try std.testing.expectEqual(@as(u64, 0), block.blob_gas_used);
 }
 
 test "block info custom values" {

--- a/src/block/transaction_context.zig
+++ b/src/block/transaction_context.zig
@@ -18,26 +18,36 @@ pub const TransactionContext = struct {
     /// Blob versioned hashes for EIP-4844 blob transactions
     /// Empty slice for non-blob transactions
     blob_versioned_hashes: []const [32]u8 = &.{},
-    /// Blob base fee for EIP-4844
-    /// Set to 0 for non-Cancun hardforks
-    /// TODO: this is a block-level setting (and already present in BlockInfo), should be removed
+    /// Deprecated compatibility field. Blob base fee is block-level and EVM
+    /// execution reads BlockInfo.blob_base_fee exclusively.
     blob_base_fee: u256 = 0,
+    /// Whether the transaction is an EIP-4844 type-3 transaction.
+    /// This remains distinct from blob_versioned_hashes so zero-blob type-3
+    /// transactions can be rejected.
+    is_blob_transaction: bool = false,
+    /// EIP-1559 fee cap used for the transaction's upfront balance check.
+    /// Null for legacy transactions, whose gas_price is already their fee cap.
+    max_fee_per_gas: ?u256 = null,
+    /// EIP-4844 fee cap used for validation and the upfront balance check.
+    max_fee_per_blob_gas: u256 = 0,
 };
 
 test "TransactionContext creation and field access" {
     const coinbase_addr = Address{ .bytes = [_]u8{0x01} ++ [_]u8{0x00} ** 19 };
-    
+
     const tx_context = TransactionContext{
         .gas_limit = 21000,
         .coinbase = coinbase_addr,
         .chain_id = 1,
     };
-    
+
     try std.testing.expectEqual(@as(u64, 21000), tx_context.gas_limit);
     try std.testing.expectEqual(coinbase_addr, tx_context.coinbase);
     try std.testing.expectEqual(@as(u16, 1), tx_context.chain_id);
     try std.testing.expectEqual(@as(usize, 0), tx_context.blob_versioned_hashes.len);
-    try std.testing.expectEqual(@as(u256, 0), tx_context.blob_base_fee);
+    try std.testing.expect(!tx_context.is_blob_transaction);
+    try std.testing.expectEqual(@as(?u256, null), tx_context.max_fee_per_gas);
+    try std.testing.expectEqual(@as(u256, 0), tx_context.max_fee_per_blob_gas);
 }
 
 test "TransactionContext with maximum values" {
@@ -46,13 +56,15 @@ test "TransactionContext with maximum values" {
         .gas_limit = std.math.maxInt(u64),
         .coinbase = max_addr,
         .chain_id = std.math.maxInt(u16),
-        .blob_base_fee = std.math.maxInt(u256),
+        .max_fee_per_gas = std.math.maxInt(u256),
+        .max_fee_per_blob_gas = std.math.maxInt(u256),
     };
-    
+
     try std.testing.expectEqual(std.math.maxInt(u64), max_tx_context.gas_limit);
     try std.testing.expectEqual(max_addr, max_tx_context.coinbase);
     try std.testing.expectEqual(std.math.maxInt(u16), max_tx_context.chain_id);
-    try std.testing.expectEqual(std.math.maxInt(u256), max_tx_context.blob_base_fee);
+    try std.testing.expectEqual(std.math.maxInt(u256), max_tx_context.max_fee_per_gas.?);
+    try std.testing.expectEqual(std.math.maxInt(u256), max_tx_context.max_fee_per_blob_gas);
 }
 
 test "TransactionContext with zero values" {
@@ -62,7 +74,7 @@ test "TransactionContext with zero values" {
         .coinbase = zero_addr,
         .chain_id = 0,
     };
-    
+
     try std.testing.expectEqual(@as(u64, 0), zero_tx_context.gas_limit);
     try std.testing.expectEqual(zero_addr, zero_tx_context.coinbase);
     try std.testing.expectEqual(@as(u16, 0), zero_tx_context.chain_id);
@@ -73,20 +85,22 @@ test "TransactionContext with blob data (EIP-4844)" {
     const blob_hash1 = [_]u8{0x01} ** 32;
     const blob_hash2 = [_]u8{0x02} ** 32;
     const blob_hashes = [_][32]u8{ blob_hash1, blob_hash2 };
-    
+
     const blob_tx_context = TransactionContext{
         .gas_limit = 30_000_000,
         .coinbase = coinbase_addr,
         .chain_id = 1,
         .blob_versioned_hashes = &blob_hashes,
-        .blob_base_fee = 1_000_000_000, // 1 gwei
+        .is_blob_transaction = true,
+        .max_fee_per_blob_gas = 1_000_000_000, // 1 gwei
     };
-    
+
     try std.testing.expectEqual(@as(u64, 30_000_000), blob_tx_context.gas_limit);
     try std.testing.expectEqual(coinbase_addr, blob_tx_context.coinbase);
     try std.testing.expectEqual(@as(u16, 1), blob_tx_context.chain_id);
     try std.testing.expectEqual(@as(usize, 2), blob_tx_context.blob_versioned_hashes.len);
     try std.testing.expectEqual(blob_hash1, blob_tx_context.blob_versioned_hashes[0]);
     try std.testing.expectEqual(blob_hash2, blob_tx_context.blob_versioned_hashes[1]);
-    try std.testing.expectEqual(@as(u256, 1_000_000_000), blob_tx_context.blob_base_fee);
+    try std.testing.expect(blob_tx_context.is_blob_transaction);
+    try std.testing.expectEqual(@as(u256, 1_000_000_000), blob_tx_context.max_fee_per_blob_gas);
 }

--- a/src/eips_and_hardforks/eips.zig
+++ b/src/eips_and_hardforks/eips.zig
@@ -8,6 +8,15 @@ pub const EipOverride = struct {
     enabled: bool,
 };
 
+pub const BlobValidationError = error{
+    BlobTransactionsDisabled,
+    NoBlobs,
+    TooManyBlobs,
+    MaxFeePerBlobGasTooLow,
+    InvalidVersionedHash,
+    BlobContractCreation,
+};
+
 // EIPs is a comptime known configuration of Eip and hardfork specific behavior
 // This struct consolidates all EIP-specific logic for the EVM
 pub const Eips = struct {
@@ -227,7 +236,6 @@ pub const Eips = struct {
         for (active_eips) |active_eip| if (active_eip == eip) return true;
         return false;
     }
-
 
     /// EIP-170: Get maximum contract code size based on hardfork
     pub fn eip_170_max_code_size(self: Self) u32 {
@@ -482,6 +490,91 @@ pub const Eips = struct {
         const gas_used = initial_gas - gas_left;
         const capped_refund = self.eip_3529_gas_refund_cap(gas_used, gas_refund_counter);
         return @min(initial_gas, gas_left + capped_refund);
+    }
+
+    /// Target blob gas per block for the configured hardfork.
+    pub fn target_blob_gas(self: Self) u64 {
+        if (!self.is_eip_active(4844)) return 0;
+        return if (self.hardfork.isAtLeast(.PRAGUE))
+            primitives.Blob.TARGET_BLOB_GAS_PER_BLOCK_PRAGUE
+        else
+            primitives.Blob.TARGET_BLOB_GAS_PER_BLOCK_CANCUN;
+    }
+
+    /// Maximum blob gas per block for the configured hardfork.
+    pub fn max_blob_gas(self: Self) u64 {
+        if (!self.is_eip_active(4844)) return 0;
+        return if (self.hardfork.isAtLeast(.PRAGUE))
+            primitives.Blob.MAX_BLOB_GAS_PER_BLOCK_PRAGUE
+        else
+            primitives.Blob.MAX_BLOB_GAS_PER_BLOCK_CANCUN;
+    }
+
+    /// Blob base-fee update fraction for the configured hardfork.
+    pub fn blob_base_fee_update_fraction(self: Self) u64 {
+        if (!self.is_eip_active(4844)) return 0;
+        return if (self.hardfork.isAtLeast(.PRAGUE))
+            primitives.Blob.BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
+        else
+            primitives.Blob.BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN;
+    }
+
+    /// Calculate the current blob gas price from excess blob gas.
+    pub fn blob_gas_price(self: Self, excess_gas: u64) u64 {
+        if (!self.is_eip_active(4844)) return 0;
+        return primitives.Blob.calculateBlobGasPriceWithFraction(
+            excess_gas,
+            self.blob_base_fee_update_fraction(),
+        );
+    }
+
+    /// Validate all EIP-4844 transaction-level constraints available to the EVM.
+    pub fn validate_blob_gas(
+        self: Self,
+        is_blob_transaction: bool,
+        blob_versioned_hashes: []const [32]u8,
+        max_fee_per_blob_gas: u256,
+        current_blob_base_fee: u256,
+        to: ?primitives.Address,
+    ) BlobValidationError!void {
+        if (!is_blob_transaction) return;
+        if (!self.is_eip_active(4844)) return BlobValidationError.BlobTransactionsDisabled;
+        if (to == null) return BlobValidationError.BlobContractCreation;
+        if (blob_versioned_hashes.len == 0) return BlobValidationError.NoBlobs;
+
+        const max_blobs = self.max_blob_gas() / primitives.Blob.BLOB_GAS_PER_BLOB;
+        if (blob_versioned_hashes.len > max_blobs) return BlobValidationError.TooManyBlobs;
+        if (max_fee_per_blob_gas < current_blob_base_fee) return BlobValidationError.MaxFeePerBlobGasTooLow;
+
+        for (blob_versioned_hashes) |hash| {
+            if (!primitives.Blob.isValidVersionedHash(.{ .bytes = hash })) {
+                return BlobValidationError.InvalidVersionedHash;
+            }
+        }
+    }
+
+    /// Actual burned blob fee for a transaction.
+    pub fn blob_gas_cost(self: Self, base_fee: u256, blob_count: usize) u256 {
+        if (!self.is_eip_active(4844)) return 0;
+        const blob_gas = @as(u256, blob_count) * primitives.Blob.BLOB_GAS_PER_BLOB;
+        return blob_gas *| base_fee;
+    }
+
+    /// Maximum blob cost used only for the upfront affordability check.
+    pub fn max_blob_gas_cost(self: Self, max_fee_per_blob_gas: u256, blob_count: usize) u256 {
+        if (!self.is_eip_active(4844)) return 0;
+        const blob_gas = @as(u256, blob_count) * primitives.Blob.BLOB_GAS_PER_BLOB;
+        return blob_gas *| max_fee_per_blob_gas;
+    }
+
+    /// Calculate excess blob gas for the next block.
+    pub fn excess_blob_gas(self: Self, parent_excess: u64, parent_blob_gas_used: u64) u64 {
+        if (!self.is_eip_active(4844)) return 0;
+        return primitives.Blob.calculateExcessBlobGasWithTarget(
+            parent_excess,
+            parent_blob_gas_used,
+            self.target_blob_gas(),
+        );
     }
 };
 
@@ -832,7 +925,6 @@ test "initcode_size_boundaries" {
     // Test that the limit doubled
     try std.testing.expectEqual(pre_shanghai.size_limit() * 2, post_shanghai.size_limit());
 }
-
 
 test "specific eip helper functions" {
     const frontier = Eips{ .hardfork = Hardfork.FRONTIER };

--- a/src/evm.zig
+++ b/src/evm.zig
@@ -124,13 +124,12 @@ pub fn Evm(config: EvmConfig) type {
         /// Contracts marked for self-destruction (cold - only used in old hardforks)
         self_destruct: SelfDestruct,
 
-
         // State dump tracking - persists across calls
         /// Tracks all addresses that have been touched (for state dump)
         touched_addresses: std.AutoHashMap(primitives.Address, void),
         /// Tracks storage slots that have been modified (address -> list of storage keys)
         touched_storage: std.AutoHashMap(primitives.Address, std.ArrayList(u256)),
-        
+
         // Tracer - at the very bottom of memory layout for minimal impact on cache performance
         /// Tracer for debugging and logging - can be accessed via evm.tracer or frame.evm_ptr.tracer
         tracer: @import("tracer/tracer.zig").Tracer,
@@ -293,14 +292,14 @@ pub fn Evm(config: EvmConfig) type {
         /// State dump structure for post-state validation
         pub const StateDump = struct {
             accounts: std.StringHashMap(AccountState),
-            
+
             pub const AccountState = struct {
                 balance: u256,
                 nonce: u64,
                 code: []const u8,
                 storage: std.AutoHashMap(u256, u256),
             };
-            
+
             pub fn deinit(self: *StateDump, allocator: std.mem.Allocator) void {
                 var it = self.accounts.iterator();
                 while (it.next()) |entry| {
@@ -311,7 +310,7 @@ pub fn Evm(config: EvmConfig) type {
                 self.accounts.deinit();
             }
         };
-        
+
         /// Dump the current state of all touched accounts in the database.
         ///
         /// Creates a snapshot of all accounts that have been accessed or modified
@@ -346,13 +345,13 @@ pub fn Evm(config: EvmConfig) type {
                     log.debug("[DUMP] account not found in database", .{});
                     continue;
                 };
-                log.debug("[DUMP] found account: balance={d}, nonce={d}", .{account.balance, account.nonce});
-                
+                log.debug("[DUMP] found account: balance={d}, nonce={d}", .{ account.balance, account.nonce });
+
                 // Skip zero balance, zero nonce accounts with no code
                 if (account.balance == 0 and account.nonce == 0 and std.mem.eql(u8, &account.code_hash, &([_]u8{0} ** 32))) {
                     continue;
                 }
-                
+
                 // Convert address to hex string
                 var addr_hex: [42]u8 = undefined;
                 @memcpy(addr_hex[0..2], "0x");
@@ -362,17 +361,17 @@ pub fn Evm(config: EvmConfig) type {
                     addr_hex[2 + i * 2 + 1] = chars[byte & 0x0F];
                 }
                 const addr_str = try allocator.dupe(u8, &addr_hex);
-                
+
                 // Get code if present
                 var code: []u8 = &.{};
                 if (!std.mem.eql(u8, &account.code_hash, &([_]u8{0} ** 32))) {
                     const db_code = try self.database.get_code(account.code_hash);
                     code = try allocator.dupe(u8, db_code);
                 }
-                
+
                 // Get storage
                 var storage = std.AutoHashMap(u256, u256).init(allocator);
-                
+
                 // Get tracked storage slots for this address
                 if (self.touched_storage.get(addr)) |slots| {
                     for (slots.items) |slot| {
@@ -382,7 +381,7 @@ pub fn Evm(config: EvmConfig) type {
                         }
                     }
                 }
-                
+
                 try state_dump.accounts.put(addr_str, StateDump.AccountState{
                     .balance = account.balance,
                     .nonce = account.nonce,
@@ -390,7 +389,7 @@ pub fn Evm(config: EvmConfig) type {
                     .storage = storage,
                 });
             }
-            
+
             return state_dump;
         }
 
@@ -508,6 +507,47 @@ pub fn Evm(config: EvmConfig) type {
                 break :blk params.getGas() - intrinsic_gas;
             };
 
+            const blob_versioned_hashes = self.context.blob_versioned_hashes;
+            const blob_count = if (self.context.is_blob_transaction) blob_versioned_hashes.len else 0;
+            config.eips.validate_blob_gas(
+                self.context.is_blob_transaction,
+                blob_versioned_hashes,
+                self.context.max_fee_per_blob_gas,
+                self.block_info.blob_base_fee,
+                params.get_to(),
+            ) catch |err| {
+                log.err("Blob transaction validation failed: {s}", .{@errorName(err)});
+                return CallResult.failure(self.getCallArenaAllocator(), 0) catch unreachable;
+            };
+
+            const max_blob_gas_cost = config.eips.max_blob_gas_cost(
+                self.context.max_fee_per_blob_gas,
+                blob_count,
+            );
+
+            // Transaction validity is checked before nonce increment or execution.
+            // EIP-1559 reserves the fee cap, not the lower effective gas price.
+            if (!config.disable_balance_checks) {
+                const origin_account = self.database.get_account(self.origin.bytes) catch |err| {
+                    log.err("Failed to read origin account for upfront balance check: {s}", .{@errorName(err)});
+                    return CallResult.failure(self.getCallArenaAllocator(), 0) catch unreachable;
+                };
+                const origin_balance = if (origin_account) |account| account.balance else 0;
+                const gas_fee_cap = self.context.max_fee_per_gas orelse self.gas_price;
+                const max_execution_cost = @mulWithOverflow(@as(u256, params.getGas()), gas_fee_cap);
+                if (max_execution_cost[1] != 0) {
+                    return CallResult.failure(self.getCallArenaAllocator(), 0) catch unreachable;
+                }
+                const execution_and_value = @addWithOverflow(max_execution_cost[0], params.getValue());
+                if (execution_and_value[1] != 0) {
+                    return CallResult.failure(self.getCallArenaAllocator(), 0) catch unreachable;
+                }
+                const required_balance = @addWithOverflow(execution_and_value[0], max_blob_gas_cost);
+                if (required_balance[1] != 0 or origin_balance < required_balance[0]) {
+                    return CallResult.failure(self.getCallArenaAllocator(), 0) catch unreachable;
+                }
+            }
+
             // Increment origin nonce for top-level transactions (EIP-2718)
             // This must happen after gas deduction but before inner_call execution
             {
@@ -547,11 +587,16 @@ pub fn Evm(config: EvmConfig) type {
                 self.gas_refund_counter = 0;
             }
 
-            // Deduct gas fees from sender's balance and pay coinbase
+            // Blob fees are fully burned and are never credited to coinbase.
             const gas_consumed = initial_gas - result.gas_left;
-            if (gas_consumed > 0 and self.gas_price > 0) {
-                const gas_consumed_u256: u256 = @intCast(gas_consumed);
-                const total_gas_fee = self.gas_price * gas_consumed_u256;
+            const gas_consumed_u256: u256 = @intCast(gas_consumed);
+            const execution_gas_fee = self.gas_price * gas_consumed_u256;
+            const blob_gas_cost = config.eips.blob_gas_cost(
+                self.block_info.blob_base_fee,
+                blob_count,
+            );
+            const total_gas_fee = execution_gas_fee +| blob_gas_cost;
+            if (total_gas_fee > 0) {
 
                 // Get origin account
                 var origin_account = self.database.get_account(self.origin.bytes) catch |err| {
@@ -583,7 +628,7 @@ pub fn Evm(config: EvmConfig) type {
                 };
 
                 // Handle coinbase rewards (miner/validator payment)
-                if (config.eips.eip_1559_is_enabled()) {
+                if (config.eips.eip_1559_is_enabled() and execution_gas_fee > 0) {
                     // EIP-1559: Only priority fee goes to coinbase, base fee is burned
                     const base_fee = self.block_info.base_fee;
                     const priority_fee_per_gas = if (self.gas_price > base_fee)
@@ -611,8 +656,8 @@ pub fn Evm(config: EvmConfig) type {
                         };
                     }
                     // Base fee (total_gas_fee - coinbase_reward) is effectively burned
-                } else {
-                    // Pre-EIP-1559: All fees go to coinbase
+                } else if (execution_gas_fee > 0) {
+                    // Pre-EIP-1559: All execution fees go to coinbase.
                     var coinbase_account = self.database.get_account(self.block_info.coinbase.bytes) catch {
                         return result;
                     } orelse Account.zero();
@@ -621,7 +666,7 @@ pub fn Evm(config: EvmConfig) type {
                         return result;
                     };
 
-                    coinbase_account.balance += total_gas_fee;
+                    coinbase_account.balance += execution_gas_fee;
                     self.database.set_account(self.block_info.coinbase.bytes, coinbase_account) catch {
                         return result;
                     };

--- a/src/frame/call_params.zig
+++ b/src/frame/call_params.zig
@@ -152,16 +152,21 @@ pub fn CallParams(config: anytype) type {
             };
         }
 
-        /// Check if this call operation transfers value
-        pub fn hasValue(self: @This()) bool {
+        /// Get the value transferred by this call operation.
+        pub fn getValue(self: @This()) u256 {
             return switch (self) {
-                .call => |params| params.value > 0,
-                .callcode => |params| params.value > 0,
-                .delegatecall => false, // DELEGATECALL preserves value from parent context
-                .staticcall => false, // STATICCALL cannot transfer value
-                .create => |params| params.value > 0,
-                .create2 => |params| params.value > 0,
+                .call => |params| params.value,
+                .callcode => |params| params.value,
+                .delegatecall => 0,
+                .staticcall => 0,
+                .create => |params| params.value,
+                .create2 => |params| params.value,
             };
+        }
+
+        /// Check if this call operation transfers value.
+        pub fn hasValue(self: @This()) bool {
+            return self.getValue() > 0;
         }
 
         /// Check if this is a read-only operation

--- a/src/instructions/handlers_context.zig
+++ b/src/instructions/handlers_context.zig
@@ -792,11 +792,8 @@ pub fn Handlers(FrameType: type) type {
                 const op_data = dispatch.getOpData(.BLOBHASH); // Use op_data.next_handler and op_data.next_cursor directly
                 return @call(FrameType.Dispatch.getTailCallModifier(), op_data.next_handler, .{ self, op_data.next_cursor.cursor });
             }
-            const index_usize = @as(usize, @intCast(index));
-            // Check if index is within bounds of versioned hashes
-            const block_info = self.getEvm().get_block_info();
-            if (index_usize < block_info.blob_versioned_hashes.len) {
-                const hash = block_info.blob_versioned_hashes[index_usize];
+            // Versioned hashes are transaction-level context, not block data.
+            if (self.getEvm().get_blob_hash(index)) |hash| {
                 // Convert [32]u8 to u256
                 var hash_value: u256 = 0;
                 for (hash) |byte| {

--- a/test/blob_gas_test.zig
+++ b/test/blob_gas_test.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+const evm = @import("evm");
+const primitives = @import("voltaire");
+
+const Address = primitives.Address.Address;
+const blob = primitives.Blob;
+const Eips = evm.Eips;
+
+test "blob gas pricing and excess accumulation across hardforks" {
+    const cancun = Eips{ .hardfork = .CANCUN };
+    const prague = Eips{ .hardfork = .PRAGUE };
+    const osaka = Eips{ .hardfork = .OSAKA };
+
+    try std.testing.expectEqual(@as(u64, 1), cancun.blob_gas_price(0));
+    try std.testing.expect(cancun.blob_gas_price(100 * blob.BLOB_GAS_PER_BLOB) > cancun.blob_gas_price(blob.BLOB_GAS_PER_BLOB));
+    try std.testing.expect(cancun.blob_gas_price(100 * blob.BLOB_GAS_PER_BLOB) > prague.blob_gas_price(100 * blob.BLOB_GAS_PER_BLOB));
+    try std.testing.expectEqual(prague.target_blob_gas(), osaka.target_blob_gas());
+    try std.testing.expectEqual(prague.max_blob_gas(), osaka.max_blob_gas());
+
+    var excess = cancun.excess_blob_gas(0, cancun.target_blob_gas());
+    try std.testing.expectEqual(@as(u64, 0), excess);
+    excess = cancun.excess_blob_gas(excess, cancun.target_blob_gas() + blob.BLOB_GAS_PER_BLOB);
+    try std.testing.expectEqual(blob.BLOB_GAS_PER_BLOB, excess);
+    excess = cancun.excess_blob_gas(excess, cancun.target_blob_gas() - blob.BLOB_GAS_PER_BLOB);
+    try std.testing.expectEqual(@as(u64, 0), excess);
+
+    const max_blobs = cancun.max_blob_gas() / blob.BLOB_GAS_PER_BLOB;
+    for (1..max_blobs + 1) |count| {
+        try std.testing.expectEqual(
+            @as(u256, count * blob.BLOB_GAS_PER_BLOB * 7),
+            cancun.blob_gas_cost(7, count),
+        );
+    }
+}
+
+test "blob transaction validation table" {
+    const cancun = Eips{ .hardfork = .CANCUN };
+    const prague = Eips{ .hardfork = .PRAGUE };
+    const to = Address{ .bytes = [_]u8{0x22} ** 20 };
+    const valid_hash = [_]u8{blob.BLOB_COMMITMENT_VERSION_KZG} ++ [_]u8{0x44} ** 31;
+    const invalid_hash = [_]u8{0x02} ++ [_]u8{0x44} ** 31;
+    const cancun_max = cancun.max_blob_gas() / blob.BLOB_GAS_PER_BLOB;
+    const prague_max = prague.max_blob_gas() / blob.BLOB_GAS_PER_BLOB;
+    var too_many: [10][32]u8 = [_][32]u8{valid_hash} ** 10;
+
+    try std.testing.expectError(error.NoBlobs, cancun.validate_blob_gas(true, &.{}, 1, 1, to));
+    try std.testing.expectError(error.TooManyBlobs, cancun.validate_blob_gas(true, too_many[0 .. cancun_max + 1], 1, 1, to));
+    try std.testing.expectError(error.MaxFeePerBlobGasTooLow, cancun.validate_blob_gas(true, &.{valid_hash}, 1, 2, to));
+    try std.testing.expectError(error.InvalidVersionedHash, cancun.validate_blob_gas(true, &.{invalid_hash}, 1, 1, to));
+    try std.testing.expectError(error.BlobContractCreation, cancun.validate_blob_gas(true, &.{valid_hash}, 1, 1, null));
+    try std.testing.expectError(error.TooManyBlobs, prague.validate_blob_gas(true, too_many[0 .. prague_max + 1], 1, 1, to));
+    try cancun.validate_blob_gas(false, &.{}, 0, 1, null);
+}
+
+test "blob fee settlement burns blob fee when execution gas price is zero" {
+    const allocator = std.testing.allocator;
+    const DefaultEvm = evm.Evm(.{});
+    const origin = Address{ .bytes = [_]u8{0x11} ** 20 };
+    const recipient = Address{ .bytes = [_]u8{0x22} ** 20 };
+    const coinbase = Address{ .bytes = [_]u8{0x33} ** 20 };
+    const versioned_hash = [_]u8{blob.BLOB_COMMITMENT_VERSION_KZG} ++ [_]u8{0x55} ** 31;
+    const blob_base_fee: u256 = 2;
+    const required = @as(u256, blob.BLOB_GAS_PER_BLOB) * blob_base_fee;
+
+    var database = evm.Database.init(allocator);
+    defer database.deinit();
+    try database.set_account(origin.bytes, .{
+        .balance = required,
+        .nonce = 0,
+        .code_hash = primitives.EMPTY_CODE_HASH,
+        .storage_root = [_]u8{0} ** 32,
+    });
+    try database.set_account(recipient.bytes, evm.Account.zero());
+
+    const block_info = evm.BlockInfo{
+        .number = 20_000_000,
+        .timestamp = 1_710_338_135,
+        .difficulty = 0,
+        .gas_limit = 30_000_000,
+        .coinbase = coinbase,
+        .base_fee = 0,
+        .prev_randao = [_]u8{0} ** 32,
+        .blob_base_fee = blob_base_fee,
+    };
+    const tx_context = evm.TransactionContext{
+        .gas_limit = 100_000,
+        .coinbase = coinbase,
+        .chain_id = 1,
+        .blob_versioned_hashes = &.{versioned_hash},
+        .is_blob_transaction = true,
+        .max_fee_per_gas = 0,
+        .max_fee_per_blob_gas = blob_base_fee,
+    };
+    var instance = try DefaultEvm.init(allocator, &database, block_info, tx_context, 0, origin);
+    defer instance.deinit();
+
+    var result = instance.call(.{ .call = .{
+        .caller = origin,
+        .to = recipient,
+        .value = 0,
+        .input = &.{},
+        .gas = 100_000,
+    } });
+    defer result.deinit(allocator);
+
+    const sender = (try database.get_account(origin.bytes)).?;
+    const miner = (try database.get_account(coinbase.bytes)) orelse evm.Account.zero();
+    try std.testing.expect(result.success);
+    try std.testing.expectEqual(@as(u256, 0), sender.balance);
+    try std.testing.expectEqual(@as(u64, 1), sender.nonce);
+    try std.testing.expectEqual(@as(u256, 0), miner.balance);
+}
+
+test "blob fee settlement credits only priority fee and burns base fees" {
+    const allocator = std.testing.allocator;
+    const DefaultEvm = evm.Evm(.{});
+    const origin = Address{ .bytes = [_]u8{0x41} ** 20 };
+    const recipient = Address{ .bytes = [_]u8{0x42} ** 20 };
+    const coinbase = Address{ .bytes = [_]u8{0x43} ** 20 };
+    const versioned_hash = [_]u8{blob.BLOB_COMMITMENT_VERSION_KZG} ++ [_]u8{0x66} ** 31;
+    const initial_sender: u256 = 10_000_000;
+    const initial_coinbase: u256 = 100;
+    const gas_price: u256 = 7;
+    const base_fee: u256 = 5;
+    const blob_base_fee: u256 = 2;
+
+    var database = evm.Database.init(allocator);
+    defer database.deinit();
+    try database.set_account(origin.bytes, .{ .balance = initial_sender, .nonce = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32 });
+    try database.set_account(coinbase.bytes, .{ .balance = initial_coinbase, .nonce = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32 });
+    try database.set_account(recipient.bytes, evm.Account.zero());
+
+    const block_info = evm.BlockInfo{
+        .number = 20_000_000,
+        .timestamp = 1_710_338_135,
+        .difficulty = 0,
+        .gas_limit = 30_000_000,
+        .coinbase = coinbase,
+        .base_fee = base_fee,
+        .prev_randao = [_]u8{0} ** 32,
+        .blob_base_fee = blob_base_fee,
+    };
+    const tx_context = evm.TransactionContext{
+        .gas_limit = 100_000,
+        .coinbase = coinbase,
+        .chain_id = 1,
+        .blob_versioned_hashes = &.{versioned_hash},
+        .is_blob_transaction = true,
+        .max_fee_per_gas = 10,
+        .max_fee_per_blob_gas = 3,
+    };
+    var instance = try DefaultEvm.init(allocator, &database, block_info, tx_context, gas_price, origin);
+    defer instance.deinit();
+
+    var result = instance.call(.{ .call = .{ .caller = origin, .to = recipient, .value = 0, .input = &.{}, .gas = 100_000 } });
+    defer result.deinit(allocator);
+    const gas_used: u256 = 100_000 - result.gas_left;
+    const execution_fee = gas_price * gas_used;
+    const blob_fee = @as(u256, blob.BLOB_GAS_PER_BLOB) * blob_base_fee;
+    const priority_fee = (gas_price - base_fee) * gas_used;
+    const sender = (try database.get_account(origin.bytes)).?;
+    const miner = (try database.get_account(coinbase.bytes)).?;
+    const recipient_account = (try database.get_account(recipient.bytes)) orelse evm.Account.zero();
+    try std.testing.expect(result.success);
+
+    try std.testing.expectEqual(initial_sender - execution_fee - blob_fee, sender.balance);
+    try std.testing.expectEqual(initial_coinbase + priority_fee, miner.balance);
+    const initial_supply = initial_sender + initial_coinbase;
+    const final_supply = sender.balance + miner.balance + recipient_account.balance;
+    try std.testing.expectEqual(base_fee * gas_used + blob_fee, initial_supply - final_supply);
+}
+
+test "upfront balance check rejects required minus one without nonce bump" {
+    const allocator = std.testing.allocator;
+    const DefaultEvm = evm.Evm(.{});
+    const origin = Address{ .bytes = [_]u8{0x71} ** 20 };
+    const recipient = Address{ .bytes = [_]u8{0x72} ** 20 };
+    const coinbase = Address{ .bytes = [_]u8{0x73} ** 20 };
+    const versioned_hash = [_]u8{blob.BLOB_COMMITMENT_VERSION_KZG} ++ [_]u8{0x77} ** 31;
+    const required: u256 = 100_000 + blob.BLOB_GAS_PER_BLOB;
+
+    var database = evm.Database.init(allocator);
+    defer database.deinit();
+    try database.set_account(origin.bytes, .{ .balance = required - 1, .nonce = 0, .code_hash = primitives.EMPTY_CODE_HASH, .storage_root = [_]u8{0} ** 32 });
+    try database.set_account(recipient.bytes, evm.Account.zero());
+
+    const block_info = evm.BlockInfo{ .number = 20_000_000, .timestamp = 1_710_338_135, .difficulty = 0, .gas_limit = 30_000_000, .coinbase = coinbase, .base_fee = 0, .prev_randao = [_]u8{0} ** 32, .blob_base_fee = 1 };
+    const tx_context = evm.TransactionContext{ .gas_limit = 100_000, .coinbase = coinbase, .chain_id = 1, .blob_versioned_hashes = &.{versioned_hash}, .is_blob_transaction = true, .max_fee_per_gas = 1, .max_fee_per_blob_gas = 1 };
+    var instance = try DefaultEvm.init(allocator, &database, block_info, tx_context, 1, origin);
+    defer instance.deinit();
+
+    var rejected = instance.call(.{ .call = .{ .caller = origin, .to = recipient, .value = 0, .input = &.{}, .gas = 100_000 } });
+    defer rejected.deinit(allocator);
+    try std.testing.expect(!rejected.success);
+    var sender = (try database.get_account(origin.bytes)).?;
+    try std.testing.expectEqual(@as(u64, 0), sender.nonce);
+    try std.testing.expectEqual(required - 1, sender.balance);
+
+    sender.balance = required;
+    try database.set_account(origin.bytes, sender);
+    var accepted = instance.call(.{ .call = .{ .caller = origin, .to = recipient, .value = 0, .input = &.{}, .gas = 100_000 } });
+    defer accepted.deinit(allocator);
+    sender = (try database.get_account(origin.bytes)).?;
+    try std.testing.expect(accepted.success);
+    try std.testing.expectEqual(@as(u64, 1), sender.nonce);
+}

--- a/test/root.zig
+++ b/test/root.zig
@@ -10,6 +10,7 @@ pub const std_options = std.Options{
 };
 
 test {
+    _ = @import("blob_gas_test.zig");
     // Integration tests - testing EVM behavior with fixtures and differential testing
     
     // Test snailtracer first


### PR DESCRIPTION
Carries forward the EIP-4844 blob gas pricing and transaction-validation work from @0xpolarzero onto current `main`.

Supersedes #830
Closes #830

## What changed
- Adds Cancun/Prague blob gas constants and backward-compatible parameterized Voltaire helpers.
- Adds hardfork-aware blob pricing, excess gas, cost, and typed transaction validation.
- Rejects zero-blob type-3 transactions, invalid version bytes, contract creation, excess blob counts, and insufficient blob fee caps.
- Uses the EIP-1559 fee cap for upfront affordability checks before nonce mutation.
- Burns blob fees independently of execution gas price and credits coinbase only the execution priority fee.
- Moves BLOBHASH transaction data into TransactionContext and parses blob fields in the spec runner.
- Adds pricing, validation, settlement, and exact-balance regression tests.

## Verification
- `zig build` passes.
- `zig build test-integration -Dtest-filter=blob` passes (13/13).
- `zig build test` was run; the broader repository suite remains red on pre-existing fixture, differential, and logging failures (including 83 unrelated integration failures).
- The requested legacy `test-execution-spec-guillotine` build step and Cancun EIP-4844 generated case registration are absent on current `main`, so an EEST pass-rate delta could not be produced locally.

*Note: This action was performed by Claude AI assistant, not @roninjin10 or @fucory*