### PR TITLE
fix: restore fresh clone build and unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["lib/foundry-compilers", "lib/ark"]
-exclude = ["bench/evm-bench", "benchmarks"]
+exclude = ["bench/evm-bench", "benchmarks", "lib/voltaire"]
 
 [workspace.package]
 version = "0.1.0"

--- a/lib/voltaire/Cargo.toml
+++ b/lib/voltaire/Cargo.toml
@@ -3,6 +3,8 @@ name = "primitives"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+
 [lib]
 name = "crypto_wrappers"
 crate-type = ["staticlib"]

--- a/src/log.zig
+++ b/src/log.zig
@@ -776,15 +776,17 @@ pub fn before_instruction(frame: anytype, comptime opcode: @import("opcodes/opco
 }
 
 test "log functions compile and execute without error" {
+    comptime {
+        _ = &err;
+    }
+    try std.testing.expect(@TypeOf(err) == @TypeOf(warn));
     debug("test debug message: {}", .{42});
-    err("test error message: {s}", .{"error"});
     warn("test warning message: {d:.2}", .{3.14});
     info("test info message: {any}", .{true});
 }
 
 test "log functions handle different argument types" {
     debug("string: {s}, number: {d}, hex: {x}", .{ "test", 123, 0xABC });
-    err("boolean: {}, float: {d:.3}", .{ false, 2.718 });
     warn("array: {any}", .{[_]u32{ 1, 2, 3 }});
     info("no args: {s}", .{""});
 }


### PR DESCRIPTION
## Summary

- keep the vendored Voltaire Rust package in its own Cargo workspace so release artifacts remain under lib/voltaire/target
- prevent log smoke tests from emitting error-level output while preserving compile-time coverage for err

## Testing

- cargo metadata --manifest-path lib/voltaire/Cargo.toml --no-deps
- cargo build --manifest-path lib/voltaire/Cargo.toml --release
- cargo metadata --no-deps
- zig build
- zig build test-unit

Closes #863

Thanks @vladfdp for the report.

*Note: This action was performed by Claude AI assistant, not @roninjin10 or @fucory*